### PR TITLE
Updated test assertions to use hamcrest matchers

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/ability/impl/herbalism/InstantIrrigationTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/herbalism/InstantIrrigationTest.java
@@ -40,8 +40,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasNotFiredEventInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -129,7 +132,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         assertEquals(Material.WATER, block.getType());
         assertEquals(message, player.nextComponentMessage());
-        server.getPluginManager().assertEventFired(InstantIrrigationActivateEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(InstantIrrigationActivateEvent.class));
         assertEquals(instant.toEpochMilli() + (119 * 1000), ((long) skillHolder.getAbilityData(instantIrrigation).get().getAbilityAttribute(AbilityAttributeRegistry.ABILITY_COOLDOWN_ATTRIBUTE_KEY).get().getContent()));
     }
 
@@ -165,7 +168,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         assertEquals(Material.WATER, block.getType());
         assertEquals(message, player.nextComponentMessage());
-        server.getPluginManager().assertEventFired(InstantIrrigationActivateEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(InstantIrrigationActivateEvent.class));
         assertEquals(instant.toEpochMilli() + (110 * 1000), ((long) skillHolder.getAbilityData(instantIrrigation).get().getAbilityAttribute(AbilityAttributeRegistry.ABILITY_COOLDOWN_ATTRIBUTE_KEY).get().getContent()));
     }
 
@@ -191,7 +194,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
         server.getPluginManager().callEvent(blockBreakEvent);
 
         assertEquals(Material.GRASS_BLOCK, block.getType());
-        server.getPluginManager().assertEventNotFired(InstantIrrigationActivateEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(InstantIrrigationActivateEvent.class));
         assertNull(player.nextComponentMessage());
         assertEquals(0, ((long) skillHolder.getAbilityData(instantIrrigation).get().getAbilityAttribute(AbilityAttributeRegistry.ABILITY_COOLDOWN_ATTRIBUTE_KEY).get().getContent()));
     }
@@ -223,7 +226,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
         server.getPluginManager().callEvent(blockBreakEvent);
 
         assertEquals(Material.GRASS_BLOCK, block.getType());
-        server.getPluginManager().assertEventNotFired(InstantIrrigationActivateEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(InstantIrrigationActivateEvent.class));
         assertNull(player.nextComponentMessage());
         assertEquals(0, ((long) skillHolder.getAbilityData(instantIrrigation).get().getAbilityAttribute(AbilityAttributeRegistry.ABILITY_COOLDOWN_ATTRIBUTE_KEY).get().getContent()));
     }
@@ -255,7 +258,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
         server.getPluginManager().callEvent(blockBreakEvent);
 
         assertEquals(Material.GRASS_BLOCK, block.getType());
-        server.getPluginManager().assertEventNotFired(InstantIrrigationActivateEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(InstantIrrigationActivateEvent.class));
         assertNull(player.nextComponentMessage());
         assertEquals(0, ((long) skillHolder.getAbilityData(instantIrrigation).get().getAbilityAttribute(AbilityAttributeRegistry.ABILITY_COOLDOWN_ATTRIBUTE_KEY).get().getContent()));
     }
@@ -289,7 +292,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
         server.getPluginManager().callEvent(blockBreakEvent);
 
         assertEquals(Material.GRASS_BLOCK, block.getType());
-        server.getPluginManager().assertEventNotFired(InstantIrrigationActivateEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(InstantIrrigationActivateEvent.class));
         assertNull(player.nextComponentMessage());
         assertEquals(0, ((long) skillHolder.getAbilityData(instantIrrigation).get().getAbilityAttribute(AbilityAttributeRegistry.ABILITY_COOLDOWN_ATTRIBUTE_KEY).get().getContent()));
     }

--- a/src/test/java/us/eunoians/mcrpg/skill/SkillRegistryTest.java
+++ b/src/test/java/us/eunoians/mcrpg/skill/SkillRegistryTest.java
@@ -12,10 +12,13 @@ import us.eunoians.mcrpg.skill.impl.MockSkill;
 
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasNotFiredEventInstance;
 import static org.mockito.Mockito.spy;
 
 public class SkillRegistryTest extends McRPGBaseTest {
@@ -43,7 +46,7 @@ public class SkillRegistryTest extends McRPGBaseTest {
         MockSkill mockSkill = spy(MockSkill.class);
         skillRegistry.register(mockSkill);
         assertTrue(skillRegistry.registered(mockSkill));
-        server.getPluginManager().assertEventFired(SkillRegisterEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(SkillRegisterEvent.class));
     }
 
     @DisplayName("Given an unregistered skill, when checking registered, then it returns false and does not fire register event")
@@ -51,7 +54,7 @@ public class SkillRegistryTest extends McRPGBaseTest {
     public void registered_returnsFalse_whenSkillNotRegistered() {
         MockSkill mockSkill = spy(MockSkill.class);
         assertFalse(skillRegistry.registered(mockSkill));
-        server.getPluginManager().assertEventNotFired(SkillRegisterEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(SkillRegisterEvent.class));
     }
 
     @DisplayName("Given a registered skill, when getting by key, then it returns the same skill")
@@ -103,7 +106,7 @@ public class SkillRegistryTest extends McRPGBaseTest {
         MockSkill mockSkill = spy(MockSkill.class);
         skillRegistry.register(mockSkill);
         skillRegistry.unregisterSkill(mockSkill);
-        server.getPluginManager().assertEventFired(SkillUnregisterEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(SkillUnregisterEvent.class));
         assertEquals(Set.of(), skillRegistry.getRegisteredSkills());
     }
 
@@ -112,6 +115,6 @@ public class SkillRegistryTest extends McRPGBaseTest {
     public void unregisterSkill_doesNotFireEvent_whenSkillNotRegistered() {
         MockSkill mockSkill = spy(MockSkill.class);
         skillRegistry.unregisterSkill(mockSkill);
-        server.getPluginManager().assertEventNotFired(SkillUnregisterEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(SkillUnregisterEvent.class));
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/skill/experience/rested/RestedExperienceManagerTest.java
+++ b/src/test/java/us/eunoians/mcrpg/skill/experience/rested/RestedExperienceManagerTest.java
@@ -26,8 +26,11 @@ import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasFiredEventInstance;
+import static org.mockbukkit.mockbukkit.matcher.plugin.PluginManagerFiredEventClassMatcher.hasNotFiredEventInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -98,7 +101,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         when(mockConfig.getFloat(MainConfigFile.RESTED_EXPERIENCE_MAXIMUM_ACCUMULATION)).thenReturn(5f);
         assertEquals(0, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10, RestedExperienceAccumulationType.OFFLINE, true);
-        server.getPluginManager().assertEventFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(2, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertEquals(component, playerMock.nextComponentMessage());
     }
@@ -114,7 +117,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         when(mockConfig.getFloat(MainConfigFile.RESTED_EXPERIENCE_MAXIMUM_ACCUMULATION)).thenReturn(5f);
         assertEquals(0, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10, RestedExperienceAccumulationType.OFFLINE, false);
-        server.getPluginManager().assertEventFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(2, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertNull(playerMock.nextComponentMessage());
     }
@@ -133,7 +136,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         when(mockConfig.getFloat(MainConfigFile.RESTED_EXPERIENCE_MAXIMUM_ACCUMULATION)).thenReturn(5f);
         assertEquals(0, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10, RestedExperienceAccumulationType.OFFLINE_SAFE_ZONE, true);
-        server.getPluginManager().assertEventFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(2, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertEquals(component, playerMock.nextComponentMessage());
     }
@@ -149,7 +152,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         when(mockConfig.getFloat(MainConfigFile.RESTED_EXPERIENCE_MAXIMUM_ACCUMULATION)).thenReturn(5f);
         assertEquals(0, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10, RestedExperienceAccumulationType.ONLINE_SAFE_ZONE, false);
-        server.getPluginManager().assertEventFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(1, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertNull(playerMock.nextComponentMessage());
     }
@@ -168,7 +171,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         when(mockConfig.getFloat(MainConfigFile.RESTED_EXPERIENCE_MAXIMUM_ACCUMULATION)).thenReturn(5f);
         assertEquals(0, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10, RestedExperienceAccumulationType.OFFLINE_SAFE_ZONE, true);
-        server.getPluginManager().assertEventFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(4, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertEquals(component, playerMock.nextComponentMessage());
     }
@@ -188,7 +191,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         mcRPGPlayer.getExperienceExtras().setRestedExperience(5f);
         assertEquals(5f, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10, RestedExperienceAccumulationType.OFFLINE_SAFE_ZONE, true);
-        server.getPluginManager().assertEventNotFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasNotFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(5f, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertEquals(component, playerMock.nextComponentMessage());
     }
@@ -206,7 +209,7 @@ public class RestedExperienceManagerTest extends McRPGBaseTest {
         when(mockConfig.getFloat(MainConfigFile.RESTED_EXPERIENCE_MAXIMUM_ACCUMULATION)).thenReturn(1.5f);
         assertEquals(0f, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         restedExperienceManager.awardRestedExperience(mcRPGPlayer, 10000, RestedExperienceAccumulationType.OFFLINE_SAFE_ZONE, true);
-        server.getPluginManager().assertEventFired(PlayerAwardedRestedExperienceEvent.class);
+        assertThat(server.getPluginManager(), hasFiredEventInstance(PlayerAwardedRestedExperienceEvent.class));
         assertEquals(1.5f, mcRPGPlayer.getExperienceExtras().getRestedExperience());
         assertEquals(component, playerMock.nextComponentMessage());
     }


### PR DESCRIPTION
Fixes deprecated MockBukkit warnings in test files by replacing `assertEventFired`/`assertEventNotFired` with the new Hamcrest matchers `hasFiredEventInstance`/`hasNotFiredEventInstance`.