### PR TITLE
Localization for ready messages, plus other localization fixes.

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/ability/attribute/AbilityTierAttribute.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/attribute/AbilityTierAttribute.java
@@ -30,7 +30,7 @@ public class AbilityTierAttribute extends OptionalSavingAbilityAttribute<Integer
 
     /**
      * Creates a new instance of this {@link AbilityTierAttribute} class, containing the provided {@link Integer} content as the value
-     *
+     *  
      * @param tier The {@link Integer} content to be used as the value in the returned {@link AbilityTierAttribute}
      * @return A new instance of this {@link AbilityTierAttribute} class, containing the provided {@link Integer} content as the value
      */

--- a/src/main/java/us/eunoians/mcrpg/ability/ready/HerbalismReadyData.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/ready/HerbalismReadyData.java
@@ -1,27 +1,34 @@
 package us.eunoians.mcrpg.ability.ready;
 
+import com.diamonddagger590.mccore.registry.RegistryKey;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.jetbrains.annotations.NotNull;
 import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
 /**
  * Ready data used for the {@link us.eunoians.mcrpg.skill.impl.herbalism.Herbalism} skill.
  */
-public class HerbalismReadyData extends ReadyData{
+public class HerbalismReadyData extends ReadyData {
 
     @NotNull
     @Override
     public Component getReadyMessage(@NotNull McRPGPlayer player) {
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
-        return miniMessage.deserialize("<gray>You raise your hoe.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.HERBALISM_READY_MESSAGE);
     }
 
     @NotNull
     @Override
     public Component getUnreadyMessage(@NotNull McRPGPlayer player) {
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
-        return miniMessage.deserialize("<gray>You lower your hoe.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.HERBALISM_UNREADY_MESSAGE);
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/ability/ready/MiningReadyData.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/ready/MiningReadyData.java
@@ -1,8 +1,13 @@
 package us.eunoians.mcrpg.ability.ready;
 
+import com.diamonddagger590.mccore.registry.RegistryKey;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
 /**
  * Ready data used for the {@link us.eunoians.mcrpg.skill.impl.mining.Mining} skill.
@@ -12,12 +17,18 @@ public class MiningReadyData extends ReadyData {
     @NotNull
     @Override
     public Component getReadyMessage(@NotNull McRPGPlayer player) {
-        return Component.text("<gray>You ready your pickaxe.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.MINING_READY_MESSAGE);
     }
 
     @NotNull
     @Override
     public Component getUnreadyMessage(@NotNull McRPGPlayer player) {
-        return Component.text("<gray>You lower your pickaxe.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.MINING_UNREADY_MESSAGE);
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/ability/ready/SwordReadyData.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/ready/SwordReadyData.java
@@ -1,8 +1,13 @@
 package us.eunoians.mcrpg.ability.ready;
 
+import com.diamonddagger590.mccore.registry.RegistryKey;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
 /**
  * Ready data that is shared by all abilities that activate from using a sword
@@ -13,12 +18,18 @@ public class SwordReadyData extends ReadyData {
     @NotNull
     @Override
     public Component getReadyMessage(@NotNull McRPGPlayer player) {
-        return Component.text("<gray>You raise your sword.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.SWORDS_READY_MESSAGE);
     }
 
     @NotNull
     @Override
     public Component getUnreadyMessage(@NotNull McRPGPlayer player) {
-        return Component.text("<gray>You lower your sword.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.SWORDS_UNREADY_MESSAGE);
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/ability/ready/WoodcuttingReadyData.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/ready/WoodcuttingReadyData.java
@@ -1,8 +1,13 @@
 package us.eunoians.mcrpg.ability.ready;
 
+import com.diamonddagger590.mccore.registry.RegistryKey;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import us.eunoians.mcrpg.skill.impl.woodcutting.WoodCutting;
 
 /**
@@ -13,12 +18,18 @@ public class WoodcuttingReadyData extends ReadyData {
     @NotNull
     @Override
     public Component getReadyMessage(@NotNull McRPGPlayer player) {
-        return Component.text("<gray>You raise your axe.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.WOODCUTTING_READY_MESSAGE);
     }
 
     @NotNull
     @Override
     public Component getUnreadyMessage(@NotNull McRPGPlayer player) {
-        return Component.text("<gray>You lower your axe.");
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+        return localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.WOODCUTTING_UNREADY_MESSAGE);
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/command/give/GiveLevelsCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/give/GiveLevelsCommand.java
@@ -65,8 +65,6 @@ public class GiveLevelsCommand extends GiveCommandBase {
                                     .manager(McRPGManagerKey.PLAYER).getPlayer(sender.getUniqueId()) : Optional.empty();
                             Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
 
-                            Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player);
-                            Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player);
                             if (playerOptional.isPresent()) {
                                 McRPGPlayer mcRPGPlayer = playerOptional.get();
                                 SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
@@ -79,6 +77,9 @@ public class GiveLevelsCommand extends GiveCommandBase {
                                      */
                                     int levelAmount = Math.min(commandContext.get(amountKey), skill.getMaxLevel() - skillHolderData.getCurrentLevel());
 
+                                    Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, levelAmount, skill, senderOptional.orElse(null));
+                                    Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, levelAmount, skill, mcRPGPlayer);
+
                                     skillHolderData.addLevels(levelAmount, resetExperience);
                                     player.sendMessage(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.GIVE_LEVELS_COMMAND_RECIPIENT_MESSAGE, receiverPlaceholders));
                                     // Only send a message if the sender is not the receiver or the sender is console
@@ -88,7 +89,8 @@ public class GiveLevelsCommand extends GiveCommandBase {
                                     return;
                                 }
                             }
-                            senderAudience.sendMessage(localizationManager.getLocalizedMessageAsComponent(senderAudience, LocalizationKey.GIVE_LEVELS_COMMAND_SENDER_ERROR_MESSAGE, senderPlaceholders));
+                            Map<String, String> errorPlaceholders = getPlaceholders(senderAudience, senderAudience, player, commandContext.get(amountKey), skill, senderOptional.orElse(null));
+                            senderAudience.sendMessage(localizationManager.getLocalizedMessageAsComponent(senderAudience, LocalizationKey.GIVE_LEVELS_COMMAND_SENDER_ERROR_MESSAGE, errorPlaceholders));
                         }
                 ));
     }

--- a/src/main/java/us/eunoians/mcrpg/configuration/file/localization/LocalizationKey.java
+++ b/src/main/java/us/eunoians/mcrpg/configuration/file/localization/LocalizationKey.java
@@ -148,6 +148,8 @@ public final class LocalizationKey extends ConfigFile {
     public static final Route BOSS_BAR_DISPLAY_MESSAGE = Route.fromString(toRoutePath(EXPERIENCE_DISPLAY_HEADER, "boss-bar-display-message"));
 
     private static final String SKILLS_HEADER = "skills";
+    private static final String SKILL_LEVEL_UP_HEADER = toRoutePath(SKILLS_HEADER, "level-up");
+    public static final Route SKILL_LEVEL_UP_MESSAGE = Route.fromString(toRoutePath(SKILL_LEVEL_UP_HEADER, "level-up-message"));
     private static final String SWORDS_HEADER = toRoutePath(SKILLS_HEADER, "swords");
     public static final Route SWORDS_DISPLAY_ITEM = Route.fromString(toRoutePath(SWORDS_HEADER, "display-item"));
     private static final String MINING_HEADER = toRoutePath(SKILLS_HEADER, "mining");
@@ -320,6 +322,25 @@ public final class LocalizationKey extends ConfigFile {
     private static final String ABILITY_COOLDOWN_HEADER = toRoutePath(ABILITY_HEADER, "cooldown");
     public static final Route ABILITY_STILL_ON_COOLDOWN = Route.fromString(toRoutePath(ABILITY_COOLDOWN_HEADER, "ability-still-on-cooldown"));
     public static final Route ABILITY_NO_LONGER_ON_COOLDOWN = Route.fromString(toRoutePath(ABILITY_COOLDOWN_HEADER, "ability-no-longer-on-cooldown"));
+
+    private static final String ABILITY_READY_HEADER = toRoutePath(ABILITY_HEADER, "ready");
+    private static final String HERBALISM_READY_HEADER = toRoutePath(ABILITY_READY_HEADER, "herbalism");
+    public static final Route HERBALISM_READY_MESSAGE = Route.fromString(toRoutePath(HERBALISM_READY_HEADER, "ready-message"));
+    public static final Route HERBALISM_UNREADY_MESSAGE = Route.fromString(toRoutePath(HERBALISM_READY_HEADER, "unready-message"));
+    private static final String MINING_READY_HEADER = toRoutePath(ABILITY_READY_HEADER, "mining");
+    public static final Route MINING_READY_MESSAGE = Route.fromString(toRoutePath(MINING_READY_HEADER, "ready-message"));
+    public static final Route MINING_UNREADY_MESSAGE = Route.fromString(toRoutePath(MINING_READY_HEADER, "unready-message"));
+    private static final String SWORDS_READY_HEADER = toRoutePath(ABILITY_READY_HEADER, "swords");
+    public static final Route SWORDS_READY_MESSAGE = Route.fromString(toRoutePath(SWORDS_READY_HEADER, "ready-message"));
+    public static final Route SWORDS_UNREADY_MESSAGE = Route.fromString(toRoutePath(SWORDS_READY_HEADER, "unready-message"));
+    private static final String WOODCUTTING_READY_HEADER = toRoutePath(ABILITY_READY_HEADER, "woodcutting");
+    public static final Route WOODCUTTING_READY_MESSAGE = Route.fromString(toRoutePath(WOODCUTTING_READY_HEADER, "ready-message"));
+    public static final Route WOODCUTTING_UNREADY_MESSAGE = Route.fromString(toRoutePath(WOODCUTTING_READY_HEADER, "unready-message"));
+
+    private static final String ABILITY_UNLOCK_HEADER = toRoutePath(ABILITY_HEADER, "unlock");
+    public static final Route ABILITY_UNLOCKED_MESSAGE = Route.fromString(toRoutePath(ABILITY_UNLOCK_HEADER, "ability-unlocked"));
+    public static final Route ABILITY_ADDED_TO_LOADOUT_MESSAGE = Route.fromString(toRoutePath(ABILITY_UNLOCK_HEADER, "ability-added-to-loadout"));
+    public static final Route ABILITY_NOT_ADDED_DUPLICATE_SKILL_MESSAGE = Route.fromString(toRoutePath(ABILITY_UNLOCK_HEADER, "ability-not-added-duplicate-skill"));
 
     private static final String ABILITY_LORE_HEADER = toRoutePath(ABILITY_HEADER, "lore");
     private static final String ABILITY_QUEST_LORE_HEADER = toRoutePath(ABILITY_LORE_HEADER, "quest");

--- a/src/main/java/us/eunoians/mcrpg/listener/ability/OnAbilityUnlockListener.java
+++ b/src/main/java/us/eunoians/mcrpg/listener/ability/OnAbilityUnlockListener.java
@@ -2,20 +2,25 @@ package us.eunoians.mcrpg.listener.ability;
 
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.impl.type.SkillAbility;
 import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.LoadoutHolder;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.event.ability.AbilityUnlockEvent;
 import us.eunoians.mcrpg.loadout.Loadout;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import us.eunoians.mcrpg.skill.Skill;
+
+import java.util.Map;
 
 public class OnAbilityUnlockListener implements Listener {
 
@@ -31,18 +36,27 @@ public class OnAbilityUnlockListener implements Listener {
         }
         McRPGPlayer mcRPGPlayer = playerOptional.get();
         Audience player = mcRPGPlayer.getAsBukkitPlayer().get();
-        player.sendMessage(miniMessage.deserialize(String.format("<green>You have unlocked a new ability! <gold>%s<green> is now available for use.", abilityUnlockEvent.getAbility().getDisplayName(mcRPGPlayer))));
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
+
+        Component abilityDisplayName = unlockableAbility.getDisplayName(mcRPGPlayer);
+        String serializedAbilityName = miniMessage.serialize(abilityDisplayName);
+        player.sendMessage(localizationManager.getLocalizedMessageAsComponent(mcRPGPlayer, LocalizationKey.ABILITY_UNLOCKED_MESSAGE,
+                Map.of("ability", serializedAbilityName)));
 
         if (abilityHolder instanceof LoadoutHolder loadoutHolder) {
             Loadout loadout = loadoutHolder.getLoadout();
             if (loadout.getRemainingLoadoutSize() > 0) {
                 if (loadout.canAbilityBeAddedToLoadout(unlockableAbility.getAbilityKey())) {
                     loadout.addAbility(unlockableAbility.getAbilityKey());
-                    player.sendMessage(miniMessage.deserialize("<green>The new ability has automatically been added to your current loadout."));
+                    player.sendMessage(localizationManager.getLocalizedMessageAsComponent(mcRPGPlayer, LocalizationKey.ABILITY_ADDED_TO_LOADOUT_MESSAGE));
                 } else if (unlockableAbility instanceof SkillAbility skillAbility) {
                     Skill skill = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.SKILL).getRegisteredSkill(skillAbility.getSkillKey());
-                    player.sendMessage(miniMessage.deserialize("<red>You already have an active ability for the skill " + skill.getDisplayName(mcRPGPlayer) + " in your loadout, so "
-                            + unlockableAbility.getDisplayName(mcRPGPlayer) + " was not automatically added."));
+                    Component skillDisplayName = skill.getDisplayName(mcRPGPlayer);
+                    String serializedSkillName = miniMessage.serialize(skillDisplayName);
+                    player.sendMessage(localizationManager.getLocalizedMessageAsComponent(mcRPGPlayer, LocalizationKey.ABILITY_NOT_ADDED_DUPLICATE_SKILL_MESSAGE,
+                            Map.of("skill", serializedSkillName, "ability", serializedAbilityName)));
                 }
             }
         }

--- a/src/main/java/us/eunoians/mcrpg/listener/skill/OnSkillLevelUpListener.java
+++ b/src/main/java/us/eunoians/mcrpg/listener/skill/OnSkillLevelUpListener.java
@@ -5,6 +5,7 @@ import com.diamonddagger590.mccore.database.transaction.FailSafeTransaction;
 import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -19,6 +20,7 @@ import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
 import us.eunoians.mcrpg.ability.attribute.AbilityUnlockedAttribute;
 import us.eunoians.mcrpg.ability.Ability;
 import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.database.table.SkillDAO;
 import us.eunoians.mcrpg.entity.McRPGPlayerManager;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
@@ -27,12 +29,14 @@ import us.eunoians.mcrpg.event.ability.AbilityUnlockEvent;
 import us.eunoians.mcrpg.event.skill.PostSkillGainExpEvent;
 import us.eunoians.mcrpg.event.skill.PostSkillGainLevelEvent;
 import us.eunoians.mcrpg.event.skill.SkillGainLevelEvent;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import us.eunoians.mcrpg.skill.Skill;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -53,7 +57,13 @@ public class OnSkillLevelUpListener implements Listener {
             McRPGPlayer mcRPGPlayer = playerOptional.get();
             MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
             Audience player = mcRPGPlayer.getAsBukkitPlayer().get();
-            player.sendMessage(miniMessage.deserialize(String.format("<green>You have gone up <gold>%d levels<green> in <gold>%s<green>.", levels, skill.getDisplayName(mcRPGPlayer))));
+            McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess()
+                    .registry(RegistryKey.MANAGER)
+                    .manager(McRPGManagerKey.LOCALIZATION);
+            Component skillDisplayName = skill.getDisplayName(mcRPGPlayer);
+            String serializedSkillName = miniMessage.serialize(skillDisplayName);
+            player.sendMessage(localizationManager.getLocalizedMessageAsComponent(mcRPGPlayer, LocalizationKey.SKILL_LEVEL_UP_MESSAGE,
+                    Map.of("levels", String.valueOf(levels), "skill", serializedSkillName)));
         }
     }
 

--- a/src/main/resources/localization/en.yml
+++ b/src/main/resources/localization/en.yml
@@ -39,7 +39,7 @@ commands:
     # Supports the following placeholders: <level>, <skill>, <target>, <sender>
     level:
       # The message to send to the player getting levels.
-      recipient-message: "<gray>You have been given <gold><levels> level(s)</gold> in <gold><skill></gold>."
+      recipient-message: "<gray>You have been given <gold><level> level(s)</gold> in <gold><skill></gold>."
       # The message to send to the sender when the command works.
       sender-success-message: "<gray>You gave <gold><level> level(s)</gold> in <gold><skill></gold> to <gold><target></gold>."
       # The message to send to the sender when the command fails.
@@ -1085,6 +1085,34 @@ ability:
     # The message to send to the player whenever an ability is no longer on cooldown
     # Supports <ability> as a placeholder for the ability that was on cooldown.
     ability-no-longer-on-cooldown: "<gold><ability> <gray>is now off cooldown!"
+  # Configure messages for when abilities are readied or unreadied.
+  ready:
+    # Messages for the Herbalism skill
+    herbalism:
+      ready-message: "<gray>You raise your hoe."
+      unready-message: "<gray>You lower your hoe."
+    # Messages for the Mining skill
+    mining:
+      ready-message: "<gray>You ready your pickaxe."
+      unready-message: "<gray>You lower your pickaxe."
+    # Messages for the Swords skill
+    swords:
+      ready-message: "<gray>You raise your sword."
+      unready-message: "<gray>You lower your sword."
+    # Messages for the Woodcutting skill
+    woodcutting:
+      ready-message: "<gray>You raise your axe."
+      unready-message: "<gray>You lower your axe."
+  # Configure messages for when abilities are unlocked
+  # Supports <ability> as a placeholder for the ability name
+  unlock:
+    # The message to send when a player unlocks a new ability
+    ability-unlocked: "<green>You have unlocked a new ability! <ability> <green>is now available for use."
+    # The message to send when an ability is automatically added to the player's loadout
+    ability-added-to-loadout: "<green>The new ability has automatically been added to your current loadout."
+    # The message to send when an ability cannot be added because there's already an active ability for that skill
+    # Supports <skill> and <ability> placeholders
+    ability-not-added-duplicate-skill: "<red>You already have an active ability for the skill <skill> <red>in your loadout, so <ability> <red>was not automatically added."
   # Configure additional lore lines for ability items that will be appended to ability item lore when conditions are met
   lore:
     # Configure ability upgrade quest lore
@@ -1340,6 +1368,11 @@ ability:
           - '<gray>Cooldown: <gold><cooldown>'
       activation-message: "<gray>You found a water source! You'll be able to do this again in <gold><cooldown> seconds</gold>."
 skills:
+  # Configure messages for skill level ups
+  # Supports <levels> and <skill> placeholders
+  level-up:
+    # The message to send when a player levels up a skill
+    level-up-message: "<green>You have gone up <gold><levels> levels<green> in <skill><green>."
   swords:
     display-item:
       name: '<red><skill></red>'


### PR DESCRIPTION
Configurable ability ready/unready messages.

Adds localization support for ability ready messages (resolves #171). Also fixes some hardcoded messages that were showing raw component output:

> Skill level up message
> Ability unlock message
> Give levels command

All messages now go through the localization system in en.yml.