### PR TITLE
Add unit tests for rested experience offline wait period

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/task/player/McRPGPlayerLoadTask.java
+++ b/src/main/java/us/eunoians/mcrpg/task/player/McRPGPlayerLoadTask.java
@@ -173,12 +173,27 @@ public final class McRPGPlayerLoadTask extends PlayerLoadTask {
                 double waitTimeBeforeAccumulation = getPlugin().registryAccess().registry(RegistryKey.MANAGER)
                         .manager(McRPGManagerKey.FILE).getFile(FileType.MAIN_CONFIG)
                         .getDouble(MainConfigFile.RESTED_EXPERIENCE_OFFLINE_WAIT_PERIOD_BEFORE_ACCUMULATION, 0.0d);
-                double difference = Math.max(0, Duration.between(now, logoutTime).abs().toSeconds() - waitTimeBeforeAccumulation);
+                int adjustedOfflineTime = calculateAdjustedOfflineTime(logoutTime, now, waitTimeBeforeAccumulation);
                 RestedExperienceManager restedExperienceManager = getPlugin().registryAccess().registry(McRPGRegistryKey.MANAGER).manager(McRPGManagerKey.RESTED_EXPERIENCE);
                 // Award rested experience
-                restedExperienceManager.awardRestedExperience(getCorePlayer(), (int) difference, accumulationType, true);
+                restedExperienceManager.awardRestedExperience(getCorePlayer(), adjustedOfflineTime, accumulationType, true);
             }
         };
+    }
+
+    /**
+     * Calculates the adjusted offline time for rested experience accumulation,
+     * accounting for the configured wait period before accumulation starts.
+     *
+     * @param logoutTime                  The {@link Instant} when the player logged out.
+     * @param now                         The current {@link Instant}.
+     * @param waitTimeBeforeAccumulation  The wait period in seconds before accumulation starts.
+     * @return The adjusted offline time in seconds, never negative.
+     */
+    @VisibleForTesting
+    static int calculateAdjustedOfflineTime(@NotNull Instant logoutTime, @NotNull Instant now, double waitTimeBeforeAccumulation) {
+        double totalOfflineSeconds = Duration.between(now, logoutTime).abs().toSeconds();
+        return (int) Math.max(0, totalOfflineSeconds - waitTimeBeforeAccumulation);
     }
 
     /**

--- a/src/test/java/us/eunoians/mcrpg/task/player/McRPGPlayerLoadTaskTest.java
+++ b/src/test/java/us/eunoians/mcrpg/task/player/McRPGPlayerLoadTaskTest.java
@@ -1,0 +1,66 @@
+package us.eunoians.mcrpg.task.player;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class McRPGPlayerLoadTaskTest {
+
+    @DisplayName("Given wait period = 0 and player offline for 100s, then adjusted time is 100s")
+    @Test
+    public void calculateAdjustedOfflineTime_returnsFullTime_whenWaitPeriodIsZero() {
+        Instant now = Instant.now();
+        Instant logoutTime = now.minusSeconds(100);
+
+        int adjustedTime = McRPGPlayerLoadTask.calculateAdjustedOfflineTime(logoutTime, now, 0.0);
+
+        assertEquals(100, adjustedTime);
+    }
+
+    @DisplayName("Given wait period = 30s and player offline for 100s, then adjusted time is 70s")
+    @Test
+    public void calculateAdjustedOfflineTime_returnsReducedTime_whenWaitPeriodIsLessThanOfflineTime() {
+        Instant now = Instant.now();
+        Instant logoutTime = now.minusSeconds(100);
+
+        int adjustedTime = McRPGPlayerLoadTask.calculateAdjustedOfflineTime(logoutTime, now, 30.0);
+
+        assertEquals(70, adjustedTime);
+    }
+
+    @DisplayName("Given wait period = 100s and player offline for 100s, then adjusted time is 0s")
+    @Test
+    public void calculateAdjustedOfflineTime_returnsZero_whenWaitPeriodEqualsOfflineTime() {
+        Instant now = Instant.now();
+        Instant logoutTime = now.minusSeconds(100);
+
+        int adjustedTime = McRPGPlayerLoadTask.calculateAdjustedOfflineTime(logoutTime, now, 100.0);
+
+        assertEquals(0, adjustedTime);
+    }
+
+    @DisplayName("Given wait period = 100s and player offline for 50s, then adjusted time is 0s (not negative)")
+    @Test
+    public void calculateAdjustedOfflineTime_returnsZero_whenWaitPeriodExceedsOfflineTime() {
+        Instant now = Instant.now();
+        Instant logoutTime = now.minusSeconds(50);
+
+        int adjustedTime = McRPGPlayerLoadTask.calculateAdjustedOfflineTime(logoutTime, now, 100.0);
+
+        assertEquals(0, adjustedTime);
+    }
+
+    @DisplayName("Given wait period = 60s and player offline for 90s, then adjusted time is 30s")
+    @Test
+    public void calculateAdjustedOfflineTime_returnsCorrectTime_withVariousValues() {
+        Instant now = Instant.now();
+        Instant logoutTime = now.minusSeconds(90);
+
+        int adjustedTime = McRPGPlayerLoadTask.calculateAdjustedOfflineTime(logoutTime, now, 60.0);
+
+        assertEquals(30, adjustedTime);
+    }
+}


### PR DESCRIPTION
Adds unit tests for the offline-wait-period-before-accumulation config option (resolves #155). 

Extracted the time calculation logic into a testable `calculateAdjustedOfflineTime` method and added tests covering:

- Wait period = 0 awards full offline time
- Wait period < offline time awards reduced time
- Wait period = offline time awards 0
- Wait period > offline time awards 0 (not negative)