### PR TITLE
Implement event cancellation logic + unit tests

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/ability/BaseAbility.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/BaseAbility.java
@@ -66,10 +66,29 @@ public abstract class BaseAbility implements Ability {
         return Set.of(AbilityAttributeRegistry.ABILITY_TOGGLED_OFF_ATTRIBUTE_KEY);
     }
 
-    // TODO finish
+    /**
+     * Checks to see if the provided {@link Event} has any {@link EventCancellingComponent}s that indicate the event should be cancelled.
+     * <p>
+     * These {@link EventCancellingComponent}s are processed in order of priority and the first component that indicates
+     * the event should be cancelled will be returned in the {@link Optional}. If no components indicate cancellation,
+     * the {@link Optional} returned will be empty.
+     *
+     * @param abilityHolder The {@link AbilityHolder} to check against.
+     * @param event         The {@link Event} to use for checking cancellation components.
+     * @return An {@link Optional} containing the first {@link EventCancellingComponent} that indicates cancellation,
+     *         or empty if no components indicate the event should be cancelled.
+     */
+    @NotNull
     public Optional<EventCancellingComponent> checkIfComponentCancels(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
-        // TODO: Implement cancellation check logic iterating over cancellingComponents (https://github.com/DiamondDagger590/McRPG/issues/179)
-        return null;
+        for (EventCancellingComponentAttribute attribute : cancellingComponents) {
+            if (attribute.clazz().isInstance(event)) {
+                EventCancellingComponent component = attribute.abilityComponent();
+                if (component.shouldCancel(abilityHolder, event)) {
+                    return Optional.of(component);
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     /**
@@ -157,7 +176,14 @@ public abstract class BaseAbility implements Ability {
         return Optional.ofNullable(returnComponent);
     }
 
-    // TODO
+    /**
+     * Adds the provided {@link EventCancellingComponent} as a component for cancelling events when this ability activates.
+     * Components are processed in priority order, with the lowest priority being first.
+     *
+     * @param eventCancellingComponent The {@link EventCancellingComponent} to register
+     * @param clazz                    The class of the {@link Event} that this component applies to
+     * @param priority                 The priority of this {@link EventCancellingComponent}
+     */
     public void addCancellingComponent(@NotNull EventCancellingComponent eventCancellingComponent, @NotNull Class<? extends Event> clazz,
                                        int priority) {
         cancellingComponents.add(new EventCancellingComponentAttribute(eventCancellingComponent, clazz, priority));

--- a/src/main/java/us/eunoians/mcrpg/ability/component/cancel/EventCancellingComponent.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/component/cancel/EventCancellingComponent.java
@@ -1,8 +1,24 @@
 package us.eunoians.mcrpg.ability.component.cancel;
 
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.ability.BaseAbility;
 import us.eunoians.mcrpg.ability.component.AbilityComponent;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 
-// TODO this is basically saying if the event causes the ability to activate, should the event be cancelled
+/**
+ * This ability component determines if an event should be cancelled when the ability activates.
+ * Implementations can be registered in {@link BaseAbility#addCancellingComponent(EventCancellingComponent, Class, int)}.
+ */
 public interface EventCancellingComponent extends AbilityComponent {
 
+    /**
+     * Checks to see if this component should cancel the provided {@link Event} for
+     * the given {@link AbilityHolder}.
+     *
+     * @param abilityHolder The {@link AbilityHolder} to check cancellation for
+     * @param event         The {@link Event} to check cancellation against
+     * @return {@code true} if this ability component should cause the event to be cancelled
+     */
+    boolean shouldCancel(@NotNull AbilityHolder abilityHolder, @NotNull Event event);
 }

--- a/src/test/java/us/eunoians/mcrpg/ability/BaseAbilityTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/BaseAbilityTest.java
@@ -1,0 +1,137 @@
+package us.eunoians.mcrpg.ability;
+
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.component.cancel.EventCancellingComponent;
+import us.eunoians.mcrpg.ability.impl.MockAbility;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+public class BaseAbilityTest extends McRPGBaseTest {
+
+    private MockAbility mockAbility;
+
+    @BeforeEach
+    public void setup() {
+        mockAbility = new MockAbility(mcRPG);
+    }
+
+    @Test
+    @DisplayName("Given no cancelling components, when checking if component cancels, then returns empty Optional")
+    public void checkIfComponentCancels_returnsEmpty_whenNoCancellingComponents(@NotNull McRPGPlayer mcRPGPlayer) {
+        AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+        Optional<EventCancellingComponent> result = mockAbility.checkIfComponentCancels(abilityHolder, event);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Given a cancelling component that returns true, when checking if component cancels, then returns the component")
+    public void checkIfComponentCancels_returnsComponent_whenShouldCancelReturnsTrue(@NotNull McRPGPlayer mcRPGPlayer) {
+        AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+        EventCancellingComponent cancellingComponent = mock(EventCancellingComponent.class);
+        when(cancellingComponent.shouldCancel(any(), any())).thenReturn(true);
+        mockAbility.addCancellingComponent(cancellingComponent, BlockBreakEvent.class, 1);
+
+        Optional<EventCancellingComponent> result = mockAbility.checkIfComponentCancels(abilityHolder, event);
+
+        assertTrue(result.isPresent());
+        assertEquals(cancellingComponent, result.get());
+    }
+
+    @Test
+    @DisplayName("Given a cancelling component that returns false, when checking if component cancels, then returns empty Optional")
+    public void checkIfComponentCancels_returnsEmpty_whenShouldCancelReturnsFalse(@NotNull McRPGPlayer mcRPGPlayer) {
+        AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+        EventCancellingComponent cancellingComponent = mock(EventCancellingComponent.class);
+        when(cancellingComponent.shouldCancel(any(), any())).thenReturn(false);
+        mockAbility.addCancellingComponent(cancellingComponent, BlockBreakEvent.class, 1);
+
+        Optional<EventCancellingComponent> result = mockAbility.checkIfComponentCancels(abilityHolder, event);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Given a cancelling component for a different event class, when checking if component cancels, then returns empty Optional")
+    public void checkIfComponentCancels_returnsEmpty_whenEventClassDoesNotMatch(@NotNull McRPGPlayer mcRPGPlayer) {
+        AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+        EventCancellingComponent cancellingComponent = mock(EventCancellingComponent.class);
+        when(cancellingComponent.shouldCancel(any(), any())).thenReturn(true);
+        // Register for PlayerInteractEvent, not BlockBreakEvent
+        mockAbility.addCancellingComponent(cancellingComponent, PlayerInteractEvent.class, 1);
+
+        Optional<EventCancellingComponent> result = mockAbility.checkIfComponentCancels(abilityHolder, event);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Given multiple cancelling components with different priorities, when checking if component cancels, then returns first matching component by priority")
+    public void checkIfComponentCancels_returnsFirstMatchingByPriority(@NotNull McRPGPlayer mcRPGPlayer) {
+        AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+        EventCancellingComponent lowPriorityComponent = mock(EventCancellingComponent.class);
+        when(lowPriorityComponent.shouldCancel(any(), any())).thenReturn(true);
+
+        EventCancellingComponent highPriorityComponent = mock(EventCancellingComponent.class);
+        when(highPriorityComponent.shouldCancel(any(), any())).thenReturn(true);
+
+        // Add high priority (10) first, then low priority (1)
+        mockAbility.addCancellingComponent(highPriorityComponent, BlockBreakEvent.class, 10);
+        mockAbility.addCancellingComponent(lowPriorityComponent, BlockBreakEvent.class, 1);
+
+        Optional<EventCancellingComponent> result = mockAbility.checkIfComponentCancels(abilityHolder, event);
+
+        assertTrue(result.isPresent());
+        // Low priority (1) should be processed first
+        assertEquals(lowPriorityComponent, result.get());
+    }
+
+    @Test
+    @DisplayName("Given first component returns false and second returns true, when checking if component cancels, then returns second component")
+    public void checkIfComponentCancels_returnsSecondComponent_whenFirstReturnsFalse(@NotNull McRPGPlayer mcRPGPlayer) {
+        AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
+        BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+        EventCancellingComponent firstComponent = mock(EventCancellingComponent.class);
+        when(firstComponent.shouldCancel(any(), any())).thenReturn(false);
+
+        EventCancellingComponent secondComponent = mock(EventCancellingComponent.class);
+        when(secondComponent.shouldCancel(any(), any())).thenReturn(true);
+
+        mockAbility.addCancellingComponent(firstComponent, BlockBreakEvent.class, 1);
+        mockAbility.addCancellingComponent(secondComponent, BlockBreakEvent.class, 2);
+
+        Optional<EventCancellingComponent> result = mockAbility.checkIfComponentCancels(abilityHolder, event);
+
+        assertTrue(result.isPresent());
+        assertEquals(secondComponent, result.get());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/MockAbility.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/MockAbility.java
@@ -1,0 +1,84 @@
+package us.eunoians.mcrpg.ability.impl;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.ability.BaseAbility;
+import us.eunoians.mcrpg.builder.item.ability.AbilityItemBuilder;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * A mock instance of an ability used for unit testing
+ * abilities abstractly without caring about a specific implementation
+ * of an ability.
+ */
+public class MockAbility extends BaseAbility {
+
+    public MockAbility(@NotNull McRPG plugin) {
+        super(plugin, new NamespacedKey(plugin, "mock-ability"));
+    }
+
+    @NotNull
+    @Override
+    public String getDatabaseName() {
+        return "mock-ability";
+    }
+
+    @NotNull
+    @Override
+    public String getName(@NotNull McRPGPlayer player) {
+        return "Mock Ability";
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return "Mock Ability";
+    }
+
+    @NotNull
+    @Override
+    public Component getDisplayName(@NotNull McRPGPlayer player) {
+        return Component.text("Mock Ability");
+    }
+
+    @NotNull
+    @Override
+    public Component getDisplayName() {
+        return Component.text("Mock Ability");
+    }
+
+    @Override
+    public void activateAbility(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
+        // No-op for testing
+    }
+
+    @Override
+    public boolean isAbilityEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isPassive() {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public AbilityItemBuilder getDisplayItemBuilder(@NotNull McRPGPlayer player) {
+        return mock(AbilityItemBuilder.class);
+    }
+
+    @NotNull
+    @Override
+    public Optional<NamespacedKey> getExpansionKey() {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
Implements #179

I've been thinking a bit on how to implement this and here's what I came up with. Though, feel free to comment if something is amiss, I'll take a look. Took some time formatting this to be as clear as possible.

- Implementing the `checkIfComponentCancels` method in `BaseAbility` that was previously a stub returning null
- Add `shouldCancel(AbilityHolder, Event)` method to `EventCancellingComponent` interface to enable cancellation logic
- Add comprehensive unit tests for the new functionality.

The `checkIfComponentCancels` method follows the same pattern established by `checkIfComponentFailsActivation` and `checkIfComponentFailsReady`

- Iterates through registered `EventCancellingComponents` in priority order (lowest first)
- Filters components by checking if the event is an instance of the registered event class
- Returns the first component where `shouldCancel()` returns true
- Returns `Optional.empty()` if no component indicates cancellation

## Why return the first cancelling component rather than checking all?
This matches the existing pattern in `checkIfComponentFailsActivation` - once we find a component that wants to cancel, we don't need to continue checking. This also allows the caller to know _which_ component caused the cancellation if needed for logging/debugging.

## Why use `isInstance()` for event class matching?
Unlike the activating/ready components which use a `Map<Class, List>` structure, cancelling components use a flat `List`. Using `isInstance()` allows for proper inheritance handling - a component registered for `PlayerEvent` would match `PlayerInteractEvent`.

## Why add `shouldCancel` to the interface?
The `EventCancellingComponent` interface was empty (just extending `AbilityComponent`). The TODO comment indicated it should determine "if the event causes the ability to activate, should the event be cancelled". Adding `shouldCancel` mirrors the pattern of `shouldActivate` in `EventActivatableComponent` and `shouldReady` in `EventReadyableComponent`. 