### PR TITLE
Implement dynamic skill level calculation.

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/command/admin/ReloadPluginCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/admin/ReloadPluginCommand.java
@@ -29,6 +29,11 @@ public class ReloadPluginCommand extends McRPGCommandBase {
                 .handler(commandContext -> {
                             Audience senderAudience = commandContext.sender().getSender();
                             McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE).reloadFiles();
+
+                            // Invalidate level caches for all online players since leveling equations may have changed
+                            McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.PLAYER).getAllPlayers()
+                                    .forEach(player -> player.asSkillHolder().invalidateAllLevelCaches());
+
                             senderAudience.sendMessage(McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION)
                                     .getLocalizedMessageAsComponent(LocalizationKey.RELOAD_COMMAND_SENDER_SUCCESS_MESSAGE));
                         }

--- a/src/main/java/us/eunoians/mcrpg/database/table/SkillDAO.java
+++ b/src/main/java/us/eunoians/mcrpg/database/table/SkillDAO.java
@@ -60,8 +60,7 @@ public class SkillDAO {
              *
              * player_uuid is the {@link java.util.UUID} of the player being stored
              * skill_id is the id of the {@link us.eunoians.mcrpg.types.Skills} that is being stored
-             * current_level is the current level of the player's skill that is being stored
-             * current_exp is the current amount of exp the player's skill that is being stored has
+             * total_experience is the total experience ever earned for the skill (level is calculated dynamically from this)
              **
              ** Reasoning for structure:
              ** The composite key is the `player_uuid` field and the `skill_id` field, as there should only be one unique combination of the two per player and skill
@@ -70,8 +69,7 @@ public class SkillDAO {
                     "(" +
                     "`player_uuid` varchar(36) NOT NULL," +
                     "`skill_id` varchar(32) NOT NULL," +
-                    "`current_level` int(11) NOT NULL DEFAULT 1," +
-                    "`current_exp` int(11) NOT NULL DEFAULT 0," +
+                    "`total_experience` int(11) NOT NULL DEFAULT 0," +
                     "PRIMARY KEY (`player_uuid`, `skill_id`)" +
                     ");")) {
                 statement.executeUpdate();
@@ -170,7 +168,7 @@ public class SkillDAO {
      * @param connection The {@link Connection} to use to run the query
      * @param uuid       The {@link UUID} of the player to get the data for
      * @param skillKey   The {@link NamespacedKey} to get the skill leveling data for
-     * @return A {@link SkillDataSnapshot} updated with the exp and level of the desired skill.
+     * @return A {@link SkillDataSnapshot} updated with the total experience of the desired skill.
      */
     @NotNull
     public static SkillDataSnapshot getPlayerSkillLevelingData(@NotNull Connection connection, @NotNull UUID uuid, @NotNull NamespacedKey skillKey) {
@@ -179,27 +177,24 @@ public class SkillDAO {
 
     /**
      * Gets the player leveling information for a specific player's skill. This method accepts a {@link SkillDataSnapshot} which will be updated utilizing
-     * {@link SkillDataSnapshot#setCurrentExp(int)} and {@link SkillDataSnapshot#setCurrentLevel(int)}.
+     * {@link SkillDataSnapshot#setTotalExperience(int)}.
      * <p>
-     * The skill that will have data obtained for it will be obtained from {@link SkillDataSnapshot#getSkillKey()} ()}.
+     * The skill that will have data obtained for it will be obtained from {@link SkillDataSnapshot#getSkillKey()}.
      *
      * @param connection        The {@link Connection} to use to run the query
      * @param uuid              The {@link UUID} of the player to get the data for
      * @param skillDataSnapshot The {@link SkillDataSnapshot} to update
-     * @return A {@link SkillDataSnapshot}, updated with the exp and level of the desired skill.
+     * @return A {@link SkillDataSnapshot}, updated with the total experience of the desired skill.
      */
     @NotNull
     public static SkillDataSnapshot getPlayerSkillLevelingData(@NotNull Connection connection, @NotNull UUID uuid, @NotNull SkillDataSnapshot skillDataSnapshot) {
-        try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT current_level, current_exp FROM " + SKILL_DATA_TABLE_NAME + " WHERE player_uuid = ? AND skill_id = ?;")) {
+        try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT total_experience FROM " + SKILL_DATA_TABLE_NAME + " WHERE player_uuid = ? AND skill_id = ?;")) {
             preparedStatement.setString(1, uuid.toString());
             preparedStatement.setString(2, skillDataSnapshot.getSkillKey().getKey().toLowerCase(Locale.ROOT));
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 while (resultSet.next()) {
-                    int currentExp = resultSet.getInt("current_exp");
-                    int currentLevel = resultSet.getInt("current_level");
-
-                    skillDataSnapshot.setCurrentExp(currentExp);
-                    skillDataSnapshot.setCurrentLevel(currentLevel);
+                    int totalExperience = resultSet.getInt("total_experience");
+                    skillDataSnapshot.setTotalExperience(totalExperience);
                 }
             }
         } catch (SQLException e) {
@@ -357,7 +352,7 @@ public class SkillDAO {
     }
 
     /**
-     * Saves {@link Skill} specific information such as exp for the provided {@link SkillHolder} for all skills.
+     * Saves {@link Skill} specific information such as total experience for the provided {@link SkillHolder} for all skills.
      *
      * @param connection  The {@link Connection} to use to save the skill information
      * @param skillHolder The {@link SkillHolder} whose skill information is being saved
@@ -373,7 +368,7 @@ public class SkillDAO {
     }
 
     /**
-     * Saves skill specific information such as exp for the provided {@link SkillHolder} for the {@link Skill} associated with the provided {@link NamespacedKey}.
+     * Saves skill specific information such as total experience for the provided {@link SkillHolder} for the {@link Skill} associated with the provided {@link NamespacedKey}.
      *
      * @param connection  The {@link Connection} to use to save the skill information
      * @param skillHolder The {@link SkillHolder} whose skill information is being saved
@@ -384,21 +379,20 @@ public class SkillDAO {
     public static List<PreparedStatement> savePlayerSkillData(@NotNull Connection connection, @NotNull SkillHolder skillHolder, @NotNull NamespacedKey skillKey) {
         List<PreparedStatement> preparedStatements = new ArrayList<>();
         try {
-            PreparedStatement skillDataStatement = connection.prepareStatement("REPLACE INTO " + SKILL_DATA_TABLE_NAME + " (player_uuid, skill_id, current_level, current_exp) VALUES (?, ?, ?, ?);");
+            PreparedStatement skillDataStatement = connection.prepareStatement("REPLACE INTO " + SKILL_DATA_TABLE_NAME + " (player_uuid, skill_id, total_experience) VALUES (?, ?, ?);");
             skillDataStatement.setString(1, skillHolder.getUUID().toString());
             PreparedStatement deleteStatement = connection.prepareStatement("DELETE FROM " + SKILL_DATA_TABLE_NAME + " WHERE player_uuid = ? AND skill_id = ?");
             deleteStatement.setString(1, skillHolder.getUUID().toString());
             Optional<SkillHolder.SkillHolderData> skillHolderDataOptional = skillHolder.getSkillHolderData(skillKey);
             if (skillHolderDataOptional.isPresent()) {
                 SkillHolder.SkillHolderData skillHolderData = skillHolderDataOptional.get();
-                // If there isnt anything to store in the db... clean it
-                if (skillHolderData.getCurrentExperience() == 0 && skillHolderData.getCurrentLevel() == 0) {
+                // If there isn't anything to store in the db... clean it
+                if (skillHolderData.getTotalExperience() == 0) {
                     deleteStatement.setString(2, skillKey.value());
                     preparedStatements.add(deleteStatement);
                 } else {
                     skillDataStatement.setString(2, skillKey.value());
-                    skillDataStatement.setInt(3, skillHolderData.getCurrentLevel());
-                    skillDataStatement.setInt(4, skillHolderData.getCurrentExperience());
+                    skillDataStatement.setInt(3, skillHolderData.getTotalExperience());
                     preparedStatements.add(skillDataStatement);
                 }
             }
@@ -407,96 +401,4 @@ public class SkillDAO {
         }
         return preparedStatements;
     }
-
-//    /**
-//     * Gets the player leaderboard rankings for the provided {@link Skills} skill type.
-//     *
-//     * @param connection The {@link Connection} to use to get the player leaderboard rankings
-//     * @param skillType  The {@link Skills} skill type to use to get the player leaderboard rankings for
-//     * @return A {@link CompletableFuture} completed with a {@link LeaderboardData} which stores all of the player rankings for the given {@link Skills} skill type or will
-//     * be completed exceptionally with an {@link SQLException} if an error occurs.
-//     */
-//    @NotNull
-//    public static CompletableFuture<LeaderboardData> getPlayerLeaderboardRankings(@NotNull Connection connection, @NotNull Skills skillType) {
-//
-//        McRPGDatabaseManager databaseManager = McRPG.getInstance().getDatabaseManager();
-//        CompletableFuture<LeaderboardData> completableFuture = new CompletableFuture<>();
-//
-//        databaseManager.getDatabaseExecutorService().submit(() -> {
-//
-//            List<PlayerLeaderboardData> playerLeaderboardData = new ArrayList<>();
-//            Map<UUID, Integer> playerRankings = new HashMap<>();
-//
-//            try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT player_uuid, current_level FROM " + SKILL_DATA_TABLE_NAME + " WHERE skill_id = ? ORDER BY current_level DESC;")) {
-//
-//                preparedStatement.setString(1, skillType.getName().toLowerCase());
-//
-//                try (ResultSet resultSet = preparedStatement.executeQuery()) {
-//
-//                    while (resultSet.next()) {
-//
-//                        UUID uuid = UUID.fromString(resultSet.getString("player_uuid"));
-//                        int level = resultSet.getInt("current_level");
-//
-//                        playerLeaderboardData.add(new PlayerLeaderboardData(uuid, level));
-//                        playerRankings.put(uuid, playerLeaderboardData.size() + 1);
-//                    }
-//                }
-//
-//            }
-//            catch (SQLException e) {
-//                completableFuture.completeExceptionally(e);
-//                return;
-//            }
-//
-//            completableFuture.complete(new LeaderboardData(playerLeaderboardData, playerRankings));
-//        });
-//
-//        return completableFuture;
-//    }
-
-//    /**
-//     * Gets the player leaderboard power level rankings.
-//     *
-//     * @param connection The {@link Connection} to use to get the player leaderboard rankings
-//     * @return A {@link CompletableFuture} completed with a {@link LeaderboardData} which stores all of the player power level rankings or will
-//     * be completed exceptionally with an {@link SQLException} if an error occurs.
-//     */
-//    @NotNull
-//    public static CompletableFuture<LeaderboardData> getPlayerPowerLeaderboardRankings(@NotNull Connection connection) {
-//
-//        McRPGDatabaseManager databaseManager = McRPG.getInstance().getDatabaseManager();
-//        CompletableFuture<LeaderboardData> completableFuture = new CompletableFuture<>();
-//
-//        databaseManager.getDatabaseExecutorService().submit(() -> {
-//
-//            List<PlayerLeaderboardData> playerLeaderboardData = new ArrayList<>();
-//            Map<UUID, Integer> playerRankings = new HashMap<>();
-//
-//            try (PreparedStatement preparedStatement = connection.prepareStatement("SELECT player_uuid, SUM(current_level) AS total_level_sum FROM " + SKILL_DATA_TABLE_NAME + " GROUP BY player_uuid ORDER BY total_level_sum DESC;")) {
-//
-//                try (ResultSet resultSet = preparedStatement.executeQuery()) {
-//
-//                    while (resultSet.next()) {
-//
-//                        UUID uuid = UUID.fromString(resultSet.getString("player_uuid"));
-//                        int powerLevel = resultSet.getInt("total_level_sum");
-//
-//                        playerLeaderboardData.add(new PlayerLeaderboardData(uuid, powerLevel));
-//                        playerRankings.put(uuid, playerLeaderboardData.size() + 1);
-//                    }
-//                }
-//
-//            }
-//            catch (SQLException e) {
-//                completableFuture.completeExceptionally(e);
-//                return;
-//            }
-//
-//            completableFuture.complete(new LeaderboardData(playerLeaderboardData, playerRankings));
-//
-//        });
-//
-//        return completableFuture;
-//    }
 }

--- a/src/main/java/us/eunoians/mcrpg/database/table/SkillDataSnapshot.java
+++ b/src/main/java/us/eunoians/mcrpg/database/table/SkillDataSnapshot.java
@@ -25,13 +25,11 @@ public class SkillDataSnapshot {
 
     private final UUID uuid;
     private final NamespacedKey skillKey;
-    private int currentExp;
-    private int currentLevel;
+    private int totalExperience;
     private final Map<NamespacedKey, Map<NamespacedKey, AbilityAttribute<?>>> abilityAttributes;
 
     /**
-     * Constructs a new {@link SkillDataSnapshot} with the values for {@link #getCurrentExp()} and {@link #getCurrentLevel()}
-     * both being 0.
+     * Constructs a new {@link SkillDataSnapshot} with the value for {@link #getTotalExperience()} being 0.
      *
      * @param uuid     The {@link UUID} of the player this snapshot is for
      * @param skillKey The {@link NamespacedKey} which represents the {@link us.eunoians.mcrpg.skill.Skill} this snapshot has data for
@@ -39,22 +37,19 @@ public class SkillDataSnapshot {
     public SkillDataSnapshot(@NotNull UUID uuid, @NotNull NamespacedKey skillKey) {
         this.uuid = uuid;
         this.skillKey = skillKey;
-        this.currentExp = 0;
-        this.currentLevel = 0;
+        this.totalExperience = 0;
         this.abilityAttributes = new HashMap<>();
     }
 
     /**
-     * @param uuid         The {@link UUID} of the player this snapshot is for
-     * @param skillKey    The {@link NamespacedKey} which represents the {@link us.eunoians.mcrpg.skill.Skill} this snapshot has data for
-     * @param currentExp   The amount of exp the skill currently has
-     * @param currentLevel The current level of the skill
+     * @param uuid            The {@link UUID} of the player this snapshot is for
+     * @param skillKey        The {@link NamespacedKey} which represents the {@link us.eunoians.mcrpg.skill.Skill} this snapshot has data for
+     * @param totalExperience The total experience ever earned for this skill
      */
-    public SkillDataSnapshot(@NotNull UUID uuid, @NotNull NamespacedKey skillKey, int currentExp, int currentLevel) {
+    public SkillDataSnapshot(@NotNull UUID uuid, @NotNull NamespacedKey skillKey, int totalExperience) {
         this.uuid = uuid;
         this.skillKey = skillKey;
-        this.currentExp = currentExp;
-        this.currentLevel = currentLevel;
+        this.totalExperience = totalExperience;
         this.abilityAttributes = new HashMap<>();
     }
 
@@ -81,41 +76,21 @@ public class SkillDataSnapshot {
     }
 
     /**
-     * Gets the amount of exp that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has according to this snapshot
+     * Gets the total experience ever earned for the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot.
      *
-     * @return The positive, zero inclusive amount of exp that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has
+     * @return The positive, zero inclusive total experience for the skill.
      */
-    public int getCurrentExp() {
-        return currentExp;
+    public int getTotalExperience() {
+        return totalExperience;
     }
 
     /**
-     * Sets the amount of exp that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has inside this
-     * snapshot.
+     * Sets the total experience for the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot.
      *
-     * @param currentExp The amount of exp that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has. Should be a positive, zero inclusive value
+     * @param totalExperience The total experience. Should be a positive, zero inclusive value.
      */
-    public void setCurrentExp(int currentExp) {
-        this.currentExp = Math.max(0, currentExp);
-    }
-
-    /**
-     * Gets the amount of levels that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has according to this snapshot
-     *
-     * @return The positive, zero inclusive amount of levels that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has
-     */
-    public int getCurrentLevel() {
-        return currentLevel;
-    }
-
-    /**
-     * Sets the amount of levels that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has inside this
-     * snapshot.
-     *
-     * @param currentLevel The amount of levels that the {@link us.eunoians.mcrpg.skill.Skill} represented by this snapshot has. Should be a positive, zero inclusive value
-     */
-    public void setCurrentLevel(int currentLevel) {
-        this.currentLevel = Math.max(0, currentLevel);
+    public void setTotalExperience(int totalExperience) {
+        this.totalExperience = Math.max(0, totalExperience);
     }
 
     /**

--- a/src/main/java/us/eunoians/mcrpg/entity/holder/SkillHolder.java
+++ b/src/main/java/us/eunoians/mcrpg/entity/holder/SkillHolder.java
@@ -46,36 +46,35 @@ public class SkillHolder extends LoadoutHolder {
     }
 
     /**
-     * Creates and stores a {@link SkillHolderData} with a default level and experience of 0 for the provided
-     * {@link Skill}.
+     * Creates and stores a {@link SkillHolderData} with 0 total experience for the provided {@link Skill}.
      *
      * @param skill The {@link Skill} to create and store data for.
      */
     public void addSkillHolderData(@NotNull Skill skill) {
-        addSkillHolderData(skill, 1, 0);
+        addSkillHolderData(skill, 0);
     }
 
     /**
-     * Creates and stores a {@link SkillHolderData} with a default experience of 0 and the provided level for the provided
-     * {@link Skill}.
+     * Creates and stores a {@link SkillHolderData} with the provided total experience for the provided {@link Skill}.
      *
-     * @param skill        The {@link Skill} to create and store data for.
-     * @param currentLevel The skill level to store in the data.
+     * @param skill           The {@link Skill} to create and store data for.
+     * @param totalExperience The total experience to store in the data.
      */
-    public void addSkillHolderData(@NotNull Skill skill, int currentLevel) {
-        addSkillHolderData(skill, currentLevel, 0);
+    public void addSkillHolderData(@NotNull Skill skill, int totalExperience) {
+        addSkillHolderData(new SkillHolderData(this, skill, totalExperience));
     }
 
     /**
-     * Creates and stores a {@link SkillHolderData} with experience and levels matching those provided for the provided
-     * {@link Skill}.
+     * Creates and stores a {@link SkillHolderData} at the specified level for the provided {@link Skill}.
+     * This is primarily useful for testing scenarios where a player needs to be at a specific level.
      *
-     * @param skill             The {@link Skill} to create and store data for.
-     * @param currentLevel      The skill level to store in the data.
-     * @param currentExperience The skill experience to store in the data.
+     * @param skill The {@link Skill} to create and store data for.
+     * @param level The level to set the skill to.
      */
-    public void addSkillHolderData(@NotNull Skill skill, int currentLevel, int currentExperience) {
-        addSkillHolderData(new SkillHolderData(this, skill, currentLevel, currentExperience));
+    public void addSkillHolderDataAtLevel(@NotNull Skill skill, int level) {
+        SkillHolderData data = new SkillHolderData(this, skill, 0);
+        data.setToLevel(level);
+        addSkillHolderData(data);
     }
 
     /**
@@ -129,33 +128,109 @@ public class SkillHolder extends LoadoutHolder {
         return skillData.containsKey(skillKey);
     }
 
+    /**
+     * Invalidates the level cache for all skills held by this holder.
+     * This should be called when skill leveling equations change (e.g., on plugin reload).
+     */
+    public void invalidateAllLevelCaches() {
+        for (SkillHolderData data : skillData.values()) {
+            data.invalidateLevelCache();
+        }
+    }
+
+    /**
+     * Holds skill-specific data for a {@link SkillHolder}.
+     * <p>
+     * Level is calculated dynamically from total experience using the skill's leveling equation.
+     * This allows server owners to change leveling equations and have player levels update automatically.
+     */
     public static class SkillHolderData {
 
         private final SkillHolder skillHolder;
         private final Skill skill;
-        private int currentExperience;
-        private int experienceForNextLevel;
-        private int currentLevel;
 
-        public SkillHolderData(@NotNull SkillHolder skillHolder, @NotNull Skill skill, int currentLevel) {
-            this(skillHolder, skill, Math.max(0, currentLevel), 0);
-        }
+        // Total experience ever earned - the source of truth
+        private int totalExperience;
 
-        public SkillHolderData(@NotNull SkillHolder skillHolder, @NotNull Skill skill, int currentLevel, int currentExperience) {
+        // Cached values - calculated from totalExperience
+        private int cachedLevel;
+        private int cachedExperienceTowardsNextLevel;
+        private int cachedExperienceForNextLevel;
+        private boolean levelCacheValid;
+
+        /**
+         * Creates a new {@link SkillHolderData} with the provided total experience.
+         *
+         * @param skillHolder     The {@link SkillHolder} that owns this data.
+         * @param skill           The {@link Skill} this data is for.
+         * @param totalExperience The total experience ever earned for this skill.
+         */
+        public SkillHolderData(@NotNull SkillHolder skillHolder, @NotNull Skill skill, int totalExperience) {
             this.skillHolder = skillHolder;
             this.skill = skill;
-            this.currentLevel = Math.max(0, currentLevel);
-            this.currentExperience = Math.max(0, currentExperience);
-            updateExperienceForNextLevel();
+            this.totalExperience = Math.max(0, totalExperience);
+            this.levelCacheValid = false;
+            recalculateLevelCache();
         }
 
         /**
-         * Calculates and updates the amount of experience required for the next level up.
+         * Recalculates the cached level and experience values from total experience.
+         * This is called when experience changes or when the cache is invalidated.
          */
-        public void updateExperienceForNextLevel() {
+        private void recalculateLevelCache() {
+            LevelCalculationResult result = calculateLevelFromTotalExperience();
+            this.cachedLevel = result.level();
+            this.cachedExperienceTowardsNextLevel = result.experienceTowardsNextLevel();
+
+            // Calculate experience needed for next level
             Parser levelParser = skill.getLevelUpEquation();
-            levelParser.setVariable("skill_level", currentLevel);
-            this.experienceForNextLevel = (int) levelParser.getValue();
+            levelParser.setVariable("skill_level", cachedLevel);
+            this.cachedExperienceForNextLevel = (int) levelParser.getValue();
+
+            this.levelCacheValid = true;
+        }
+
+        /**
+         * Calculates the level from total experience using the skill's leveling equation.
+         *
+         * @return A {@link LevelCalculationResult} containing the calculated level and remaining experience
+         */
+        @NotNull
+        private LevelCalculationResult calculateLevelFromTotalExperience() {
+            int remainingExp = this.totalExperience;
+            int level = 0;
+            int maxLevel = skill.getMaxLevel();
+            Parser parser = skill.getLevelUpEquation();
+
+            while (level < maxLevel) {
+                parser.setVariable("skill_level", level);
+                int expForThisLevel = (int) parser.getValue();
+
+                if (remainingExp < expForThisLevel) {
+                    break;
+                }
+                remainingExp -= expForThisLevel;
+                level++;
+            }
+
+            return new LevelCalculationResult(level, remainingExp);
+        }
+
+        /**
+         * Invalidates the level cache, forcing a recalculation on next access.
+         * This should be called when the skill's leveling equation changes (e.g., on plugin reload).
+         */
+        public void invalidateLevelCache() {
+            this.levelCacheValid = false;
+        }
+
+        /**
+         * Ensures the level cache is valid, recalculating if necessary.
+         */
+        private void ensureCacheValid() {
+            if (!levelCacheValid) {
+                recalculateLevelCache();
+            }
         }
 
         /**
@@ -179,12 +254,23 @@ public class SkillHolder extends LoadoutHolder {
         }
 
         /**
-         * Gets the current experience for the {@link Skill} represented by this data.
+         * Gets the total experience ever earned for this skill.
          *
-         * @return The current experience for the {@link Skill} represented by this data.
+         * @return The total experience ever earned for this skill.
+         */
+        public int getTotalExperience() {
+            return totalExperience;
+        }
+
+        /**
+         * Gets the current experience towards the next level for the {@link Skill} represented by this data.
+         * This is the partial progress towards the next level, not the total experience.
+         *
+         * @return The current experience towards the next level.
          */
         public int getCurrentExperience() {
-            return currentExperience;
+            ensureCacheValid();
+            return cachedExperienceTowardsNextLevel;
         }
 
         /**
@@ -193,29 +279,30 @@ public class SkillHolder extends LoadoutHolder {
          * @return The amount of experience required for the next level up.
          */
         public int getExperienceForNextLevel() {
-            return experienceForNextLevel;
+            ensureCacheValid();
+            return cachedExperienceForNextLevel;
         }
 
         /**
-         * Gets the amount of experience the player still has to gain for the next level
-         * up.
+         * Gets the amount of experience the player still has to gain for the next level up.
          *
          * @return The amount of experience required for the next level up.
          */
         public int getRemainingExperienceForNextLevel() {
-            return experienceForNextLevel - currentExperience;
+            ensureCacheValid();
+            return cachedExperienceForNextLevel - cachedExperienceTowardsNextLevel;
         }
 
         /**
          * Gets the current level for the {@link Skill} represented by this data.
+         * The level is dynamically calculated from total experience using the skill's leveling equation.
          *
          * @return The current level for the {@link Skill} represented by this data.
          */
         public int getCurrentLevel() {
-            return currentLevel;
+            ensureCacheValid();
+            return cachedLevel;
         }
-
-        // TODO refactor to SkillHolder?? should the data be responsible for updating itself? probs not lol
 
         /**
          * Adds the provided amount of experience to the {@link Skill}.
@@ -223,171 +310,176 @@ public class SkillHolder extends LoadoutHolder {
          * This method will call a {@link SkillGainExpEvent}, and only award experience if the event is not canceled.
          *
          * @param experience The amount of experience to add.
-         * @return The amount of experience that was unused in leveling up the player.
+         * @return The amount of experience that was unused (when at max level).
          */
         public int addExperience(int experience) {
-            if (currentLevel >= skill.getMaxLevel()) {
+            ensureCacheValid();
+            if (cachedLevel >= skill.getMaxLevel()) {
                 return experience;
             } else if (experience <= 0) {
                 return 0;
             }
+
             SkillGainExpEvent skillGainExpEvent = new SkillGainExpEvent(getSkillHolder(), getSkillKey(), Math.max(0, experience));
             Bukkit.getPluginManager().callEvent(skillGainExpEvent);
             if (skillGainExpEvent.isCancelled()) {
                 return experience;
             }
-            // Calculate levels
+
+            int previousLevel = cachedLevel;
             experience = skillGainExpEvent.getExperience();
-            int expNeeded = experienceForNextLevel - currentExperience;
+
+            // Add to total experience
+            totalExperience += experience;
+
+            // Recalculate level from new total
+            recalculateLevelCache();
+
+            // Calculate leftover experience (experience beyond max level)
             int leftoverExperience = 0;
-            // If we need more experience than we actually have
-            if (experience >= expNeeded) {
-                LevelUpCalculationResult calculationResult = calculateLevelsGainedForExperience(experience);
-                addLevels(calculationResult.amountOfLevelUps());
-                currentExperience = calculationResult.experienceLeftToLevel();
-                leftoverExperience = calculationResult.leftoverExperience();
+            if (cachedLevel >= skill.getMaxLevel()) {
+                // Calculate total XP needed for max level
+                int totalExpForMaxLevel = calculateTotalExperienceForLevel(skill.getMaxLevel());
+                leftoverExperience = Math.max(0, totalExperience - totalExpForMaxLevel);
+                // Cap total experience at max level
+                totalExperience = totalExpForMaxLevel;
+                recalculateLevelCache();
             }
-            else {
-                currentExperience += skillGainExpEvent.getExperience();
+
+            // Fire level up event if level changed
+            int levelsGained = cachedLevel - previousLevel;
+            if (levelsGained > 0) {
+                SkillGainLevelEvent skillGainLevelEvent = new SkillGainLevelEvent(getSkillHolder(), getSkillKey(), levelsGained);
+                Bukkit.getPluginManager().callEvent(skillGainLevelEvent);
+                Bukkit.getPluginManager().callEvent(new PostSkillGainLevelEvent(skillHolder, getSkillKey(), previousLevel, cachedLevel));
             }
+
             Bukkit.getPluginManager().callEvent(new PostSkillGainExpEvent(skillHolder, getSkillKey()));
             return leftoverExperience;
         }
 
         /**
-         * Directly sets the amount of experience for the {@link Skill}. This method will NOT call a
-         * {@link SkillGainExpEvent}, but will still call {@link #checkForLevelups()}.
+         * Directly sets the total experience for the {@link Skill}. This method will NOT call a
+         * {@link SkillGainExpEvent}.
          *
-         * @param experience The amount of experience to set.
+         * @param experience The total experience to set.
          */
-        public void setCurrentExperience(int experience) {
-            currentExperience = Math.max(0, experience);
-            checkForLevelups();
+        public void setTotalExperience(int experience) {
+            int previousLevel = getCurrentLevel();
+            totalExperience = Math.max(0, experience);
+            recalculateLevelCache();
+
+            int levelsGained = cachedLevel - previousLevel;
+            if (levelsGained > 0) {
+                Bukkit.getPluginManager().callEvent(new PostSkillGainLevelEvent(skillHolder, getSkillKey(), previousLevel, cachedLevel));
+            }
             Bukkit.getPluginManager().callEvent(new PostSkillGainExpEvent(skillHolder, getSkillKey()));
         }
 
         /**
-         * Adds the provided amount of levels to the skill.
+         * Adds the provided amount of levels to the skill by adding the equivalent experience.
          * <p>
          * This method will not add levels past the max level for a given skill.
          *
          * @param levels The amount of levels to add.
+         * @return The amount of levels that were actually added.
          */
         public int addLevels(int levels) {
             return addLevels(levels, false);
         }
 
         /**
-         * Adds the provided amount of levels to the skill. This method can also reset the current experience for a skill
-         * after a level up. This prevents any roll over of experience for whatever reason.
+         * Adds the provided amount of levels to the skill by adding the equivalent experience.
          * <p>
          * This method will not add levels past the max level for a given skill.
-         * <p>
-         * This method will also call a {@link SkillGainLevelEvent} and then also call {@link #checkForLevelups()} as well.
          *
-         * @param levels             The amount of levels to add.
-         * @param resetExpOnLevelUp If the current experience should be reset on level up or not.
-         * @return The amount of levels that were actually added (Amount may differ based on event results/max level)
+         * @param levels            The amount of levels to add.
+         * @param resetExpOnLevelUp If true, sets experience to exactly the start of the new level (no partial progress).
+         * @return The amount of levels that were actually added.
          */
         public int addLevels(int levels, boolean resetExpOnLevelUp) {
             if (levels <= 0) {
                 return 0;
             }
-            int amountOfLevelups = 0;
-            levels = Math.min(levels, skill.getMaxLevel() - getCurrentLevel());
-            SkillGainLevelEvent skillGainLevelEvent = new SkillGainLevelEvent(getSkillHolder(), getSkillKey(), levels);
-            Bukkit.getPluginManager().callEvent(skillGainLevelEvent);
-            levels = Math.min(skillGainLevelEvent.getLevels(), skill.getMaxLevel() - getCurrentLevel());
-            currentLevel += levels;
-            amountOfLevelups += levels;
-            // Update the amount of experience needed for the next level and check if there is enough experience to do a level up
-            updateExperienceForNextLevel();
-            amountOfLevelups += checkForLevelups();
-            // If we are resetting experience, reset it
-            if (resetExpOnLevelUp || currentLevel >= skill.getMaxLevel()) {
-                currentExperience = 0;
+
+            ensureCacheValid();
+            int previousLevel = cachedLevel;
+
+            // Calculate how much experience we need to add to gain these levels
+            int targetLevel = Math.min(cachedLevel + levels, skill.getMaxLevel());
+            int experienceToAdd = calculateTotalExperienceForLevel(targetLevel) - totalExperience;
+
+            if (resetExpOnLevelUp) {
+                // Set to exactly the start of the target level
+                totalExperience = calculateTotalExperienceForLevel(targetLevel);
+            } else {
+                // Add just enough to reach the target level, keeping partial progress
+                totalExperience += Math.max(0, experienceToAdd);
             }
-            if (levels >= 0) {
-                Bukkit.getPluginManager().callEvent(new PostSkillGainLevelEvent(skillHolder, getSkillKey(), getCurrentLevel() - levels, getCurrentLevel()));
+
+            recalculateLevelCache();
+
+            int levelsGained = cachedLevel - previousLevel;
+            if (levelsGained > 0) {
+                SkillGainLevelEvent skillGainLevelEvent = new SkillGainLevelEvent(getSkillHolder(), getSkillKey(), levelsGained);
+                Bukkit.getPluginManager().callEvent(skillGainLevelEvent);
+                Bukkit.getPluginManager().callEvent(new PostSkillGainLevelEvent(skillHolder, getSkillKey(), previousLevel, cachedLevel));
             }
-            return amountOfLevelups;
+
+            return levelsGained;
         }
 
         /**
-         * Resets this skill back to level 0.
+         * Resets this skill back to 0 total experience (level 0).
          */
         public void resetSkill() {
-            currentExperience = 0;
-            currentLevel = 0;
-            updateExperienceForNextLevel();
+            totalExperience = 0;
+            recalculateLevelCache();
         }
 
         /**
-         * Checks to see if there is enough experience to level up. If so, it will continue trying to
-         * level up the skill until there isn't enough experience to level up.
+         * Calculates the total experience needed to reach a specific level.
          *
-         * @return The amount of levels the holder has gone up by
+         * @param targetLevel The level to calculate total experience for.
+         * @return The total experience needed to reach the target level.
          */
-        private int checkForLevelups() {
-            int amountOfLevelups = 0;
-            //do level ups
-            while (currentExperience >= experienceForNextLevel) {
-                currentExperience -= experienceForNextLevel;
-                addLevels(1);
-                amountOfLevelups++;
-                updateExperienceForNextLevel();
+        public int calculateTotalExperienceForLevel(int targetLevel) {
+            int total = 0;
+            Parser parser = skill.getLevelUpEquation();
+            for (int level = 0; level < targetLevel && level < skill.getMaxLevel(); level++) {
+                parser.setVariable("skill_level", level);
+                total += (int) parser.getValue();
             }
-            return amountOfLevelups;
+            return total;
         }
 
-        @NotNull
-        private LevelUpCalculationResult calculateLevelsGainedForExperience(int experience) {
-            int amountOfLevelups = 0;
-            Parser skillParser =  skill.getLevelUpEquation();
-            int remainingExperienceToConsume = experience;
-            skillParser.setVariable("skill_level", currentLevel + amountOfLevelups);
-            int experienceToLevel = (int) skillParser.getValue() - currentExperience;
-            // How much experience is needed to level-up
-            int experienceLeftToLevel = experienceToLevel;
-            while (remainingExperienceToConsume > 0) {
-                // If we reached the max level, then we should break
-                if (currentLevel + amountOfLevelups >= skill.getMaxLevel()) {
-                    break;
-                }
-                // If there's enough experience to give a full level, do so
-                if (remainingExperienceToConsume >= experienceToLevel) {
-                    remainingExperienceToConsume -= experienceToLevel;
-                    // We leveled up so set this to 0
-                    experienceLeftToLevel = 0;
-                    amountOfLevelups++;
-                }
-                // If there isn't enough experience for a full level, do a partial one.
-                else {
-                    experienceLeftToLevel = experienceToLevel - remainingExperienceToConsume;
-                    remainingExperienceToConsume = 0;
-                    break;
-                }
-                skillParser.setVariable("skill_level", currentLevel + amountOfLevelups);
-                experienceToLevel = (int) skillParser.getValue();
-            }
-            return new LevelUpCalculationResult(amountOfLevelups, experienceLeftToLevel, remainingExperienceToConsume);
-        }
-
+        /**
+         * Calculates how much additional experience is needed to gain a specific number of levels from current level.
+         *
+         * @param levels The number of levels to calculate experience for.
+         * @return The experience needed to gain the specified number of levels.
+         */
         public int calculateExperienceNeededToGainLevels(int levels) {
-            int experienceNeededToGainLevels = 0;
-            for (int i = 0; i < levels ; i++) {
-                int level = currentLevel + i;
-                if (level >= skill.getMaxLevel()) {
-                    break;
-                }
-                Parser skillParser =  skill.getLevelUpEquation();
-                skillParser.setVariable("skill_level", currentLevel + i);
-                experienceNeededToGainLevels += (int) skillParser.getValue();
-            }
-            return experienceNeededToGainLevels;
+            ensureCacheValid();
+            int targetLevel = Math.min(cachedLevel + levels, skill.getMaxLevel());
+            return calculateTotalExperienceForLevel(targetLevel) - totalExperience;
         }
-    }
 
-    private record LevelUpCalculationResult(int amountOfLevelUps, int experienceLeftToLevel, int leftoverExperience) {
+        /**
+         * Sets the skill to a specific level by calculating and setting the total experience needed.
+         * This is primarily useful for testing scenarios.
+         *
+         * @param level The level to set the skill to.
+         */
+        public void setToLevel(int level) {
+            totalExperience = calculateTotalExperienceForLevel(Math.min(level, skill.getMaxLevel()));
+            recalculateLevelCache();
+        }
+
+        /**
+         * Record for holding level calculation results.
+         */
+        private record LevelCalculationResult(int level, int experienceTowardsNextLevel) {
+        }
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/task/player/McRPGPlayerLoadTask.java
+++ b/src/main/java/us/eunoians/mcrpg/task/player/McRPGPlayerLoadTask.java
@@ -219,7 +219,7 @@ public final class McRPGPlayerLoadTask extends PlayerLoadTask {
             for (Map.Entry<Skill, SkillDataSnapshot> entry : skillDataSnapshots.entrySet()) {
                 Skill skill = entry.getKey();
                 SkillDataSnapshot skillDataSnapshot = entry.getValue();
-                skillHolder.addSkillHolderData(skill, skillDataSnapshot.getCurrentLevel(), skillDataSnapshot.getCurrentExp());
+                skillHolder.addSkillHolderData(skill, skillDataSnapshot.getTotalExperience());
 
                 for (NamespacedKey abilityKey : abilityRegistry.getAbilitiesBelongingToSkill(skill)) {
                     Ability ability = abilityRegistry.getRegisteredAbility(abilityKey);

--- a/src/main/resources/skill_configuration/herbalism_configuration.yml
+++ b/src/main/resources/skill_configuration/herbalism_configuration.yml
@@ -9,7 +9,7 @@ permissions:
 # Configure leveling requirements for this skill.
 leveling:
   # Configure the equation to calculate the player's experience for the next level
-  level-up-equation: '200+(0.17*(skill_level^1.669))'
+  level-up-equation: '100+(skill_level^1.8)'
   # Configure the maximum level this skill can be
   maximum-skill-level: 1000
 # Configure experience gain for this skill
@@ -18,7 +18,7 @@ experience:
   # on what item the player is holding in their main hand. If an item
   # isn't in this list but is allowed, then the default value of 1.0 is used.
   #
-  # These modifiers can be either material values such as WOODEN_HOE
+  # These modifiers can bew either material values such as WOODEN_HOE
   # or the custom item id for whatever custom item plugin you might be using
   # if you want to allow custom items.
   material-modifiers:

--- a/src/main/resources/skill_configuration/mining_configuration.yml
+++ b/src/main/resources/skill_configuration/mining_configuration.yml
@@ -9,7 +9,7 @@ permissions:
 # Configure leveling requirements for this skill.
 leveling:
   # Configure the equation to calculate the player's experience for the next level
-  level-up-equation: '200+(0.17*(skill_level^1.669))'
+  level-up-equation: '100+(skill_level^1.8)'
   # Configure the maximum level this skill can be
   maximum-skill-level: 1000
 # Configure experience gain for this skill

--- a/src/main/resources/skill_configuration/swords_configuration.yml
+++ b/src/main/resources/skill_configuration/swords_configuration.yml
@@ -9,7 +9,7 @@ permissions:
 # Configure leveling requirements for this skill.
 leveling:
   # Configure the equation to calculate the player's experience for the next level
-  level-up-equation: '200+(0.17*(skill_level^1.669))'
+  level-up-equation: '250+(skill_level^2.0)'
   # Configure the maximum level this skill can be
   maximum-skill-level: 1000
 # Configure experience gain for this skill

--- a/src/main/resources/skill_configuration/woodcutting_configuration.yml
+++ b/src/main/resources/skill_configuration/woodcutting_configuration.yml
@@ -5,7 +5,7 @@ permissions:
   use-permissions-to-unlock-abilities: false
   use-permissions-to-activate-abilities: false
 leveling:
-  level-up-equation: '200+(0.17*(skill_level^1.669))'
+  level-up-equation: '100+(skill_level^1.8)'
   maximum-skill-level: 1000
 experience:
   # Configure what items a player can use to break blocks with in order to gain experience.

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/herbalism/InstantIrrigationTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/herbalism/InstantIrrigationTest.java
@@ -76,6 +76,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
         FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
         when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
         when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+        when(herbalismConfig.getInt(HerbalismConfigFile.MAXIMUM_SKILL_LEVEL)).thenReturn(1000);
 
         mainConfig = mock(YamlDocument.class);
         when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
@@ -111,7 +112,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).trackAbilityHolder(skillHolder);
-        skillHolder.addSkillHolderData(herbalism, 1);
+        skillHolder.addSkillHolderDataAtLevel(herbalism, 1);
         skillHolder.addAvailableAbility(instantIrrigation);
 
         Loadout loadout = new Loadout(mcRPGPlayer.getUUID(), 1, Set.of(instantIrrigation.getAbilityKey()));
@@ -147,7 +148,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).trackAbilityHolder(skillHolder);
-        skillHolder.addSkillHolderData(herbalism, 100);
+        skillHolder.addSkillHolderDataAtLevel(herbalism, 100);
         skillHolder.addAvailableAbility(instantIrrigation);
 
         Loadout loadout = new Loadout(mcRPGPlayer.getUUID(), 1, Set.of(instantIrrigation.getAbilityKey()));
@@ -178,7 +179,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).trackAbilityHolder(skillHolder);
-        skillHolder.addSkillHolderData(herbalism, 1);
+        skillHolder.addSkillHolderDataAtLevel(herbalism, 1);
         skillHolder.addAvailableAbility(instantIrrigation);
 
         Loadout loadout = new Loadout(mcRPGPlayer.getUUID(), 1, Set.of(instantIrrigation.getAbilityKey()));
@@ -210,7 +211,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).trackAbilityHolder(skillHolder);
-        skillHolder.addSkillHolderData(herbalism, 1);
+        skillHolder.addSkillHolderDataAtLevel(herbalism, 1);
         skillHolder.addAvailableAbility(instantIrrigation);
 
         Loadout loadout = new Loadout(mcRPGPlayer.getUUID(), 1, Set.of(instantIrrigation.getAbilityKey()));
@@ -242,7 +243,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).trackAbilityHolder(skillHolder);
-        skillHolder.addSkillHolderData(herbalism, 1);
+        skillHolder.addSkillHolderDataAtLevel(herbalism, 1);
         skillHolder.addAvailableAbility(instantIrrigation);
 
         Loadout loadout = new Loadout(mcRPGPlayer.getUUID(), 1, Set.of(instantIrrigation.getAbilityKey()));
@@ -274,7 +275,7 @@ public class InstantIrrigationTest extends McRPGBaseTest {
 
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).trackAbilityHolder(skillHolder);
-        skillHolder.addSkillHolderData(herbalism, 1);
+        skillHolder.addSkillHolderDataAtLevel(herbalism, 1);
         skillHolder.addAvailableAbility(instantIrrigation);
 
         Loadout loadout = new Loadout(mcRPGPlayer.getUUID(), 1, Set.of(instantIrrigation.getAbilityKey()));

--- a/src/test/java/us/eunoians/mcrpg/command/redeem/RedeemExperienceCommandTest.java
+++ b/src/test/java/us/eunoians/mcrpg/command/redeem/RedeemExperienceCommandTest.java
@@ -46,7 +46,7 @@ public class RedeemExperienceCommandTest extends McRPGBaseTest {
     @Test
     public void redeemExperience_sendsNotEnoughMessage_whenNoRedeemableExperience(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
         SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
         Component message = mcRPG.getMiniMessage().deserialize("You do not have enough redeemable experience");
         when(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.REDEEMABLE_EXPERIENCE_NOT_ENOUGH_EXPERIENCE_MESSAGE)).thenReturn(message);
@@ -65,7 +65,7 @@ public class RedeemExperienceCommandTest extends McRPGBaseTest {
     public void redeemExperience_sendsMaxLevelMessage_whenSkillAtMaxLevel(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
         mcRPGPlayer.getExperienceExtras().setRedeemableExperience(1000);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
         SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
         skillHolderData.addLevels(999);
         when(skill.getMaxLevel()).thenReturn(1000);
@@ -89,10 +89,11 @@ public class RedeemExperienceCommandTest extends McRPGBaseTest {
     public void redeemExperience_refundsUnusedExperience_whenMaxLevelReached(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
         mcRPGPlayer.getExperienceExtras().setRedeemableExperience(1000);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
-        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
+        // Set up mocks BEFORE creating skill holder data
         when(skill.getMaxLevel()).thenReturn(2);
         when(skill.getLevelUpEquation()).thenReturn(new Parser("50"));
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
+        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
 
         Component message = mcRPG.getMiniMessage().deserialize("You redeemed experience!");
         when(localizationManager.getLocalizedMessageAsComponent(eq(player), eq(LocalizationKey.REDEEMABLE_EXPERIENCE_REDEEMED_EXPERIENCE_MESSAGE), any())).thenReturn(message);
@@ -113,10 +114,11 @@ public class RedeemExperienceCommandTest extends McRPGBaseTest {
     public void redeemExperience_consumesAllExperience_whenMaxLevelNotReached(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
         mcRPGPlayer.getExperienceExtras().setRedeemableExperience(25);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
-        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
+        // Set up mocks BEFORE creating skill holder data
         when(skill.getMaxLevel()).thenReturn(2);
         when(skill.getLevelUpEquation()).thenReturn(new Parser("50"));
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
+        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
 
         Component message = mcRPG.getMiniMessage().deserialize("You redeemed experience!");
         when(localizationManager.getLocalizedMessageAsComponent(eq(player), eq(LocalizationKey.REDEEMABLE_EXPERIENCE_REDEEMED_EXPERIENCE_MESSAGE), any())).thenReturn(message);
@@ -136,10 +138,11 @@ public class RedeemExperienceCommandTest extends McRPGBaseTest {
     @Test
     public void redeemExperience_consumesFullExperience_whenLevelingPartialLevel(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
+        // Set up mocks BEFORE creating skill holder data
         when(skill.getMaxLevel()).thenReturn(1000);
         when(skill.getLevelUpEquation()).thenReturn(new Parser("200+(0.17*(skill_level^1.669))"));
         mcRPGPlayer.getExperienceExtras().setRedeemableExperience(1000);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
         SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
 
         Component message = mcRPG.getMiniMessage().deserialize("You redeemed experience!");
@@ -149,7 +152,7 @@ public class RedeemExperienceCommandTest extends McRPGBaseTest {
         assertEquals(1000, mcRPGPlayer.getExperienceExtras().getRedeemableExperience());
         RedeemExperienceCommand.redeemExperience(mcRPGPlayer, skill, 500);
         assertEquals(message, player.nextComponentMessage());
-        assertEquals(101, skillHolderData.getCurrentExperience());
+        assertEquals(100, skillHolderData.getCurrentExperience());
         assertEquals(3, skillHolderData.getCurrentLevel());
         assertEquals(500, mcRPGPlayer.getExperienceExtras().getRedeemableExperience());
     }

--- a/src/test/java/us/eunoians/mcrpg/command/redeem/RedeemLevelsCommandTest.java
+++ b/src/test/java/us/eunoians/mcrpg/command/redeem/RedeemLevelsCommandTest.java
@@ -46,7 +46,7 @@ public class RedeemLevelsCommandTest extends McRPGBaseTest {
     @Test
     public void redeemLevels_sendsNotEnoughMessage_whenNoRedeemableLevels(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
         SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
         Component message = mcRPG.getMiniMessage().deserialize("You do not have enough redeemable levels");
         when(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.REDEEMABLE_LEVELS_NOT_ENOUGH_LEVELS_MESSAGE)).thenReturn(message);
@@ -65,7 +65,7 @@ public class RedeemLevelsCommandTest extends McRPGBaseTest {
     public void redeemLevels_sendsMaxLevelMessage_whenSkillAtMaxLevel(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
         mcRPGPlayer.getExperienceExtras().setRedeemableLevels(1000);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
         SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
         skillHolderData.addLevels(999);
         when(skill.getMaxLevel()).thenReturn(1000);
@@ -88,10 +88,11 @@ public class RedeemLevelsCommandTest extends McRPGBaseTest {
     public void redeemLevels_refundsUnusedLevels_whenMaxLevelReached(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
         mcRPGPlayer.getExperienceExtras().setRedeemableLevels(1000);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
-        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
+        // Set up mocks BEFORE creating skill holder data
         when(skill.getMaxLevel()).thenReturn(2);
         when(skill.getLevelUpEquation()).thenReturn(new Parser("50"));
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
+        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
 
         Component message = mcRPG.getMiniMessage().deserialize("You redeemed levels!");
         when(localizationManager.getLocalizedMessageAsComponent(eq(player), eq(LocalizationKey.REDEEMABLE_LEVELS_REDEEMED_LEVELS_MESSAGE), any())).thenReturn(message);
@@ -111,10 +112,11 @@ public class RedeemLevelsCommandTest extends McRPGBaseTest {
     public void redeemLevels_consumesAllLevels_whenMaxLevelNotReached(@NotNull McRPGPlayer mcRPGPlayer) {
         PlayerMock player = addPlayerToServer(mcRPGPlayer);
         mcRPGPlayer.getExperienceExtras().setRedeemableLevels(2);
-        mcRPGPlayer.asSkillHolder().addSkillHolderData(skill);
-        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
+        // Set up mocks BEFORE creating skill holder data
         when(skill.getMaxLevel()).thenReturn(5);
         when(skill.getLevelUpEquation()).thenReturn(new Parser("50"));
+        mcRPGPlayer.asSkillHolder().addSkillHolderDataAtLevel(skill, 1);
+        SkillHolder.SkillHolderData skillHolderData = mcRPGPlayer.asSkillHolder().getSkillHolderData(skill).get();
 
         Component message = mcRPG.getMiniMessage().deserialize("You redeemed experience!");
         when(localizationManager.getLocalizedMessageAsComponent(eq(player), eq(LocalizationKey.REDEEMABLE_LEVELS_REDEEMED_LEVELS_MESSAGE), any())).thenReturn(message);

--- a/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/ExperienceModifiersContractTest.java
+++ b/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/ExperienceModifiersContractTest.java
@@ -98,7 +98,7 @@ public class ExperienceModifiersContractTest extends McRPGBaseTest {
         addPlayerToServer(mcRPGPlayer);
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         // Add mock skill data
-        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0, 0));
+        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0));
         skillHolder.addSkillHolderData(skillHolderData);
 
         // Setup files
@@ -133,7 +133,7 @@ public class ExperienceModifiersContractTest extends McRPGBaseTest {
         addPlayerToServer(mcRPGPlayer);
         SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
         // Add mock skill data
-        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0, 0));
+        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0));
         skillHolder.addSkillHolderData(skillHolderData);
 
         // Setup files

--- a/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/RestedExperienceModifierTest.java
+++ b/src/test/java/us/eunoians/mcrpg/skill/experience/modifier/RestedExperienceModifierTest.java
@@ -100,7 +100,7 @@ public class RestedExperienceModifierTest extends McRPGBaseTest {
         EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, skillHolder, 100);
         addPlayerToServer(mcRPGPlayer);
         // Add mock skill data
-        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0, 0));
+        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0));
         skillHolder.addSkillHolderData(skillHolderData);
         // Mock Configuration
         FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
@@ -121,7 +121,7 @@ public class RestedExperienceModifierTest extends McRPGBaseTest {
         EntityDamageContext entityDamageContext = constructEntityDamageContext(mcRPGPlayer, skillHolder, 100);
         addPlayerToServer(mcRPGPlayer);
         // Add mock skill data
-        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0, 0));
+        SkillHolder.SkillHolderData skillHolderData = spy(new SkillHolder.SkillHolderData(skillHolder, mockSkill, 0));
         skillHolder.addSkillHolderData(skillHolderData);
         // Mock Configuration
         FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);


### PR DESCRIPTION
Instead of storing level and current XP separately, we now store **total experience** and calculate level on the fly using the skill's leveling equation. This means server owners can tweak leveling curves and player levels will adjust automatically.

Gutted `SkillHolderData` - replaced `currentLevel` + `currentExperience` with a single `totalExperience` field. Level gets calculated when needed and cached until XP changes.

New stuff:
- `invalidateLevelCache()` - forces recalc
- `setToLevel(int)` - sets XP to exactly reach a level
- `calculateTotalExperienceForLevel(int)` - cumulative XP for a level
- `addSkillHolderDataAtLevel(Skill, int)` - helper for tests

The calculation loop just walks through levels 0 to max, subtracting each level's cost until you can't afford the next one.

### SkillDataSnapshot.java

Was: `currentLevel`, `currentExp`
Now: `totalExperience`

### SkillDAO.java

DB schema changed from `current_level` + `current_exp` columns to single `total_experience`.

### McRPGPlayerLoadTask.java

Now passes total XP when loading player data.

### ReloadPluginCommand.java

Added cache invalidation for online players on reload so equation changes take effect immediately.

## New leveling equations

The old equation `200+(0.17*(skill_level^1.669))` was basically flat - ~200 XP per level forever. Fixed that.

### Herbalism, Mining, Woodcutting: `100+(skill_level^1.8)`

| Level | XP needed |
|-------|-----------|
| 1 | 101 |
| 10 | 163 |
| 50 | 1,084 |
| 100 | 3,981 |
| 500 | 55,462 |
| 999 | 157,612 |

Total to max: ~52.6M XP

### Swords: `250+(skill_level^2.0)`

Combat levels faster (mobs give more XP), so it needs a steeper curve.

| Level | XP needed |
|-------|-----------|
| 1 | 251 |
| 10 | 350 |
| 50 | 2,750 |
| 100 | 10,250 |
| 500 | 250,250 |
| 999 | 998,250 |

Total to max: ~333.6M XP

Levels need much more balancing and play testing at the moment. The equations have been changed primarily just to see if calculation works, but is no means the final end result that anyone is happy with. Both the equations & sources need fixing.

## Test fixes

Had to fix mock setup order - level calculation happens at construction now, so mocks need to be set up BEFORE creating skill holder data. Bit me a few times.

- `InstantIrrigationTest` - added `MAXIMUM_SKILL_LEVEL` mock
- `RedeemExperienceCommandTest` / `RedeemLevelsCommandTest` - moved mock setup before `addSkillHolderDataAtLevel()` calls

## Design notes

Per DiamondDagger590:
- Abilities stay unlocked even if level drops (they're stored as attributes)
- Cache invalidates on XP gain and plugin reload

Implements #175