### PR TITLE
Update Paper API version to 1.21.11 and adjust test dependencies for MockBukkit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,10 +67,12 @@ dependencies {
     testImplementation(testFixtures("com.diamonddagger590:McCore:$mccoreVersion"))
     testFixturesImplementation(testFixtures("com.diamonddagger590:McCore:$mccoreVersion"))
 
-    val paperVersion = "1.21.10-R0.1-SNAPSHOT"
+    val paperVersion = "1.21.11-R0.1-SNAPSHOT"
     compileOnly("io.papermc.paper:paper-api:$paperVersion")
-    testImplementation("io.papermc.paper:paper-api:$paperVersion")
-    testFixturesImplementation("io.papermc.paper:paper-api:$paperVersion")
+    // MockBukkit 4.98.x is built against 1.21.10, so tests need to use that version
+    val testPaperVersion = "1.21.10-R0.1-SNAPSHOT"
+    testImplementation("io.papermc.paper:paper-api:$testPaperVersion")
+    testFixturesImplementation("io.papermc.paper:paper-api:$testPaperVersion")
 
     val bstatsVersion = "2.2.1"
     implementation("org.bstats:bstats-bukkit:$bstatsVersion")
@@ -130,6 +132,13 @@ tasks.withType<ProcessResources> {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+// Force Paper API version in test configurations to match what MockBukkit expects
+configurations.matching { it.name.startsWith("test") }.configureEach {
+    resolutionStrategy {
+        force("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
+    }
 }
 
 tasks {

--- a/src/main/java/us/eunoians/mcrpg/bootstrap/McRPGBootstrap.java
+++ b/src/main/java/us/eunoians/mcrpg/bootstrap/McRPGBootstrap.java
@@ -87,7 +87,9 @@ public class McRPGBootstrap extends CoreBootstrap<McRPG> {
     public void stop(@NotNull StartupProfile startupProfile) {
         if (startupProfile == StartupProfile.PROD) {
             RegistryAccess registryAccess = getPlugin().registryAccess();
-            registryAccess.registry(RegistryKey.MANAGER).manager(McRPGManagerKey.GLOWING).shutdown();
+            if (registryAccess.registry(RegistryKey.MANAGER).registered(McRPGManagerKey.GLOWING)) {
+                registryAccess.registry(RegistryKey.MANAGER).manager(McRPGManagerKey.GLOWING).shutdown();
+            }
             if (registryAccess.registry(RegistryKey.MANAGER).registered(McRPGManagerKey.DATABASE)) {
                 Database database = registryAccess.registry(RegistryKey.MANAGER).manager(McRPGManagerKey.DATABASE).getDatabase();
                 try (Connection connection = database.getConnection()) {


### PR DESCRIPTION
PR to update McRPG to work with 1.21.11 with the upcoming remapper removal (Per Paper's recommendation) as Minecraft is dropping obfuscation with the server flag:
`-Dpaper.disablePluginRemapping=true`

- Updates Paper API version to 1.21.11-R0.1-SNAPSHOT
- Makes Paper API to be 1.21.10-R0.1-SNAPSHOT for MockBukkit tests (For now as MockBukkit has no support for 1.21.11 and fails and it'll do for now)
- Fixes a minor issue with GlowingManager.shutdown() that happens upon plugin crash (discovered with the update) that does a null check whether GlowingManager is even registered if the plugin fails on startup.

This might require more fixing if we encounter issues when MockBukkit updates, but for now, no additional issues have been discovered.