### PR TITLE
Add setting to disable bonus experience consumption

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/configuration/file/localization/LocalizationKey.java
+++ b/src/main/java/us/eunoians/mcrpg/configuration/file/localization/LocalizationKey.java
@@ -282,6 +282,9 @@ public final class LocalizationKey extends ConfigFile {
     private static final String PLAYER_SETTINGS_GUI_REQUIRE_EMPTY_OFFHAND_SETTING_SLOT_HEADER = toRoutePath(PLAYER_SETTINGS_GUI_HEADER, "require-empty-offhand-to-active-ability-slot");
     public static final Route PLAYER_SETTINGS_GUI_REQUIRE_EMPTY_OFFHAND_SETTING_SLOT_ENABLED_DISPLAY_ITEM = Route.fromString(toRoutePath(PLAYER_SETTINGS_GUI_REQUIRE_EMPTY_OFFHAND_SETTING_SLOT_HEADER, "enabled.display-item"));
     public static final Route PLAYER_SETTINGS_GUI_REQUIRE_EMPTY_OFFHAND_SETTING_SLOT_DISABLED_DISPLAY_ITEM = Route.fromString(toRoutePath(PLAYER_SETTINGS_GUI_REQUIRE_EMPTY_OFFHAND_SETTING_SLOT_HEADER, "disabled.display-item"));
+    private static final String PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_HEADER = toRoutePath(PLAYER_SETTINGS_GUI_HEADER, "disable-bonus-experience-consumption-setting-slot");
+    public static final Route PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_ENABLED_DISPLAY_ITEM = Route.fromString(toRoutePath(PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_HEADER, "enabled.display-item"));
+    public static final Route PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_DISABLED_DISPLAY_ITEM = Route.fromString(toRoutePath(PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_HEADER, "disabled.display-item"));
 
     private static final String EXPERIENCE_BANK_GUI_HEADER = toRoutePath(GUI_HEADER, "experience-bank-gui");
     public static final Route EXPERIENCE_BANK_GUI_TITLE = Route.fromString(toRoutePath(EXPERIENCE_BANK_GUI_HEADER, "title"));

--- a/src/main/java/us/eunoians/mcrpg/expansion/McRPGExpansion.java
+++ b/src/main/java/us/eunoians/mcrpg/expansion/McRPGExpansion.java
@@ -32,6 +32,7 @@ import us.eunoians.mcrpg.expansion.content.PlayerSettingContentPack;
 import us.eunoians.mcrpg.expansion.content.SkillContentPack;
 import us.eunoians.mcrpg.localization.NativeLocale;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.setting.impl.DisableBonusExperienceConsumptionSetting;
 import us.eunoians.mcrpg.setting.impl.ExperienceDisplaySetting;
 import us.eunoians.mcrpg.setting.impl.KeepHandEmptySetting;
 import us.eunoians.mcrpg.setting.impl.KeepHotbarSlotEmptySetting;
@@ -135,6 +136,7 @@ public final class McRPGExpansion extends ContentExpansion {
         playerSettingContent.addContent(KeepHandEmptySetting.values()[0]);
         playerSettingContent.addContent(KeepHotbarSlotEmptySetting.values()[0]);
         playerSettingContent.addContent(RequireEmptyOffhandSetting.values()[0]);
+        playerSettingContent.addContent(DisableBonusExperienceConsumptionSetting.values()[0]);
         playerSettingContent.addContent(LocaleSetting.values()[0]);
         return playerSettingContent;
     }

--- a/src/main/java/us/eunoians/mcrpg/gui/setting/slot/DisableBonusExperienceConsumptionSettingSlot.java
+++ b/src/main/java/us/eunoians/mcrpg/gui/setting/slot/DisableBonusExperienceConsumptionSettingSlot.java
@@ -1,0 +1,42 @@
+package us.eunoians.mcrpg.gui.setting.slot;
+
+import com.diamonddagger590.mccore.builder.item.impl.ItemBuilder;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.setting.impl.DisableBonusExperienceConsumptionSetting;
+
+/**
+ * A {@link McRPGSettingSlot} that displays {@link DisableBonusExperienceConsumptionSetting}s.
+ */
+public class DisableBonusExperienceConsumptionSettingSlot extends McRPGSettingSlot<DisableBonusExperienceConsumptionSetting> {
+
+    public DisableBonusExperienceConsumptionSettingSlot(@NotNull McRPGPlayer mcRPGPlayer, @NotNull DisableBonusExperienceConsumptionSetting setting) {
+        super(mcRPGPlayer, setting);
+    }
+
+    @NotNull
+    @Override
+    public ItemBuilder getItem(@NotNull McRPGPlayer mcRPGPlayer) {
+        switch (getSetting()) {
+            case ENABLED -> {
+                return ItemBuilder.from(RegistryAccess.registryAccess().registry(RegistryKey.MANAGER)
+                        .manager(McRPGManagerKey.LOCALIZATION)
+                        .getLocalizedSection(mcRPGPlayer, LocalizationKey.PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_ENABLED_DISPLAY_ITEM));
+            }
+            case DISABLED -> {
+                return ItemBuilder.from(RegistryAccess.registryAccess().registry(RegistryKey.MANAGER)
+                        .manager(McRPGManagerKey.LOCALIZATION)
+                        .getLocalizedSection(mcRPGPlayer, LocalizationKey.PLAYER_SETTINGS_GUI_DISABLE_BONUS_EXPERIENCE_CONSUMPTION_SETTING_DISABLED_DISPLAY_ITEM));
+            }
+            default -> {
+                return ItemBuilder.from(new ItemStack(Material.AIR));
+            }
+        }
+    }
+}

--- a/src/main/java/us/eunoians/mcrpg/setting/impl/DisableBonusExperienceConsumptionSetting.java
+++ b/src/main/java/us/eunoians/mcrpg/setting/impl/DisableBonusExperienceConsumptionSetting.java
@@ -1,0 +1,89 @@
+package us.eunoians.mcrpg.setting.impl;
+
+import com.diamonddagger590.mccore.player.CorePlayer;
+import com.diamonddagger590.mccore.setting.PlayerSetting;
+import com.diamonddagger590.mccore.util.LinkedNode;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.gui.setting.slot.DisableBonusExperienceConsumptionSettingSlot;
+import us.eunoians.mcrpg.setting.McRPGSetting;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A player setting that allows players to disable the consumption of their
+ * rested and boosted experience. When enabled, players will not consume
+ * their bonus experience pools but also won't receive the bonus experience multiplier.
+ */
+public enum DisableBonusExperienceConsumptionSetting implements McRPGSetting {
+
+    /**
+     * This setting will prevent rested and boosted experience from being consumed.
+     * Players will not receive bonus experience while this is enabled.
+     */
+    ENABLED,
+    /**
+     * This setting allows rested and boosted experience to be consumed normally,
+     * providing bonus experience multipliers.
+     */
+    DISABLED,
+    ;
+
+    private static final LinkedNode<DisableBonusExperienceConsumptionSetting> FIRST_SETTING = new LinkedNode<>(DISABLED);
+    private static final Map<DisableBonusExperienceConsumptionSetting, LinkedNode<DisableBonusExperienceConsumptionSetting>> SETTINGS = new HashMap<>();
+    public static final NamespacedKey SETTING_KEY = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "disable-bonus-experience-consumption-setting");
+
+    static {
+        SETTINGS.put(FIRST_SETTING.getNodeValue(), FIRST_SETTING);
+        LinkedNode<DisableBonusExperienceConsumptionSetting> prev = FIRST_SETTING;
+        for (DisableBonusExperienceConsumptionSetting setting : values()) {
+            if (setting != FIRST_SETTING.getNodeValue()) {
+                LinkedNode<DisableBonusExperienceConsumptionSetting> next = new LinkedNode<>(setting);
+                prev.setNext(next);
+                prev = next;
+                SETTINGS.put(setting, prev);
+            }
+        }
+        prev.setNext(FIRST_SETTING);
+    }
+
+    @NotNull
+    @Override
+    public NamespacedKey getSettingKey() {
+        return SETTING_KEY;
+    }
+
+    @NotNull
+    @Override
+    public LinkedNode<DisableBonusExperienceConsumptionSetting> getFirstSetting() {
+        return FIRST_SETTING;
+    }
+
+    @NotNull
+    @Override
+    public LinkedNode<DisableBonusExperienceConsumptionSetting> getNextSetting() {
+        return SETTINGS.get(this).getNextNode();
+    }
+
+    @NotNull
+    @Override
+    public DisableBonusExperienceConsumptionSettingSlot getSettingSlot(@NotNull McRPGPlayer player) {
+        return new DisableBonusExperienceConsumptionSettingSlot(player, this);
+    }
+
+    @Override
+    public void onSettingChange(@NotNull CorePlayer player, @NotNull Optional<PlayerSetting> oldSetting) {
+        // No-op
+    }
+
+    @NotNull
+    @Override
+    public Optional<DisableBonusExperienceConsumptionSetting> fromString(@NotNull String setting) {
+        return Arrays.stream(values()).filter(disableBonusExperienceConsumptionSetting -> disableBonusExperienceConsumptionSetting.toString().equalsIgnoreCase(setting)).findFirst();
+    }
+}

--- a/src/main/java/us/eunoians/mcrpg/skill/experience/modifier/BoostedExperienceModifier.java
+++ b/src/main/java/us/eunoians/mcrpg/skill/experience/modifier/BoostedExperienceModifier.java
@@ -14,6 +14,7 @@ import us.eunoians.mcrpg.configuration.file.MainConfigFile;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.entity.player.PlayerExperienceExtras;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.setting.impl.DisableBonusExperienceConsumptionSetting;
 import us.eunoians.mcrpg.skill.experience.context.SkillExperienceContext;
 
 import java.util.UUID;
@@ -42,6 +43,12 @@ public final class BoostedExperienceModifier extends ExperienceModifier {
         var playerOptional = mcRPG.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(skillExperienceContext.getSkillHolder().getUUID());
         if (playerOptional.isPresent()) {
             McRPGPlayer mcRPGPlayer = playerOptional.get();
+            // Check if the player has disabled bonus experience consumption
+            if (mcRPGPlayer.getPlayerSetting(DisableBonusExperienceConsumptionSetting.SETTING_KEY)
+                    .filter(setting -> setting == DisableBonusExperienceConsumptionSetting.ENABLED)
+                    .isPresent()) {
+                return false;
+            }
             PlayerExperienceExtras playerExperienceExtras = mcRPGPlayer.getExperienceExtras();
             return playerExperienceExtras.getBoostedExperience() > 0;
         }

--- a/src/main/java/us/eunoians/mcrpg/skill/experience/modifier/RestedExperienceModifier.java
+++ b/src/main/java/us/eunoians/mcrpg/skill/experience/modifier/RestedExperienceModifier.java
@@ -15,6 +15,7 @@ import us.eunoians.mcrpg.entity.holder.SkillHolder;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.entity.player.PlayerExperienceExtras;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.setting.impl.DisableBonusExperienceConsumptionSetting;
 import us.eunoians.mcrpg.skill.experience.context.SkillExperienceContext;
 
 import java.util.UUID;
@@ -42,6 +43,12 @@ public class RestedExperienceModifier extends ExperienceModifier {
         var playerOptional = mcRPG.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(skillExperienceContext.getSkillHolder().getUUID());
         if (playerOptional.isPresent()) {
             McRPGPlayer mcRPGPlayer = playerOptional.get();
+            // Check if the player has disabled bonus experience consumption
+            if (mcRPGPlayer.getPlayerSetting(DisableBonusExperienceConsumptionSetting.SETTING_KEY)
+                    .filter(setting -> setting == DisableBonusExperienceConsumptionSetting.ENABLED)
+                    .isPresent()) {
+                return false;
+            }
             PlayerExperienceExtras playerExperienceExtras = mcRPGPlayer.getExperienceExtras();
             return playerExperienceExtras.getRestedExperience() > 0;
         }

--- a/src/main/resources/localization/en.yml
+++ b/src/main/resources/localization/en.yml
@@ -820,6 +820,30 @@ gui:
             - '<gray>Abilities can be readied even with an item in your offhand.'
             - ''
             - '<gold>Click <gray>to change this setting.'
+    # Configure the slot representing the setting to disable consumption of rested and boosted experience
+    disable-bonus-experience-consumption-setting-slot:
+      # Configure the setting display for when the setting is ENABLED (consumption is disabled)
+      enabled:
+        display-item:
+          material: RED_STAINED_GLASS_PANE
+          name: '<gold>Bonus Experience Consumption'
+          lore:
+            - '<gray>Status: <red>Disabled</red>.'
+            - '<gray>Rested and boosted experience will not be consumed.'
+            - '<gray>You will not receive bonus experience while this is enabled.'
+            - ''
+            - '<gold>Click <gray>to enable bonus experience consumption.'
+      # Configure the setting display for when the setting is DISABLED (consumption is enabled)
+      disabled:
+        display-item:
+          material: GREEN_STAINED_GLASS_PANE
+          name: '<gold>Bonus Experience Consumption'
+          lore:
+            - '<gray>Status: <green>Enabled</green>.'
+            - '<gray>Rested and boosted experience will be consumed normally.'
+            - '<gray>You will receive bonus experience from your pools.'
+            - ''
+            - '<gold>Click <gray>to disable bonus experience consumption.'
   # This GUI allows players to configure the allowlist of blocks for Remote Transfer.
   remote-transfer-gui:
     title: "<gold>Toggling Remote Transfer Items"

--- a/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/BoostedExperienceModifierTest.java
+++ b/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/BoostedExperienceModifierTest.java
@@ -18,6 +18,7 @@ import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
 import us.eunoians.mcrpg.entity.player.PlayerExperienceExtras;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.setting.impl.DisableBonusExperienceConsumptionSetting;
 import us.eunoians.mcrpg.skill.Skill;
 import us.eunoians.mcrpg.skill.experience.ExperienceModifierRegistry;
 import us.eunoians.mcrpg.skill.experience.ExperienceModifierRegistryExtension;
@@ -64,6 +65,24 @@ public class BoostedExperienceModifierTest extends McRPGBaseTest {
     public void canProcessContext_returnsTrue_whenContextValid(@NotNull McRPGPlayer mcRPGPlayer) {
         EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, 100);
         mcRPGPlayer.getExperienceExtras().setBoostedExperience(10);
+        assertTrue(boostedExperienceModifier.canProcessContext(entityDamageContext));
+    }
+
+    @Test
+    @DisplayName("Given a valid skill experience context with boosted XP but DisableBonusExperienceConsumptionSetting enabled, when checking canProcessContext, then it returns false")
+    public void canProcessContext_returnsFalse_whenSettingEnabled(@NotNull McRPGPlayer mcRPGPlayer) {
+        EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, 100);
+        mcRPGPlayer.getExperienceExtras().setBoostedExperience(10);
+        mcRPGPlayer.setPlayerSetting(DisableBonusExperienceConsumptionSetting.ENABLED);
+        assertFalse(boostedExperienceModifier.canProcessContext(entityDamageContext));
+    }
+
+    @Test
+    @DisplayName("Given a valid skill experience context with boosted XP and DisableBonusExperienceConsumptionSetting disabled, when checking canProcessContext, then it returns true")
+    public void canProcessContext_returnsTrue_whenSettingDisabled(@NotNull McRPGPlayer mcRPGPlayer) {
+        EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, 100);
+        mcRPGPlayer.getExperienceExtras().setBoostedExperience(10);
+        mcRPGPlayer.setPlayerSetting(DisableBonusExperienceConsumptionSetting.DISABLED);
         assertTrue(boostedExperienceModifier.canProcessContext(entityDamageContext));
     }
 

--- a/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/RestedExperienceModifierTest.java
+++ b/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/RestedExperienceModifierTest.java
@@ -20,6 +20,7 @@ import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
 import us.eunoians.mcrpg.entity.player.PlayerExperienceExtras;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.setting.impl.DisableBonusExperienceConsumptionSetting;
 import us.eunoians.mcrpg.skill.impl.MockSkill;
 import us.eunoians.mcrpg.skill.experience.ExperienceModifierRegistry;
 import us.eunoians.mcrpg.skill.experience.ExperienceModifierRegistryExtension;
@@ -59,10 +60,28 @@ public class RestedExperienceModifierTest extends McRPGBaseTest {
     }
 
     @Test
-    @DisplayName("Given a valid skill experience context with boosted XP, when checking canProcessContext, then it returns true")
+    @DisplayName("Given a valid skill experience context with rested XP, when checking canProcessContext, then it returns true")
     public void canProcessContext_returnsTrue_whenContextValid(@NotNull McRPGPlayer mcRPGPlayer) {
         EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, mcRPGPlayer.asSkillHolder(), 100);
         mcRPGPlayer.getExperienceExtras().setRestedExperience(10);
+        assertTrue(restedExperienceModifier.canProcessContext(entityDamageContext));
+    }
+
+    @Test
+    @DisplayName("Given a valid skill experience context with rested XP but DisableBonusExperienceConsumptionSetting enabled, when checking canProcessContext, then it returns false")
+    public void canProcessContext_returnsFalse_whenSettingEnabled(@NotNull McRPGPlayer mcRPGPlayer) {
+        EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, mcRPGPlayer.asSkillHolder(), 100);
+        mcRPGPlayer.getExperienceExtras().setRestedExperience(10);
+        mcRPGPlayer.setPlayerSetting(DisableBonusExperienceConsumptionSetting.ENABLED);
+        assertFalse(restedExperienceModifier.canProcessContext(entityDamageContext));
+    }
+
+    @Test
+    @DisplayName("Given a valid skill experience context with rested XP and DisableBonusExperienceConsumptionSetting disabled, when checking canProcessContext, then it returns true")
+    public void canProcessContext_returnsTrue_whenSettingDisabled(@NotNull McRPGPlayer mcRPGPlayer) {
+        EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, mcRPGPlayer.asSkillHolder(), 100);
+        mcRPGPlayer.getExperienceExtras().setRestedExperience(10);
+        mcRPGPlayer.setPlayerSetting(DisableBonusExperienceConsumptionSetting.DISABLED);
         assertTrue(restedExperienceModifier.canProcessContext(entityDamageContext));
     }
 


### PR DESCRIPTION
- Introduced `DisableBonusExperienceConsumptionSetting` to manage bonus experience consumption behavior.
- Created `DisableBonusExperienceConsumptionSettingSlot` for GUI representation.
- Updated `BoostedExperienceModifier` and `RestedExperienceModifier` to respect the new setting.
- Added localization entries for the new setting in `en.yml`.
- Implemented unit tests for the new setting functionality in `BoostedExperienceModifierTest` and `RestedExperienceModifierTest`.

Affects outstanding issues: #149 and by extension #142 