### PR TITLE
Add null check for audience in BossBarExperienceDisplay to prevent NoSuchElementException

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/display/impl/BossBarExperienceDisplay.java
+++ b/src/main/java/us/eunoians/mcrpg/display/impl/BossBarExperienceDisplay.java
@@ -74,12 +74,16 @@ public class BossBarExperienceDisplay extends ExperienceDisplay {
      * @param skillHolderData The {@link SkillHolder.SkillHolderData} containing data.
      */
     protected void displayUpdate(@NotNull NamespacedKey skillKey, @NotNull McRPGPlayer mcRPGPlayer, @NotNull SkillHolder.SkillHolderData skillHolderData) {
+        var audienceOptional = mcRPGPlayer.getAsBukkitPlayer();
+        if (audienceOptional.isEmpty()) {
+            return;
+        }
+        Audience audience = audienceOptional.get();
         McRPG mcRPG = getMcRPGPlayer().getPlugin();
         YamlDocument mainConfig = mcRPG.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE).getFile(FileType.MAIN_CONFIG);
         McRPGLocalizationManager localizationManager = mcRPG.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
         SkillRegistry skillRegistry = mcRPG.registryAccess().registry(McRPGRegistryKey.SKILL);
         Skill skill = skillRegistry.getRegisteredSkill(skillKey);
-        Audience audience = mcRPGPlayer.getAsBukkitPlayer().get();
         cleanDisplay();
         int currentLevel = skillHolderData.getCurrentLevel();
         int currentExperience = skillHolderData.getCurrentExperience();
@@ -101,8 +105,7 @@ public class BossBarExperienceDisplay extends ExperienceDisplay {
     public void cleanDisplay() {
         if (bossBar != null) {
             McRPGPlayer mcRPGPlayer = getMcRPGPlayer();
-            Audience audience = mcRPGPlayer.getAsBukkitPlayer().get();
-            audience.hideBossBar(bossBar);
+            mcRPGPlayer.getAsBukkitPlayer().ifPresent(audience -> audience.hideBossBar(bossBar));
             bossBar = null;
         }
     }


### PR DESCRIPTION
Fixes `NoSuchElementException` that occurs when the boss bar experience display tries to clean up after a player has disconnected.

The `BossBarExperienceDisplay` class was calling .get() directly on the Optional returned by `getAsBukkitPlayer()` without checking if the player was still online. This caused exceptions in two scenarios:

- Delayed cleanup task: When a player gains experience, a delayed task is scheduled to hide the boss bar after a few seconds. If the player disconnects before this task runs, the cleanup fails because the player no longer exists.
- PlayerUnloadEvent: When the `PlayerUnloadEvent` fires during disconnect, it triggers `cleanDisplay()` which also fails for the same reason.

```java.util.NoSuchElementException: No value present
    at java.base/java.util.Optional.get(Optional.java:143)
    at us.eunoians.mcrpg.display.impl.BossBarExperienceDisplay.cleanDisplay(BossBarExperienceDisplay.java:104)
```

In `cleanDisplay()` Changed `getAsBukkitPlayer().get()` to use `ifPresent()` to safely handle the case where the player is no longer online
In `displayUpdate()` Added an early return check using `isEmpty()` before attempting to show the boss bar

(In the commit accidentally wrote NPE, but now that I think about it, that means a completely different thing, but I can't rename it now, lol)