### PR TITLE
Refactor command descriptions to use localization keys

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/command/CommandPlaceholders.java
+++ b/src/main/java/us/eunoians/mcrpg/command/CommandPlaceholders.java
@@ -20,6 +20,7 @@ public enum CommandPlaceholders {
     SKILL("skill"),
     ABILITY("ability"),
     LOADOUT_SLOT("loadout-slot"),
+    UPGRADE_POINTS("upgrade-points"),
     ;
 
     private final String placeholder;

--- a/src/main/java/us/eunoians/mcrpg/command/admin/DebugCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/DebugCommand.java
@@ -2,7 +2,6 @@ package us.eunoians.mcrpg.command.admin;
 
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -12,11 +11,21 @@ import org.incendo.cloud.key.CloudKey;
 import org.incendo.cloud.minecraft.extras.RichDescription;
 import org.incendo.cloud.permission.Permission;
 import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.configuration.file.localization.LocalizationKey;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+
+import static us.eunoians.mcrpg.command.CommandPlaceholders.EXPERIENCE;
+import static us.eunoians.mcrpg.command.CommandPlaceholders.LEVEL;
+import static us.eunoians.mcrpg.command.CommandPlaceholders.SKILL;
+import static us.eunoians.mcrpg.command.CommandPlaceholders.TARGET;
+import static us.eunoians.mcrpg.command.CommandPlaceholders.UPGRADE_POINTS;
 
 /**
  * Command used for development, prints various debug information about a player
@@ -25,11 +34,11 @@ public class DebugCommand {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("debug")
-                .optional("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to reset something for")))
+                .optional("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_DEBUG_PLAYER)))
                 .permission(Permission.of("mcrpg.debug"))
                 .handler(commandContext -> {
                             CloudKey<Player> playerKey = CloudKey.of("player", Player.class);
@@ -38,11 +47,23 @@ public class DebugCommand {
 
                     Optional<AbilityHolder> abilityHolderOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).getAbilityHolder(player.getUniqueId());
                             if (abilityHolderOptional.isPresent() && abilityHolderOptional.get() instanceof SkillHolder skillHolder) {
-                                player.sendMessage(miniMessage.deserialize(String.format("<gray>Printing debug information for player <gold>%s", player.getName())));
-                                player.sendMessage(miniMessage.deserialize(String.format("<gray>Upgrade Points: <gold>%s", skillHolder.getUpgradePoints())));
+                                Map<String, String> headerPlaceholders = new HashMap<>();
+                                headerPlaceholders.put(TARGET.getPlaceholder(), player.getName());
+                                player.sendMessage(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.DEBUG_COMMAND_HEADER_MESSAGE, headerPlaceholders));
+
+                                Map<String, String> upgradePointsPlaceholders = new HashMap<>();
+                                upgradePointsPlaceholders.put(UPGRADE_POINTS.getPlaceholder(), Integer.toString(skillHolder.getUpgradePoints()));
+                                player.sendMessage(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.DEBUG_COMMAND_UPGRADE_POINTS_MESSAGE, upgradePointsPlaceholders));
+
                                 for (NamespacedKey skill : skillHolder.getSkills()) {
                                     Optional<SkillHolder.SkillHolderData> skillHolderDataOptional = skillHolder.getSkillHolderData(skill);
-                                    skillHolderDataOptional.ifPresent(skillHolderData -> player.sendMessage(miniMessage.deserialize(String.format("<gray>Skill: <gold>%s <gray>Level: <gold>%d <gray>Exp: <gold>%d", skillHolderData.getSkillKey().value(), skillHolderData.getCurrentLevel(), skillHolderData.getCurrentExperience()))));
+                                    skillHolderDataOptional.ifPresent(skillHolderData -> {
+                                        Map<String, String> skillPlaceholders = new HashMap<>();
+                                        skillPlaceholders.put(SKILL.getPlaceholder(), skillHolderData.getSkillKey().value());
+                                        skillPlaceholders.put(LEVEL.getPlaceholder(), Integer.toString(skillHolderData.getCurrentLevel()));
+                                        skillPlaceholders.put(EXPERIENCE.getPlaceholder(), Integer.toString(skillHolderData.getCurrentExperience()));
+                                        player.sendMessage(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.DEBUG_COMMAND_SKILL_INFO_MESSAGE, skillPlaceholders));
+                                    });
                                 }
                             }
                         }

--- a/src/main/java/us/eunoians/mcrpg/command/admin/bank/BoostedExperienceModifyCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/bank/BoostedExperienceModifyCommand.java
@@ -5,7 +5,6 @@ import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -39,15 +38,15 @@ public class BoostedExperienceModifyCommand extends AdminBankCommandBase{
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("admin")
                 .literal("exp-bank", "experience-bank", "bank")
                 .literal("give")
                 .literal("boosted-exp", "boosted")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to give something to")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of boosted experience to give")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_PLAYER)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_BOOSTED_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_GIVE_COMMAND_ROOT_PERMISSION, GIVE_BOOSTED_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
@@ -57,7 +56,6 @@ public class BoostedExperienceModifyCommand extends AdminBankCommandBase{
                     int expAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, expAmount);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, expAmount);
@@ -80,8 +78,8 @@ public class BoostedExperienceModifyCommand extends AdminBankCommandBase{
                 .literal("exp-bank", "experience-bank", "bank")
                 .literal("remove", "minus")
                 .literal("boosted-exp", "boosted")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to remove something from")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of boosted exp to remove")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_PLAYER)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_BOOSTED_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_REMOVE_COMMAND_ROOT_PERMISSION, REMOVE_BOOSTED_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
@@ -91,7 +89,6 @@ public class BoostedExperienceModifyCommand extends AdminBankCommandBase{
                     int expAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, expAmount);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, expAmount);
@@ -114,7 +111,7 @@ public class BoostedExperienceModifyCommand extends AdminBankCommandBase{
                 .literal("exp-bank", "experience-bank", "bank")
                 .literal("reset")
                 .literal("boosted-exp", "boosted")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to reset")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_RESET_PLAYER)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_RESET_COMMAND_ROOT_PERMISSION, RESET_BOOSTED_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
@@ -122,7 +119,6 @@ public class BoostedExperienceModifyCommand extends AdminBankCommandBase{
                     Player player = commandContext.get(playerKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, 0);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, 0);

--- a/src/main/java/us/eunoians/mcrpg/command/admin/bank/RestedExperienceModifyCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/bank/RestedExperienceModifyCommand.java
@@ -5,7 +5,6 @@ import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -39,15 +38,15 @@ public class RestedExperienceModifyCommand extends AdminBankCommandBase {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("admin")
                 .literal("exp-bank", "experience-bank", "bank")
                 .literal("give")
                 .literal("rested-exp", "rested")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to give something to")))
-                .required("amount", FloatParser.floatParser(0), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of rested experience to give")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_PLAYER)))
+                .required("amount", FloatParser.floatParser(0), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_RESTED_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_GIVE_COMMAND_ROOT_PERMISSION, GIVE_RESTED_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
@@ -57,7 +56,6 @@ public class RestedExperienceModifyCommand extends AdminBankCommandBase {
                     float expAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, expAmount);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, expAmount);
@@ -80,8 +78,8 @@ public class RestedExperienceModifyCommand extends AdminBankCommandBase {
                 .literal("exp-bank", "experience-bank", "bank")
                 .literal("remove", "minus")
                 .literal("rested-exp", "rested")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to remove something from")))
-                .required("amount", FloatParser.floatParser(0), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of rested exp to remove")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_PLAYER)))
+                .required("amount", FloatParser.floatParser(0), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_RESTED_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_REMOVE_COMMAND_ROOT_PERMISSION, REMOVE_RESTED_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
@@ -91,7 +89,6 @@ public class RestedExperienceModifyCommand extends AdminBankCommandBase {
                     float expAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, expAmount);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, expAmount);
@@ -114,7 +111,7 @@ public class RestedExperienceModifyCommand extends AdminBankCommandBase {
                 .literal("exp-bank", "experience-bank", "bank")
                 .literal("reset")
                 .literal("rested-exp", "rested")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to reset")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_RESET_PLAYER)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_RESET_COMMAND_ROOT_PERMISSION, RESET_RESTED_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
@@ -122,7 +119,6 @@ public class RestedExperienceModifyCommand extends AdminBankCommandBase {
                     Player player = commandContext.get(playerKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, 0);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, 0);

--- a/src/main/java/us/eunoians/mcrpg/command/admin/bank/redeemable/RedeemableExperienceModifyCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/bank/redeemable/RedeemableExperienceModifyCommand.java
@@ -5,7 +5,6 @@ import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -41,7 +40,7 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("admin")
@@ -49,8 +48,8 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
                 .literal("give")
                 .literal("redeemable", "redeem")
                 .literal("experience", "exp")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to give something to")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of redeemable experience to give")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_GIVE_PLAYER)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_REDEEMABLE_EXPERIENCE_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_GIVE_COMMAND_ROOT_PERMISSION, GIVE_REDEEMABLE_EXPERIENCE_PERMISSION, RedeemableModifyCommandBase.REDEEMABLE_BANK_GIVE_ROOT_PERMISSION))
                 .handler(commandContext -> {
@@ -60,7 +59,6 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
                     int experienceAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Optional<McRPGPlayer> senderOptional = senderAudience instanceof Player sender ? McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                             .manager(McRPGManagerKey.PLAYER).getPlayer(sender.getUniqueId()) : Optional.empty();
@@ -87,8 +85,8 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
                 .literal("remove")
                 .literal("redeemable", "redeem")
                 .literal("experience", "exp")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to remove something from")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of redeemable experience to remove")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_REMOVE_PLAYER)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_REDEEMABLE_EXPERIENCE_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_REMOVE_COMMAND_ROOT_PERMISSION, REMOVE_REDEEMABLE_EXPERIENCE_PERMISSION, RedeemableModifyCommandBase.REDEEMABLE_BANK_REMOVE_ROOT_PERMISSION))
                 .handler(commandContext -> {
@@ -98,7 +96,6 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
                     int experienceAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Optional<McRPGPlayer> senderOptional = senderAudience instanceof Player sender ? McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                             .manager(McRPGManagerKey.PLAYER).getPlayer(sender.getUniqueId()) : Optional.empty();
@@ -125,7 +122,7 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
                 .literal("reset")
                 .literal("redeemable", "redeem")
                 .literal("experience", "exp")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to remove something from")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_RESET_PLAYER)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_RESET_COMMAND_ROOT_PERMISSION, RESET_REDEEMABLE_EXPERIENCE_PERMISSION, RedeemableModifyCommandBase.REDEEMABLE_BANK_RESET_ROOT_PERMISSION))
                 .handler(commandContext -> {
@@ -133,7 +130,6 @@ public class RedeemableExperienceModifyCommand extends RedeemableModifyCommandBa
                     Player player = commandContext.get(playerKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Optional<McRPGPlayer> senderOptional = senderAudience instanceof Player sender ? McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                             .manager(McRPGManagerKey.PLAYER).getPlayer(sender.getUniqueId()) : Optional.empty();

--- a/src/main/java/us/eunoians/mcrpg/command/admin/bank/redeemable/RedeemableLevelsModifyCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/bank/redeemable/RedeemableLevelsModifyCommand.java
@@ -5,7 +5,6 @@ import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -40,7 +39,7 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("admin")
@@ -48,8 +47,8 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
                 .literal("give")
                 .literal("redeemable", "redeem")
                 .literal("levels", "lv", "lvs")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to give something to")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of redeemable levels to give")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_GIVE_PLAYER)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_REDEEMABLE_LEVELS_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_GIVE_COMMAND_ROOT_PERMISSION, GIVE_REDEEMABLE_LEVELS_PERMISSION, RedeemableModifyCommandBase.REDEEMABLE_BANK_GIVE_ROOT_PERMISSION))
                 .handler(commandContext -> {
@@ -59,7 +58,6 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
                     int levelAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, levelAmount);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, levelAmount);
@@ -83,8 +81,8 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
                 .literal("remove", "minus")
                 .literal("redeemable", "redeem")
                 .literal("levels", "lv", "lvs")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to remove something from")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of redeemable levels to remove")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_REMOVE_PLAYER)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_REDEEMABLE_LEVELS_AMOUNT)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_REMOVE_COMMAND_ROOT_PERMISSION, REMOVE_REDEEMABLE_LEVELS_PERMISSION, RedeemableModifyCommandBase.REDEEMABLE_BANK_REMOVE_ROOT_PERMISSION))
                 .handler(commandContext -> {
@@ -94,7 +92,6 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
                     int levelAmount = commandContext.get(amountKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, levelAmount);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, levelAmount);
@@ -118,7 +115,7 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
                 .literal("reset")
                 .literal("redeemable", "redeem")
                 .literal("levels", "lv", "lvs")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to reset")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_EXP_BANK_RESET_PLAYER)))
                 .permission(Permission.anyOf(McRPGCommandBase.ROOT_PERMISSION, AdminBaseCommand.ADMIN_BASE_PERMISSION, AdminBankCommandBase.BANK_MODIFY_COMMAND_ROOT_PERMISSION,
                         AdminBankCommandBase.BANK_RESET_COMMAND_ROOT_PERMISSION, RESET_REDEEMABLE_LEVELS_PERMISSION, RedeemableModifyCommandBase.REDEEMABLE_BANK_RESET_ROOT_PERMISSION))
                 .handler(commandContext -> {
@@ -126,7 +123,6 @@ public class RedeemableLevelsModifyCommand extends RedeemableModifyCommandBase {
                     Player player = commandContext.get(playerKey);
 
                     Audience senderAudience = commandContext.sender().getSender();
-                    McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                     Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                     Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player, 0);
                     Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player, 0);

--- a/src/main/java/us/eunoians/mcrpg/command/admin/reset/ResetPlayerCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/reset/ResetPlayerCommand.java
@@ -2,12 +2,10 @@ package us.eunoians.mcrpg.command.admin.reset;
 
 import com.diamonddagger590.mccore.database.Database;
 import com.diamonddagger590.mccore.database.transaction.FailSafeTransaction;
-import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.task.core.CoreTask;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -41,12 +39,12 @@ public class ResetPlayerCommand extends ResetBaseCommand {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("admin")
-                .literal("reset").commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>The subcommand for all commands that resets a target")))
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to reset something for")))
+                .literal("reset").commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_RESET)))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_RESET_PLAYER)))
                 .permission(Permission.anyOf(ROOT_PERMISSION, ADMIN_BASE_PERMISSION, RESET_COMMAND_BASE_PERMISSION, RESET_PLAYER_PERMISSION))
                 .meta(ConfirmationManager.META_CONFIRMATION_REQUIRED, true)
                 .handler(commandContext -> {
@@ -56,7 +54,6 @@ public class ResetPlayerCommand extends ResetBaseCommand {
                             Audience senderAudience = commandContext.sender().getSender();
                             Map<String, String> senderPlaceholders = getPlaceholders(senderAudience, senderAudience, player);
                             Map<String, String> receiverPlaceholders = getPlaceholders(player, senderAudience, player);
-                            McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                             McRPG mcRPG = McRPG.getInstance();
 
                             Optional<AbilityHolder> abilityHolderOptional = mcRPG.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).getAbilityHolder(player.getUniqueId());

--- a/src/main/java/us/eunoians/mcrpg/command/admin/reset/ResetSkillCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/reset/ResetSkillCommand.java
@@ -8,7 +8,6 @@ import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import com.diamonddagger590.mccore.task.core.CoreTask;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -48,14 +47,14 @@ public class ResetSkillCommand extends ResetBaseCommand {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("admin")
-                .literal("reset").commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>The subcommand for all commands that resets a target")))
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to reset something for")))
+                .literal("reset").commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_RESET)))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_RESET_PLAYER)))
                 .literal("skill")
-                .required("reset_skill", SkillParser.skillParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The skill to reset")))
+                .required("reset_skill", SkillParser.skillParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_RESET_SKILL)))
                 .meta(ConfirmationManager.META_CONFIRMATION_REQUIRED, true)
                 .permission(Permission.anyOf(ROOT_PERMISSION, ADMIN_BASE_PERMISSION, RESET_COMMAND_BASE_PERMISSION, RESET_SKILL_PERMISSION))
                 .handler(commandContext -> {
@@ -64,7 +63,6 @@ public class ResetSkillCommand extends ResetBaseCommand {
                             CloudKey<Skill> skillKey = CloudKey.of("reset_skill", Skill.class);
                             Skill skill = commandContext.get(skillKey);
                             Audience senderAudience = commandContext.sender().getSender();
-                            McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
                             Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                             Optional<McRPGPlayer> senderOptional = commandContext.sender().getSender() instanceof Player sender ? McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)

--- a/src/main/java/us/eunoians/mcrpg/command/give/GiveExperienceCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/give/GiveExperienceCommand.java
@@ -1,11 +1,9 @@
 package us.eunoians.mcrpg.command.give;
 
-import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -41,14 +39,14 @@ public class GiveExperienceCommand extends GiveCommandBase {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
-                .literal("give").commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>The subcommand for all commands that give targets something")))
+                .literal("give").commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE)))
                 .literal("exp", "experience")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to give something to to")))
-                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The skill to give experience for")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of experience to give")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_PLAYER)))
+                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_EXPERIENCE_SKILL)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_EXPERIENCE_AMOUNT)))
                 .permission(Permission.anyOf(ROOT_PERMISSION, GIVE_COMMAND_ROOT_PERMISSION, GIVE_EXPERIENCE_PERMISSION))
                 .handler(commandContext -> {
                             CloudKey<Skill> skillKey = CloudKey.of("skill", Skill.class);
@@ -59,7 +57,6 @@ public class GiveExperienceCommand extends GiveCommandBase {
                             int experienceAmount = commandContext.get(amountKey);
 
                             Audience senderAudience = commandContext.sender().getSender();
-                            McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                             Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());
                             Optional<McRPGPlayer> senderOptional = senderAudience instanceof Player sender ? McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                                     .manager(McRPGManagerKey.PLAYER).getPlayer(sender.getUniqueId()) : Optional.empty();

--- a/src/main/java/us/eunoians/mcrpg/command/give/GiveLevelsCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/give/GiveLevelsCommand.java
@@ -1,11 +1,9 @@
 package us.eunoians.mcrpg.command.give;
 
-import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.bukkit.parser.PlayerParser;
@@ -41,15 +39,15 @@ public class GiveLevelsCommand extends GiveCommandBase {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
 
         commandManager.command(commandManager.commandBuilder("mcrpg")
-                .literal("give").commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>The subcommand for all commands that give targets something")))
+                .literal("give").commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE)))
                 .literal("level", "levels")
-                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The player to give something to to")))
-                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The skill to give levels for")))
-                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The amount of levels to give")))
-                .flag(commandManager.flagBuilder("reset_experience").withAliases("r")).commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>If the player's current experience should be reset to 0 after levels are given.")))
+                .required("player", PlayerParser.playerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_PLAYER)))
+                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_LEVELS_SKILL)))
+                .required("amount", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_LEVELS_AMOUNT)))
+                .flag(commandManager.flagBuilder("reset_experience").withAliases("r")).commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_GIVE_LEVELS_RESET_EXPERIENCE_FLAG)))
                 .permission(Permission.anyOf(ROOT_PERMISSION, GIVE_COMMAND_ROOT_PERMISSION, GIVE_LEVELS_PERMISSION))
                 .handler(commandContext -> {
                             CloudKey<Skill> skillKey = CloudKey.of("skill", Skill.class);
@@ -60,7 +58,6 @@ public class GiveLevelsCommand extends GiveCommandBase {
                             boolean resetExperience = commandContext.flags().isPresent("reset_experience");
 
                             Audience senderAudience = commandContext.sender().getSender();
-                            McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                             Optional<McRPGPlayer> senderOptional = senderAudience instanceof Player sender ? McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                                     .manager(McRPGManagerKey.PLAYER).getPlayer(sender.getUniqueId()) : Optional.empty();
                             Optional<McRPGPlayer> playerOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getPlayer(player.getUniqueId());

--- a/src/main/java/us/eunoians/mcrpg/command/loadout/LoadoutEditCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/loadout/LoadoutEditCommand.java
@@ -4,7 +4,6 @@ import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
@@ -39,17 +38,16 @@ public class LoadoutEditCommand extends McRPGCommandBase {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("loadout")
                 .literal("edit")
-                .optional("slot", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The loadout to edit.")))
+                .optional("slot", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_LOADOUT_EDIT_SLOT)))
                 .handler(commandContext -> {
                     CommandSender commandSender = commandContext.sender().getSender();
                     CloudKey<Integer> slotKey = CloudKey.of("slot", Integer.class);
                     if (commandSender instanceof Player player) {
                         McRPGPlayerManager playerManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER);
-                        McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                         playerManager.getPlayer(player.getUniqueId()).ifPresent(mcRPGPlayer -> {
                             LoadoutHolder loadoutHolder = mcRPGPlayer.asSkillHolder();
                             int loadoutSlot = commandContext.getOrDefault(slotKey, loadoutHolder.getCurrentLoadoutSlot());

--- a/src/main/java/us/eunoians/mcrpg/command/loadout/LoadoutSetCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/loadout/LoadoutSetCommand.java
@@ -4,7 +4,6 @@ import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
@@ -33,18 +32,17 @@ public class LoadoutSetCommand extends McRPGCommandBase {
 
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
         commandManager.command(commandManager.commandBuilder("mcrpg")
                 .literal("loadout")
                 .literal("set")
-                .required("slot", IntegerParser.integerParser(1), RichDescription.richDescription(miniMessage.deserialize("<gray>The loadout to set.")))
+                .required("slot", IntegerParser.integerParser(1), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_LOADOUT_SLOT)))
                 .handler(commandContext -> {
                     CommandSender commandSender = commandContext.sender().getSender();
                     CloudKey<Integer> amountKey = CloudKey.of("slot", Integer.class);
                     int loadoutSlot = commandContext.get(amountKey);
                     if (commandSender instanceof Player player) {
                         McRPGPlayerManager playerManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER);
-                        McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                         Map<String, String> placeholders = getPlaceholders(loadoutSlot);
                         playerManager.getPlayer(player.getUniqueId()).ifPresent(mcRPGPlayer -> {
                             LoadoutHolder loadoutHolder = mcRPGPlayer.asSkillHolder();

--- a/src/main/java/us/eunoians/mcrpg/command/redeem/RedeemExperienceCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/redeem/RedeemExperienceCommand.java
@@ -4,7 +4,6 @@ import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.Command;
@@ -40,14 +39,15 @@ public class RedeemExperienceCommand extends McRPGCommandBase {
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                 .manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
 
         Command.Builder<CommandSourceStack> redeemBuilder = commandManager.commandBuilder("mcrpg")
-                .literal("redeem").commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>The subcommand that allows players to redeem things.")))
+                .literal("redeem").commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_REDEEM)))
                 .literal("experience", "exp")
-                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The skill to redeem experience in")));
+                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_REDEEM_SKILL)));
         commandManager.command(redeemBuilder
-                .required("amount", IntegerParser.integerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>How much experience to redeem?")))
+                .required("amount", IntegerParser.integerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_REDEEM_EXPERIENCE_AMOUNT)))
                 .handler(commandContext -> {
                             CommandSender commandSender = commandContext.sender().getSender();
                             CloudKey<Skill> skillKey = CloudKey.of("skill", Skill.class);
@@ -60,7 +60,7 @@ public class RedeemExperienceCommand extends McRPGCommandBase {
                                 playerOptional.ifPresent(mcRPGPlayer -> redeemExperience(mcRPGPlayer, skill, amount));
                                 // If they aren't present, it typically means their data isn't loaded yet so it's fine to just no-op
                             } else {
-                                commandSender.sendMessage(miniMessage.deserialize("<red>Non-players are not allowed to run this command."));
+                                commandSender.sendMessage(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.NON_PLAYER_COMMAND_ERROR));
                             }
                         }
                 ));
@@ -78,7 +78,7 @@ public class RedeemExperienceCommand extends McRPGCommandBase {
                         playerOptional.ifPresent(mcRPGPlayer -> redeemExperience(mcRPGPlayer, skill, mcRPGPlayer.getExperienceExtras().getRedeemableExperience()));
                         // If they aren't present, it typically means their data isn't loaded yet so it's fine to just no-op
                     } else {
-                        commandSender.sendMessage(miniMessage.deserialize("<red>Non-players are not allowed to run this command."));
+                        commandSender.sendMessage(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.NON_PLAYER_COMMAND_ERROR));
                     }
                 }));
     }

--- a/src/main/java/us/eunoians/mcrpg/command/redeem/RedeemLevelsCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/redeem/RedeemLevelsCommand.java
@@ -4,7 +4,6 @@ import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.registry.manager.ManagerKey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.Command;
@@ -40,14 +39,15 @@ public class RedeemLevelsCommand extends McRPGCommandBase {
     public static void registerCommand() {
         CommandManager<CommandSourceStack> commandManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
                 .manager(ManagerKey.COMMAND).getCommandManager();
-        MiniMessage miniMessage = McRPG.getInstance().getMiniMessage();
+        McRPGLocalizationManager localizationManager = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.LOCALIZATION);
 
         Command.Builder<CommandSourceStack> redeemBuilder = commandManager.commandBuilder("mcrpg")
-                .literal("redeem").commandDescription(RichDescription.richDescription(miniMessage.deserialize("<gray>The subcommand that allows players to redeem things.")))
+                .literal("redeem").commandDescription(RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_REDEEM)))
                 .literal("levels", "lv", "lvs", "level")
-                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>The skill to redeem experience in")));
+                .required("skill", SkillParser.skillParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_REDEEM_SKILL)));
         commandManager.command(redeemBuilder
-                .required("amount", IntegerParser.integerParser(), RichDescription.richDescription(miniMessage.deserialize("<gray>How many levels to redeem?")))
+                .required("amount", IntegerParser.integerParser(), RichDescription.richDescription(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.COMMAND_DESCRIPTION_REDEEM_LEVELS_AMOUNT)))
                 .handler(commandContext -> {
                             CommandSender commandSender = commandContext.sender().getSender();
                             CloudKey<Skill> skillKey = CloudKey.of("skill", Skill.class);
@@ -61,7 +61,7 @@ public class RedeemLevelsCommand extends McRPGCommandBase {
                                 // If they aren't present, it typically means their data isn't loaded yet so it's fine to just no-op
                             } else {
                                 // Otherwise it's console which isn't supported
-                                commandSender.sendMessage(miniMessage.deserialize("<red>Non-players are not allowed to run this command."));
+                                commandSender.sendMessage(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.NON_PLAYER_COMMAND_ERROR));
                             }
                         }
                 ));
@@ -79,7 +79,7 @@ public class RedeemLevelsCommand extends McRPGCommandBase {
                         playerOptional.ifPresent(mcRPGPlayer -> redeemLevels(mcRPGPlayer, skill, mcRPGPlayer.getExperienceExtras().getRedeemableLevels()));
                         // If they aren't present, it typically means their data isn't loaded yet so it's fine to just no-op
                     } else {
-                        commandSender.sendMessage(miniMessage.deserialize("<red>Non-players are not allowed to run this command."));
+                        commandSender.sendMessage(localizationManager.getLocalizedMessageAsComponent(LocalizationKey.NON_PLAYER_COMMAND_ERROR));
                     }
                 }));
     }

--- a/src/main/java/us/eunoians/mcrpg/configuration/file/localization/LocalizationKey.java
+++ b/src/main/java/us/eunoians/mcrpg/configuration/file/localization/LocalizationKey.java
@@ -16,6 +16,36 @@ public final class LocalizationKey extends ConfigFile {
 
     private static final String COMMAND_HEADER = "commands";
     public static final Route CONSOLE_NAME = Route.fromString(toRoutePath(COMMAND_HEADER, "console-name"));
+    public static final Route NON_PLAYER_COMMAND_ERROR = Route.fromString(toRoutePath(COMMAND_HEADER, "non-player-error"));
+
+    // Command descriptions for help text
+    private static final String COMMAND_DESCRIPTIONS_HEADER = toRoutePath(COMMAND_HEADER, "descriptions");
+    public static final Route COMMAND_DESCRIPTION_REDEEM = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "redeem"));
+    public static final Route COMMAND_DESCRIPTION_REDEEM_SKILL = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "redeem-skill"));
+    public static final Route COMMAND_DESCRIPTION_REDEEM_EXPERIENCE_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "redeem-experience-amount"));
+    public static final Route COMMAND_DESCRIPTION_REDEEM_LEVELS_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "redeem-levels-amount"));
+    public static final Route COMMAND_DESCRIPTION_GIVE = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give"));
+    public static final Route COMMAND_DESCRIPTION_GIVE_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give-player"));
+    public static final Route COMMAND_DESCRIPTION_GIVE_EXPERIENCE_SKILL = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give-experience-skill"));
+    public static final Route COMMAND_DESCRIPTION_GIVE_EXPERIENCE_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give-experience-amount"));
+    public static final Route COMMAND_DESCRIPTION_GIVE_LEVELS_SKILL = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give-levels-skill"));
+    public static final Route COMMAND_DESCRIPTION_GIVE_LEVELS_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give-levels-amount"));
+    public static final Route COMMAND_DESCRIPTION_GIVE_LEVELS_RESET_EXPERIENCE_FLAG = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "give-levels-reset-experience-flag"));
+    public static final Route COMMAND_DESCRIPTION_RESET = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "reset"));
+    public static final Route COMMAND_DESCRIPTION_RESET_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "reset-player"));
+    public static final Route COMMAND_DESCRIPTION_RESET_SKILL = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "reset-skill"));
+    public static final Route COMMAND_DESCRIPTION_LOADOUT_SLOT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "loadout-slot"));
+    public static final Route COMMAND_DESCRIPTION_LOADOUT_EDIT_SLOT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "loadout-edit-slot"));
+    public static final Route COMMAND_DESCRIPTION_DEBUG_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "debug-player"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-player"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-amount"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_RESTED_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-rested-amount"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_BOOSTED_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-boosted-amount"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_REDEEMABLE_EXPERIENCE_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-redeemable-experience-amount"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_REDEEMABLE_LEVELS_AMOUNT = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-redeemable-levels-amount"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_RESET_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-reset-player"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_GIVE_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-give-player"));
+    public static final Route COMMAND_DESCRIPTION_EXP_BANK_REMOVE_PLAYER = Route.fromString(toRoutePath(COMMAND_DESCRIPTIONS_HEADER, "exp-bank-remove-player"));
 
     private static final String CONFIRMATION_COMMAND_HEADER = toRoutePath(COMMAND_HEADER, "confirmation");
     public static final Route NO_PENDING_CONFIRMATION_COMMANDS = Route.fromString(toRoutePath(CONFIRMATION_COMMAND_HEADER, "no-pending-confirmations"));
@@ -49,6 +79,11 @@ public final class LocalizationKey extends ConfigFile {
     private static final String ADMIN_COMMAND_HEADER = toRoutePath(COMMAND_HEADER, "admin");
     private static final String RELOAD_COMMAND_HEADER = toRoutePath(ADMIN_COMMAND_HEADER, "reload");
     public static final Route RELOAD_COMMAND_SENDER_SUCCESS_MESSAGE = Route.fromString(toRoutePath(RELOAD_COMMAND_HEADER, "sender-success-message"));
+
+    private static final String DEBUG_COMMAND_HEADER = toRoutePath(ADMIN_COMMAND_HEADER, "debug");
+    public static final Route DEBUG_COMMAND_HEADER_MESSAGE = Route.fromString(toRoutePath(DEBUG_COMMAND_HEADER, "header-message"));
+    public static final Route DEBUG_COMMAND_UPGRADE_POINTS_MESSAGE = Route.fromString(toRoutePath(DEBUG_COMMAND_HEADER, "upgrade-points-message"));
+    public static final Route DEBUG_COMMAND_SKILL_INFO_MESSAGE = Route.fromString(toRoutePath(DEBUG_COMMAND_HEADER, "skill-info-message"));
 
     private static final String RESET_COMMAND_HEADER = toRoutePath(ADMIN_COMMAND_HEADER, "reset");
     private static final String RESET_PLAYER_COMMAND_HEADER = toRoutePath(RESET_COMMAND_HEADER, "player");

--- a/src/main/resources/localization/en.yml
+++ b/src/main/resources/localization/en.yml
@@ -16,6 +16,36 @@ config-version: 1
 commands:
   # The name of console to use if the sender of a command is ever console and the <sender> placeholder is used
   console-name: "console"
+  # The message to send when a non-player tries to use a player-only command
+  non-player-error: "<red>Non-players are not allowed to run this command."
+  # Configure command descriptions shown in help text
+  descriptions:
+    redeem: "<gray>The subcommand that allows players to redeem things."
+    redeem-skill: "<gray>The skill to redeem experience in."
+    redeem-experience-amount: "<gray>How much experience to redeem?"
+    redeem-levels-amount: "<gray>How many levels to redeem?"
+    give: "<gray>The subcommand for all commands that give targets something."
+    give-player: "<gray>The player to give something to."
+    give-experience-skill: "<gray>The skill to give experience for."
+    give-experience-amount: "<gray>The amount of experience to give."
+    give-levels-skill: "<gray>The skill to give levels for."
+    give-levels-amount: "<gray>The amount of levels to give."
+    give-levels-reset-experience-flag: "<gray>If the player's current experience should be reset to 0 after levels are given."
+    reset: "<gray>The subcommand for all commands that resets a target."
+    reset-player: "<gray>The player to reset something for."
+    reset-skill: "<gray>The skill to reset."
+    loadout-slot: "<gray>The loadout to set."
+    loadout-edit-slot: "<gray>The loadout to edit."
+    debug-player: "<gray>The player to debug."
+    exp-bank-player: "<gray>The player to modify."
+    exp-bank-amount: "<gray>The amount to modify."
+    exp-bank-rested-amount: "<gray>The amount of rested experience."
+    exp-bank-boosted-amount: "<gray>The amount of boosted experience."
+    exp-bank-redeemable-experience-amount: "<gray>The amount of redeemable experience."
+    exp-bank-redeemable-levels-amount: "<gray>The amount of redeemable levels."
+    exp-bank-reset-player: "<gray>The player to reset."
+    exp-bank-give-player: "<gray>The player to give something to."
+    exp-bank-remove-player: "<gray>The player to remove something from."
   # Configure messages to surrounding /mcrpg confirm
   # This command will be used to confirm important commands such as resetting a player
   confirmation:
@@ -83,6 +113,15 @@ commands:
     reload:
       # The message to send to the sender when the command works.
       sender-success-message: "<gray>You have reloaded all McRPG files."
+    # Configure the debug command
+    # Supports the following placeholders: <target>, <upgrade-points>, <skill>, <level>, <experience>
+    debug:
+      # The header message printed at the start of debug output.
+      header-message: "<gray>Printing debug information for player <gold><target>"
+      # The message showing upgrade points.
+      upgrade-points-message: "<gray>Upgrade Points: <gold><upgrade-points>"
+      # The message showing skill information.
+      skill-info-message: "<gray>Skill: <gold><skill> <gray>Level: <gold><level> <gray>Exp: <gold><experience>"
     # Configure the reset commands
     reset:
       # Supports the following placeholders: <target>, <sender>


### PR DESCRIPTION
- Removed MiniMessage usage in various command classes and replaced it with McRPGLocalizationManager for better localization support.
- Added new localization keys for command descriptions in LocalizationKey.java and updated the corresponding English localization file (en.yml).
- Updated commands such as RedeemExperienceCommand, RedeemLevelsCommand, GiveExperienceCommand, GiveLevelsCommand, ResetPlayerCommand, and others to utilize the new localization keys for improved maintainability and clarity.

Current consensus is that we're not gonna maintain `RichDescription` so for now their descriptions are just for show.
We WILL however, be reusing them once we making our own `/mcrpg help` command

No other left hard coded messages.

Affects issue #157 