### PR TITLE
Implement type-safe registry keys for Skills and Abilities (#129)

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/ability/AbilityKey.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/AbilityKey.java
@@ -1,0 +1,40 @@
+package us.eunoians.mcrpg.ability;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A key that allows type-safe access to an {@link Ability} through the {@link AbilityRegistry}.
+ * <p>
+ * To access an ability, users will need to call {@link RegistryAccess#registryAccess()} and provide
+ * {@link us.eunoians.mcrpg.registry.McRPGRegistryKey#ABILITY} to get back the {@link AbilityRegistry}.
+ * <p>
+ * From there, users can call {@link AbilityRegistry#ability(AbilityKey)} to get the ability belonging to the
+ * provided key without requiring any casting.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * // Before (with casting):
+ * NymphsVitality nymphsVitality = (NymphsVitality) McRPG.getInstance()
+ *     .registryAccess()
+ *     .registry(McRPGRegistryKey.ABILITY)
+ *     .getRegisteredAbility(NymphsVitality.NYMPHS_VITALITY_KEY);
+ *
+ * // After (with typed key):
+ * NymphsVitality nymphsVitality = McRPG.getInstance()
+ *     .registryAccess()
+ *     .registry(McRPGRegistryKey.ABILITY)
+ *     .ability(McRPGAbilityKey.NYMPHS_VITALITY);
+ * }</pre>
+ *
+ * @param <A> The {@link Ability} being represented by this key.
+ */
+public interface AbilityKey<A extends Ability> {
+
+    /**
+     * Gets the {@link Class} of the {@link Ability} represented by this key.
+     *
+     * @return The {@link Class} of the {@link Ability} represented by this key.
+     */
+    @NotNull
+    Class<A> abilityClass();
+}

--- a/src/main/java/us/eunoians/mcrpg/ability/AbilityKeyImpl.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/AbilityKeyImpl.java
@@ -1,0 +1,31 @@
+package us.eunoians.mcrpg.ability;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The implementation of an {@link AbilityKey}. To create
+ * instances of a key, users should call {@link #create(Class)}.
+ *
+ * @param ability The {@link Class} of the {@link Ability} being represented by this key.
+ * @param <A>     The {@link Ability} class stored in this key.
+ */
+public record AbilityKeyImpl<A extends Ability>(@NotNull Class<A> ability) implements AbilityKey<A> {
+
+    /**
+     * Creates a new instance of a key using the provided {@link Class}.
+     *
+     * @param clazz The class to store in the key.
+     * @param <A>   The type of {@link Ability} to store in this key.
+     * @return An {@link AbilityKey} representing an {@link Ability}.
+     */
+    @NotNull
+    public static <A extends Ability> AbilityKey<A> create(@NotNull Class<A> clazz) {
+        return new AbilityKeyImpl<>(clazz);
+    }
+
+    @NotNull
+    @Override
+    public Class<A> abilityClass() {
+        return ability;
+    }
+}

--- a/src/main/java/us/eunoians/mcrpg/ability/AbilityRegistry.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/AbilityRegistry.java
@@ -38,6 +38,7 @@ public class AbilityRegistry implements Registry<Ability> {
 
     private final McRPG mcRPG;
     private final Map<NamespacedKey, Ability> abilities;
+    private final Map<Class<? extends Ability>, Ability> abilitiesByClass;
     private final Map<NamespacedKey, Set<NamespacedKey>> abilitiesWithSkills;
     private final Set<NamespacedKey> abilitiesWithoutSkills;
     //TODO find a new home for these two
@@ -47,6 +48,7 @@ public class AbilityRegistry implements Registry<Ability> {
     public AbilityRegistry(@NotNull McRPG mcRPG) {
         this.mcRPG = mcRPG;
         abilities = new HashMap<>();
+        abilitiesByClass = new HashMap<>();
         abilitiesWithSkills = new HashMap<>();
         abilitiesWithoutSkills = new HashSet<>();
         entityAlliedFunctions = new HashMap<>();
@@ -67,6 +69,7 @@ public class AbilityRegistry implements Registry<Ability> {
     public void register(@NotNull Ability ability) {
         NamespacedKey abilityKey = ability.getAbilityKey();
         abilities.put(abilityKey, ability);
+        abilitiesByClass.put(ability.getClass(), ability);
 
         if (ability instanceof SkillAbility skillAbility) {
             NamespacedKey skillKey = skillAbility.getSkillKey();
@@ -143,6 +146,8 @@ public class AbilityRegistry implements Registry<Ability> {
             return;
         }
 
+        abilitiesByClass.remove(ability.getClass());
+
         if (ability instanceof SkillAbility skillAbility) {
             NamespacedKey skillKey = skillAbility.getSkillKey();
 
@@ -177,6 +182,37 @@ public class AbilityRegistry implements Registry<Ability> {
         }
 
         return abilities.get(abilityKey);
+    }
+
+    /**
+     * Gets the {@link Ability} belonging to the provided {@link AbilityKey}.
+     * <p>
+     * This method provides type-safe access to abilities without requiring casting.
+     *
+     * @param abilityKey The key to get the corresponding {@link Ability}.
+     * @param <T>        The implementation of {@link Ability} which is being returned.
+     * @return The {@link Ability} belonging to the provided {@link AbilityKey}.
+     * @throws IllegalStateException If the provided {@link AbilityKey} doesn't have
+     *                               a corresponding {@link Ability} registered.
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    public <T extends Ability> T ability(@NotNull AbilityKey<T> abilityKey) {
+        Ability ability = abilitiesByClass.get(abilityKey.abilityClass());
+        if (ability == null) {
+            throw new IllegalStateException("Ability not registered: " + abilityKey.abilityClass().getSimpleName());
+        }
+        return (T) ability;
+    }
+
+    /**
+     * Checks to see if the provided {@link AbilityKey} has a corresponding {@link Ability} registered.
+     *
+     * @param abilityKey The {@link AbilityKey} to check.
+     * @return {@code true} if the ability is registered, {@code false} otherwise.
+     */
+    public boolean registered(@NotNull AbilityKey<?> abilityKey) {
+        return abilitiesByClass.containsKey(abilityKey.abilityClass());
     }
 
     /**

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/herbalism/TooManyPlantsComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/herbalism/TooManyPlantsComponents.java
@@ -7,6 +7,7 @@ import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.OnBlockBreakComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
 
@@ -21,7 +22,7 @@ public class TooManyPlantsComponents {
 
         @Override
         public boolean affectsBlock(@NotNull Block block) {
-            return ((TooManyPlants) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(TooManyPlants.TOO_MANY_PLANTS_KEY)).isBlockValid(block);
+            return McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.TOO_MANY_PLANTS).isBlockValid(block);
         }
 
         @Override
@@ -29,7 +30,7 @@ public class TooManyPlantsComponents {
             if (!OnBlockBreakComponent.super.shouldActivate(abilityHolder, event)) {
                 return false;
             }
-            TooManyPlants tooManyPlants = (TooManyPlants) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(TooManyPlants.TOO_MANY_PLANTS_KEY);
+            TooManyPlants tooManyPlants = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.TOO_MANY_PLANTS);
             if (abilityHolder instanceof SkillHolder skillHolder) {
                 var skillHolderDataOptional = skillHolder.getSkillHolderData(Herbalism.HERBALISM_KEY);
                 if (skillHolderDataOptional.isPresent()) {

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/mining/ExtraOreComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/mining/ExtraOreComponents.java
@@ -7,6 +7,7 @@ import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.OnBlockBreakComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.skill.impl.mining.Mining;
 
@@ -25,7 +26,7 @@ public class ExtraOreComponents {
 
         @Override
         public boolean affectsBlock(@NotNull Block block) {
-            return ((ExtraOre) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(ExtraOre.EXTRA_ORE_KEY)).isBlockValid(block);
+            return McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.EXTRA_ORE).isBlockValid(block);
         }
 
         @Override
@@ -33,7 +34,7 @@ public class ExtraOreComponents {
             if (!OnBlockBreakComponent.super.shouldActivate(abilityHolder, event)) {
                 return false;
             }
-            ExtraOre extraOre = (ExtraOre) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(ExtraOre.EXTRA_ORE_KEY);
+            ExtraOre extraOre = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.EXTRA_ORE);
             if (abilityHolder instanceof SkillHolder skillHolder) {
                 var skillHolderDataOptional = skillHolder.getSkillHolderData(Mining.MINING_KEY);
                 if (skillHolderDataOptional.isPresent()) {

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/mining/ItsATripleComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/mining/ItsATripleComponents.java
@@ -6,6 +6,7 @@ import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.event.ability.mining.ExtraOreActivateEvent;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 import java.util.Random;
@@ -20,7 +21,7 @@ public class ItsATripleComponents {
         @Override
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             if (event instanceof ExtraOreActivateEvent extraOreActivateEvent) {
-                ItsATriple itsATriple = (ItsATriple) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(ItsATriple.ITS_A_TRIPLE_KEY);
+                ItsATriple itsATriple = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.ITS_A_TRIPLE);
                 return extraOreActivateEvent.getAbilityHolder().getUUID().equals(abilityHolder.getUUID())
                         && itsATriple.getActivationChance(itsATriple.getCurrentAbilityTier(abilityHolder)) * 1000 > RANDOM.nextInt(100000);
             }

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/mining/RemoteTransfer.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/mining/RemoteTransfer.java
@@ -37,6 +37,7 @@ import us.eunoians.mcrpg.configuration.file.skill.MiningConfigFile;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.event.ability.mining.RemoteTransferActivateEvent;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import us.eunoians.mcrpg.skill.impl.mining.Mining;
@@ -245,7 +246,7 @@ public final class RemoteTransfer extends McRPGAbility implements PassiveAbility
                 presentInConfig = true;
             }
         }
-        RemoteTransfer remoteTransfer = (RemoteTransfer) getPlugin().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        RemoteTransfer remoteTransfer = getPlugin().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
         var abilityDataOptional = abilityHolder.getAbilityData(remoteTransfer);
         if (abilityDataOptional.isPresent() && abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).isPresent() &&
                 abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).get() instanceof RemoteTransferItemSetAttribute remoteTransferItemSetAttribute) {

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/mining/RemoteTransferComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/mining/RemoteTransferComponents.java
@@ -15,6 +15,7 @@ import us.eunoians.mcrpg.ability.attribute.AbilityLocationAttribute;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.event.fake.FakeChestOpenEvent;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 /**
@@ -30,7 +31,7 @@ public class RemoteTransferComponents {
         @Override
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             BlockDropItemEvent blockDropItemEvent = (BlockDropItemEvent) event;
-            RemoteTransfer remoteTransfer = (RemoteTransfer) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+            RemoteTransfer remoteTransfer = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
             if (!remoteTransfer.isAbilityEnabled() || !abilityHolder.getUUID().equals(blockDropItemEvent.getPlayer().getUniqueId())) {
                 return false;
             }

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/swords/DeeperWoundComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/swords/DeeperWoundComponents.java
@@ -7,6 +7,7 @@ import us.eunoians.mcrpg.ability.AbilityRegistry;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.event.ability.swords.BleedActivateEvent;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 import java.util.Random;
@@ -24,7 +25,7 @@ public class DeeperWoundComponents {
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             if (event instanceof BleedActivateEvent bleedActivateEvent && !bleedActivateEvent.isCancelled()) {
                 AbilityRegistry abilityRegistry = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY);
-                DeeperWound deeperWound = (DeeperWound) abilityRegistry.getRegisteredAbility(DeeperWound.DEEPER_WOUND_KEY);
+                DeeperWound deeperWound = abilityRegistry.ability(McRPGAbilityKey.DEEPER_WOUND);
                 double activationChance = deeperWound.getActivationChance(deeperWound.getCurrentAbilityTier(abilityHolder));
                 return bleedActivateEvent.getAbilityHolder().equals(abilityHolder) && activationChance * 1000 > RANDOM.nextInt(100000);
             }

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/swords/VampireComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/swords/VampireComponents.java
@@ -9,6 +9,7 @@ import us.eunoians.mcrpg.ability.AbilityRegistry;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.event.ability.swords.BleedActivateEvent;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 import java.util.Random;
@@ -27,7 +28,7 @@ public class VampireComponents {
             if (event instanceof BleedActivateEvent bleedActivateEvent && !bleedActivateEvent.isCancelled()
                     && Bukkit.getEntity(abilityHolder.getUUID()) instanceof LivingEntity) {
                 AbilityRegistry abilityRegistry = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY);
-                Vampire vampire = (Vampire) abilityRegistry.getRegisteredAbility(Vampire.VAMPIRE_KEY);
+                Vampire vampire = abilityRegistry.ability(McRPGAbilityKey.VAMPIRE);
                 double activationChance = vampire.getActivationChance(vampire.getCurrentAbilityTier(abilityHolder));
                 return activationChance * 1000 > RANDOM.nextInt(100000);
             }

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/swords/bleed/BleedComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/swords/bleed/BleedComponents.java
@@ -14,6 +14,7 @@ import us.eunoians.mcrpg.ability.impl.swords.Bleed;
 import us.eunoians.mcrpg.ability.impl.swords.SerratedStrikes;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import us.eunoians.mcrpg.skill.impl.swords.Swords;
@@ -45,12 +46,12 @@ public class BleedComponents {
             // Get the activation boost from serrated strikes
             double activationBoost = 0;
             if (abilityHolder.isAbilityActive(SerratedStrikes.SERRATED_STRIKES_KEY)) {
-                SerratedStrikes serratedStrikes = (SerratedStrikes) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(SerratedStrikes.SERRATED_STRIKES_KEY);
+                SerratedStrikes serratedStrikes = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.SERRATED_STRIKES);
                 activationBoost = serratedStrikes.getBoostToBleedActivation(serratedStrikes.getCurrentAbilityTier(abilityHolder));
             }
             // Check if they're a skill holder, if so then check the activation equation. Otherwise activate it ig (needs custom handling in the future for bosses n stuff)
             if (abilityHolder instanceof SkillHolder skillHolder) {
-                Bleed bleed = (Bleed) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(Bleed.BLEED_KEY);
+                Bleed bleed = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.BLEED);
                 var skillHolderDataOptional = skillHolder.getSkillHolderData(Swords.SWORDS_KEY);
                 if (skillHolderDataOptional.isPresent()) {
                     return (bleed.getActivationChance(skillHolder) + activationBoost) * 1000 > RANDOM.nextInt(100000);

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/DryadsGiftComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/DryadsGiftComponents.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 import java.util.Random;
@@ -20,7 +21,7 @@ public class DryadsGiftComponents {
         @Override
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             if (event instanceof BlockBreakEvent blockBreakEvent) {
-                DryadsGift dryadsGift = (DryadsGift) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(DryadsGift.DRYADS_GIFT_KEY);
+                DryadsGift dryadsGift = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.DRYADS_GIFT);
                 return blockBreakEvent.getPlayer().getUniqueId().equals(abilityHolder.getUUID()) && dryadsGift.isBlockValid(blockBreakEvent.getBlock())
                         && dryadsGift.getActivationChance(dryadsGift.getCurrentAbilityTier(abilityHolder)) * 1000 > RANDOM.nextInt(100000);
             }

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/ExtraLumberComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/ExtraLumberComponents.java
@@ -7,6 +7,7 @@ import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.OnBlockBreakComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.skill.impl.woodcutting.WoodCutting;
 
@@ -24,7 +25,7 @@ public class ExtraLumberComponents {
 
         @Override
         public boolean affectsBlock(@NotNull Block block) {
-            return ((ExtraLumber) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(ExtraLumber.EXTRA_LUMBER_KEY)).isBlockValid(block);
+            return McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.EXTRA_LUMBER).isBlockValid(block);
         }
 
         @Override
@@ -32,7 +33,7 @@ public class ExtraLumberComponents {
             if (!OnBlockBreakComponent.super.shouldActivate(abilityHolder, event)) {
                 return false;
             }
-            ExtraLumber extraLumber = (ExtraLumber) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(ExtraLumber.EXTRA_LUMBER_KEY);
+            ExtraLumber extraLumber = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.EXTRA_LUMBER);
             if (abilityHolder instanceof SkillHolder skillHolder) {
                 var skillHolderDataOptional = skillHolder.getSkillHolderData(WoodCutting.WOODCUTTING_KEY);
                 if (skillHolderDataOptional.isPresent()) {

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/HeavySwingComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/HeavySwingComponents.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 import java.util.Random;
@@ -23,7 +24,7 @@ public class HeavySwingComponents {
         @Override
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             if (event instanceof BlockBreakEvent blockBreakEvent) {
-                HeavySwing heavySwing = (HeavySwing) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(HeavySwing.HEAVY_SWING_KEY);
+                HeavySwing heavySwing = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.HEAVY_SWING);
                 return blockBreakEvent.getPlayer().getUniqueId().equals(abilityHolder.getUUID()) && heavySwing.isBlockValid(blockBreakEvent.getBlock())
                         && heavySwing.getActivationChance(heavySwing.getCurrentAbilityTier(abilityHolder)) * 1000 > RANDOM.nextInt(100000);
             }

--- a/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/NymphsVitalityComponents.java
+++ b/src/main/java/us/eunoians/mcrpg/ability/impl/woodcutting/NymphsVitalityComponents.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.component.activatable.EventActivatableComponent;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 
 /**
@@ -25,7 +26,7 @@ public class NymphsVitalityComponents {
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             if (event instanceof FoodLevelChangeEvent foodLevelChangeEvent) {
                 HumanEntity humanEntity = foodLevelChangeEvent.getEntity();
-                NymphsVitality nymphsVitality = (NymphsVitality) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(NymphsVitality.NYMPHS_VITALITY_KEY);
+                NymphsVitality nymphsVitality = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.NYMPHS_VITALITY);
                 return humanEntity.getUniqueId().equals(abilityHolder.getUUID())
                         && humanEntity.getFoodLevel() <= nymphsVitality.getMinimumHunger(nymphsVitality.getCurrentAbilityTier(abilityHolder))
                         && nymphsVitality.isBiomeValid(humanEntity.getLocation().getBlock().getBiome());
@@ -40,7 +41,7 @@ public class NymphsVitalityComponents {
         public boolean shouldActivate(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
             if (event instanceof PlayerMoveEvent playerMoveEvent) {
                 Player player = playerMoveEvent.getPlayer();
-                NymphsVitality nymphsVitality = (NymphsVitality) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(NymphsVitality.NYMPHS_VITALITY_KEY);
+                NymphsVitality nymphsVitality = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.NYMPHS_VITALITY);
                 return player.getUniqueId().equals(abilityHolder.getUUID())
                         && player.getFoodLevel() <= nymphsVitality.getMinimumHunger(nymphsVitality.getCurrentAbilityTier(abilityHolder))
                         && nymphsVitality.isBiomeValid(player.getLocation().getBlock().getBiome());

--- a/src/main/java/us/eunoians/mcrpg/command/link/LinkChestCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/link/LinkChestCommand.java
@@ -24,6 +24,7 @@ import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.event.fake.FakeChestOpenEvent;
 import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
@@ -48,7 +49,7 @@ public class LinkChestCommand {
                         McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                         playerManager.getPlayer(player.getUniqueId()).ifPresent(mcRPGPlayer -> {
                             Map<String, String> placeholders = getPlaceholders(mcRPGPlayer);
-                            RemoteTransfer remoteTransfer = (RemoteTransfer) RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+                            RemoteTransfer remoteTransfer = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
                             Block block = player.getTargetBlock(null, 100);
                             if (block.getType() != Material.CHEST) {
                                 player.sendMessage(localizationManager.getLocalizedMessageAsComponent(player, LocalizationKey.LINK_COMMAND_NOT_LOOKING_AT_CHEST_MESSAGE, placeholders));
@@ -77,7 +78,7 @@ public class LinkChestCommand {
     @NotNull
     public static Map<String, String> getPlaceholders(@Nullable McRPGPlayer mcRPGPlayer) {
         Map<String, String> placeholders = new HashMap<>();
-        Ability ability = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        Ability ability = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
         placeholders.put(SKILL.getPlaceholder(), mcRPGPlayer == null ? ability.getName() : ability.getName(mcRPGPlayer));
         return placeholders;
     }

--- a/src/main/java/us/eunoians/mcrpg/command/link/UnlinkChestCommand.java
+++ b/src/main/java/us/eunoians/mcrpg/command/link/UnlinkChestCommand.java
@@ -19,6 +19,7 @@ import us.eunoians.mcrpg.entity.McRPGPlayerManager;
 import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
@@ -40,7 +41,7 @@ public class UnlinkChestCommand {
                         McRPGLocalizationManager localizationManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.LOCALIZATION);
                         playerManager.getPlayer(player.getUniqueId()).ifPresent(mcRPGPlayer -> {
                             Map<String, String> placeholders = getPlaceholders(mcRPGPlayer);
-                            RemoteTransfer remoteTransfer = (RemoteTransfer) RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+                            RemoteTransfer remoteTransfer = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
                             AbilityHolder abilityHolder = mcRPGPlayer.asSkillHolder();
                             var abilityDataOptional = abilityHolder.getAbilityData(remoteTransfer);
                             if (abilityDataOptional.isPresent()) {
@@ -61,7 +62,7 @@ public class UnlinkChestCommand {
     @NotNull
     public static Map<String, String> getPlaceholders(@Nullable McRPGPlayer mcRPGPlayer) {
         Map<String, String> placeholders = new HashMap<>();
-        Ability ability = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        Ability ability = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
         placeholders.put(SKILL.getPlaceholder(), mcRPGPlayer == null ? ability.getName() : ability.getName(mcRPGPlayer));
         return placeholders;
     }

--- a/src/main/java/us/eunoians/mcrpg/gui/ability/slot/remotetransfer/RemoteTransferToggleSlot.java
+++ b/src/main/java/us/eunoians/mcrpg/gui/ability/slot/remotetransfer/RemoteTransferToggleSlot.java
@@ -17,6 +17,7 @@ import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 import us.eunoians.mcrpg.gui.ability.RemoteTransferGui;
 import us.eunoians.mcrpg.gui.slot.McRPGSlot;
 import us.eunoians.mcrpg.localization.McRPGLocalizationManager;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
@@ -84,7 +85,7 @@ public class RemoteTransferToggleSlot implements McRPGSlot {
      * @return {@code true} if the item represented by this slow is disallowed for usage with {@link RemoteTransfer}.
      */
     public boolean isItemDisallowed() {
-        RemoteTransfer remoteTransfer = (RemoteTransfer) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        RemoteTransfer remoteTransfer = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
         var abilityDataOptional = mcRPGPlayer.asSkillHolder().getAbilityData(remoteTransfer);
         if (abilityDataOptional.isPresent() && abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).isPresent() &&
                 abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).get() instanceof RemoteTransferItemSetAttribute remoteTransferItemSetAttribute) {
@@ -97,7 +98,7 @@ public class RemoteTransferToggleSlot implements McRPGSlot {
      * Toggles the allow list state for the item represented by this slot.
      */
     public void toggleItemStack() {
-        RemoteTransfer remoteTransfer = (RemoteTransfer) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        RemoteTransfer remoteTransfer = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
         var abilityDataOptional = mcRPGPlayer.asSkillHolder().getAbilityData(remoteTransfer);
         if (abilityDataOptional.isPresent() && abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).isPresent() &&
                 abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).get() instanceof RemoteTransferItemSetAttribute remoteTransferItemSetAttribute) {
@@ -117,7 +118,7 @@ public class RemoteTransferToggleSlot implements McRPGSlot {
      * @param enableItem If the item represented by this slot should be allow listed by {@link RemoteTransfer}.
      */
     public void toggleItemStack(boolean enableItem) {
-        RemoteTransfer remoteTransfer = (RemoteTransfer) McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        RemoteTransfer remoteTransfer = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY).ability(McRPGAbilityKey.REMOTE_TRANSFER);
         var abilityDataOptional = mcRPGPlayer.asSkillHolder().getAbilityData(remoteTransfer);
         if (abilityDataOptional.isPresent() && abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).isPresent() &&
                 abilityDataOptional.get().getAbilityAttribute(AbilityAttributeRegistry.REMOTE_TRANSFER_ITEM_SET_ATTRIBUTE).get() instanceof RemoteTransferItemSetAttribute remoteTransferItemSetAttribute) {

--- a/src/main/java/us/eunoians/mcrpg/listener/ability/OnBlockDropItemListener.java
+++ b/src/main/java/us/eunoians/mcrpg/listener/ability/OnBlockDropItemListener.java
@@ -9,6 +9,7 @@ import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.ability.AbilityRegistry;
 import us.eunoians.mcrpg.ability.impl.type.DropMultiplierAbility;
 import us.eunoians.mcrpg.ability.impl.mining.RemoteTransfer;
+import us.eunoians.mcrpg.registry.McRPGAbilityKey;
 import us.eunoians.mcrpg.registry.McRPGRegistryKey;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 
@@ -28,7 +29,7 @@ public class OnBlockDropItemListener implements Listener {
     public void handleDropMultiplierEvent(BlockDropItemEvent blockDropItemEvent) {
         // Handle remote transfer (cuz she special)
         AbilityRegistry abilityRegistry = McRPG.getInstance().registryAccess().registry(McRPGRegistryKey.ABILITY);
-        RemoteTransfer remoteTransfer = (RemoteTransfer) abilityRegistry.getRegisteredAbility(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        RemoteTransfer remoteTransfer = abilityRegistry.ability(McRPGAbilityKey.REMOTE_TRANSFER);
         var abilityHolderOptional = McRPG.getInstance().registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.ENTITY).getAbilityHolder(blockDropItemEvent.getPlayer().getUniqueId());
         abilityHolderOptional.ifPresent(abilityHolder -> remoteTransfer.activateAbility(abilityHolder, blockDropItemEvent));
     }

--- a/src/main/java/us/eunoians/mcrpg/registry/McRPGAbilityKey.java
+++ b/src/main/java/us/eunoians/mcrpg/registry/McRPGAbilityKey.java
@@ -1,0 +1,72 @@
+package us.eunoians.mcrpg.registry;
+
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.ability.AbilityKey;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.impl.herbalism.InstantIrrigation;
+import us.eunoians.mcrpg.ability.impl.herbalism.MassHarvest;
+import us.eunoians.mcrpg.ability.impl.herbalism.TooManyPlants;
+import us.eunoians.mcrpg.ability.impl.herbalism.VerdantSurge;
+import us.eunoians.mcrpg.ability.impl.mining.ExtraOre;
+import us.eunoians.mcrpg.ability.impl.mining.ItsATriple;
+import us.eunoians.mcrpg.ability.impl.mining.OreScanner;
+import us.eunoians.mcrpg.ability.impl.mining.RemoteTransfer;
+import us.eunoians.mcrpg.ability.impl.swords.Bleed;
+import us.eunoians.mcrpg.ability.impl.swords.DeeperWound;
+import us.eunoians.mcrpg.ability.impl.swords.EnhancedBleed;
+import us.eunoians.mcrpg.ability.impl.swords.RageSpike;
+import us.eunoians.mcrpg.ability.impl.swords.SerratedStrikes;
+import us.eunoians.mcrpg.ability.impl.swords.Vampire;
+import us.eunoians.mcrpg.ability.impl.woodcutting.DryadsGift;
+import us.eunoians.mcrpg.ability.impl.woodcutting.ExtraLumber;
+import us.eunoians.mcrpg.ability.impl.woodcutting.HeavySwing;
+import us.eunoians.mcrpg.ability.impl.woodcutting.NymphsVitality;
+
+import static us.eunoians.mcrpg.ability.AbilityKeyImpl.create;
+
+/**
+ * A soft enum of different {@link AbilityKey}s supported by McRPG.
+ * <p>
+ * To use these, you will need access to the {@link AbilityRegistry}
+ * via {@link com.diamonddagger590.mccore.registry.RegistryAccess#registry(com.diamonddagger590.mccore.registry.RegistryKey)}
+ * and pass in {@link McRPGRegistryKey#ABILITY}.
+ * <p>
+ * From there, you can call {@link AbilityRegistry#ability(AbilityKey)} with the key
+ * you want to get the {@link Ability} for.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * NymphsVitality nymphsVitality = McRPG.getInstance()
+ *     .registryAccess()
+ *     .registry(McRPGRegistryKey.ABILITY)
+ *     .ability(McRPGAbilityKey.NYMPHS_VITALITY);
+ * }</pre>
+ */
+public interface McRPGAbilityKey {
+
+    // Herbalism abilities
+    AbilityKey<InstantIrrigation> INSTANT_IRRIGATION = create(InstantIrrigation.class);
+    AbilityKey<MassHarvest> MASS_HARVEST = create(MassHarvest.class);
+    AbilityKey<TooManyPlants> TOO_MANY_PLANTS = create(TooManyPlants.class);
+    AbilityKey<VerdantSurge> VERDANT_SURGE = create(VerdantSurge.class);
+
+    // Mining abilities
+    AbilityKey<ExtraOre> EXTRA_ORE = create(ExtraOre.class);
+    AbilityKey<ItsATriple> ITS_A_TRIPLE = create(ItsATriple.class);
+    AbilityKey<OreScanner> ORE_SCANNER = create(OreScanner.class);
+    AbilityKey<RemoteTransfer> REMOTE_TRANSFER = create(RemoteTransfer.class);
+
+    // Swords abilities
+    AbilityKey<Bleed> BLEED = create(Bleed.class);
+    AbilityKey<DeeperWound> DEEPER_WOUND = create(DeeperWound.class);
+    AbilityKey<EnhancedBleed> ENHANCED_BLEED = create(EnhancedBleed.class);
+    AbilityKey<RageSpike> RAGE_SPIKE = create(RageSpike.class);
+    AbilityKey<SerratedStrikes> SERRATED_STRIKES = create(SerratedStrikes.class);
+    AbilityKey<Vampire> VAMPIRE = create(Vampire.class);
+
+    // Woodcutting abilities
+    AbilityKey<DryadsGift> DRYADS_GIFT = create(DryadsGift.class);
+    AbilityKey<ExtraLumber> EXTRA_LUMBER = create(ExtraLumber.class);
+    AbilityKey<HeavySwing> HEAVY_SWING = create(HeavySwing.class);
+    AbilityKey<NymphsVitality> NYMPHS_VITALITY = create(NymphsVitality.class);
+}

--- a/src/main/java/us/eunoians/mcrpg/registry/McRPGSkillKey.java
+++ b/src/main/java/us/eunoians/mcrpg/registry/McRPGSkillKey.java
@@ -1,0 +1,37 @@
+package us.eunoians.mcrpg.registry;
+
+import us.eunoians.mcrpg.skill.Skill;
+import us.eunoians.mcrpg.skill.SkillKey;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+import us.eunoians.mcrpg.skill.impl.swords.Swords;
+import us.eunoians.mcrpg.skill.impl.woodcutting.WoodCutting;
+
+import static us.eunoians.mcrpg.skill.SkillKeyImpl.create;
+
+/**
+ * A soft enum of different {@link SkillKey}s supported by McRPG.
+ * <p>
+ * To use these, you will need access to the {@link SkillRegistry}
+ * via {@link com.diamonddagger590.mccore.registry.RegistryAccess#registry(com.diamonddagger590.mccore.registry.RegistryKey)}
+ * and pass in {@link McRPGRegistryKey#SKILL}.
+ * <p>
+ * From there, you can call {@link SkillRegistry#skill(SkillKey)} with the key
+ * you want to get the {@link Skill} for.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * Swords swords = McRPG.getInstance()
+ *     .registryAccess()
+ *     .registry(McRPGRegistryKey.SKILL)
+ *     .skill(McRPGSkillKey.SWORDS);
+ * }</pre>
+ */
+public interface McRPGSkillKey {
+
+    SkillKey<Herbalism> HERBALISM = create(Herbalism.class);
+    SkillKey<Mining> MINING = create(Mining.class);
+    SkillKey<Swords> SWORDS = create(Swords.class);
+    SkillKey<WoodCutting> WOODCUTTING = create(WoodCutting.class);
+}

--- a/src/main/java/us/eunoians/mcrpg/skill/SkillKey.java
+++ b/src/main/java/us/eunoians/mcrpg/skill/SkillKey.java
@@ -1,0 +1,40 @@
+package us.eunoians.mcrpg.skill;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A key that allows type-safe access to a {@link Skill} through the {@link SkillRegistry}.
+ * <p>
+ * To access a skill, users will need to call {@link com.diamonddagger590.mccore.registry.RegistryAccess#registryAccess()}
+ * and provide {@link us.eunoians.mcrpg.registry.McRPGRegistryKey#SKILL} to get back the {@link SkillRegistry}.
+ * <p>
+ * From there, users can call {@link SkillRegistry#skill(SkillKey)} to get the skill belonging to the
+ * provided key without requiring any casting.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * // Before (with casting):
+ * Swords swords = (Swords) McRPG.getInstance()
+ *     .registryAccess()
+ *     .registry(McRPGRegistryKey.SKILL)
+ *     .getRegisteredSkill(Swords.SWORDS_KEY);
+ *
+ * // After (with typed key):
+ * Swords swords = McRPG.getInstance()
+ *     .registryAccess()
+ *     .registry(McRPGRegistryKey.SKILL)
+ *     .skill(McRPGSkillKey.SWORDS);
+ * }</pre>
+ *
+ * @param <S> The {@link Skill} being represented by this key.
+ */
+public interface SkillKey<S extends Skill> {
+
+    /**
+     * Gets the {@link Class} of the {@link Skill} represented by this key.
+     *
+     * @return The {@link Class} of the {@link Skill} represented by this key.
+     */
+    @NotNull
+    Class<S> skillClass();
+}

--- a/src/main/java/us/eunoians/mcrpg/skill/SkillKeyImpl.java
+++ b/src/main/java/us/eunoians/mcrpg/skill/SkillKeyImpl.java
@@ -1,0 +1,31 @@
+package us.eunoians.mcrpg.skill;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The implementation of a {@link SkillKey}. To create
+ * instances of a key, users should call {@link #create(Class)}.
+ *
+ * @param skill The {@link Class} of the {@link Skill} being represented by this key.
+ * @param <S>   The {@link Skill} class stored in this key.
+ */
+public record SkillKeyImpl<S extends Skill>(@NotNull Class<S> skill) implements SkillKey<S> {
+
+    /**
+     * Creates a new instance of a key using the provided {@link Class}.
+     *
+     * @param clazz The class to store in the key.
+     * @param <S>   The type of {@link Skill} to store in this key.
+     * @return A {@link SkillKey} representing a {@link Skill}.
+     */
+    @NotNull
+    public static <S extends Skill> SkillKey<S> create(@NotNull Class<S> clazz) {
+        return new SkillKeyImpl<>(clazz);
+    }
+
+    @NotNull
+    @Override
+    public Class<S> skillClass() {
+        return skill;
+    }
+}

--- a/src/main/java/us/eunoians/mcrpg/skill/SkillRegistry.java
+++ b/src/main/java/us/eunoians/mcrpg/skill/SkillRegistry.java
@@ -29,9 +29,11 @@ import java.util.Set;
 public class SkillRegistry implements Registry<Skill> {
 
     private final Map<NamespacedKey, Skill> skills;
+    private final Map<Class<? extends Skill>, Skill> skillsByClass;
 
     public SkillRegistry() {
         this.skills = new HashMap<>();
+        this.skillsByClass = new HashMap<>();
     }
 
     /**
@@ -44,6 +46,7 @@ public class SkillRegistry implements Registry<Skill> {
             throw new IllegalArgumentException("Skill " + skill.getSkillKey() + " already registered");
         }
         skills.put(skill.getSkillKey(), skill);
+        skillsByClass.put(skill.getClass(), skill);
         Bukkit.getPluginManager().callEvent(new SkillRegisterEvent(skill));
     }
 
@@ -118,8 +121,40 @@ public class SkillRegistry implements Registry<Skill> {
     public void unregisterSkill(@NotNull NamespacedKey skillKey) {
         Skill skill = skills.remove(skillKey);
         if (skill != null) {
+            skillsByClass.remove(skill.getClass());
             Bukkit.getPluginManager().callEvent(new SkillUnregisterEvent(skill));
         }
+    }
+
+    /**
+     * Gets the {@link Skill} belonging to the provided {@link SkillKey}.
+     * <p>
+     * This method provides type-safe access to skills without requiring casting.
+     *
+     * @param skillKey The key to get the corresponding {@link Skill}.
+     * @param <T>      The implementation of {@link Skill} which is being returned.
+     * @return The {@link Skill} belonging to the provided {@link SkillKey}.
+     * @throws IllegalStateException If the provided {@link SkillKey} doesn't have
+     *                               a corresponding {@link Skill} registered.
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    public <T extends Skill> T skill(@NotNull SkillKey<T> skillKey) {
+        Skill skill = skillsByClass.get(skillKey.skillClass());
+        if (skill == null) {
+            throw new IllegalStateException("Skill not registered: " + skillKey.skillClass().getSimpleName());
+        }
+        return (T) skill;
+    }
+
+    /**
+     * Checks to see if the provided {@link SkillKey} has a corresponding {@link Skill} registered.
+     *
+     * @param skillKey The {@link SkillKey} to check.
+     * @return {@code true} if the skill is registered, {@code false} otherwise.
+     */
+    public boolean registered(@NotNull SkillKey<?> skillKey) {
+        return skillsByClass.containsKey(skillKey.skillClass());
     }
 
 }


### PR DESCRIPTION
## Summary
- Add `AbilityKey<A>` and `SkillKey<S>` for type-safe registry access
- Add `McRPGAbilityKey` and `McRPGSkillKey` with all key constants
- Refactor codebase to eliminate explicit casts when retrieving abilities/skills

Closes #129

## Changes

### New Files
- `AbilityKey.java` - Generic interface for typed ability keys
- `AbilityKeyImpl.java` - Record implementation
- `SkillKey.java` - Generic interface for typed skill keys
- `SkillKeyImpl.java` - Record implementation
- `McRPGAbilityKey.java` - Constants for all McRPG abilities
- `McRPGSkillKey.java` - Constants for all McRPG skills

### Modified Files
- `AbilityRegistry.java` - Added `ability(AbilityKey<T>)` method and class-based lookup
- `SkillRegistry.java` - Added `skill(SkillKey<T>)` method and class-based lookup
- 14+ component/command/listener files refactored to use typed keys

## Usage

**Before (casting required):**
```java
HeavySwing heavySwing = (HeavySwing) McRPG.getInstance()
    .registryAccess()
    .registry(McRPGRegistryKey.ABILITY)
    .getRegisteredAbility(HeavySwing.HEAVY_SWING_KEY);
```

This PR will no doubt require changes, as I made this off my own assumptions reading the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added type-safe ability and skill key system enabling compile-time verified lookups through centralized registries.

* **Refactor**
  * Modernized ability registry access patterns across all activation components (herbalism, mining, swords, woodcutting) to leverage new typed key-based retrieval methods.
  * Established centralized ability and skill key repositories for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->