### PR TITLE
Fix null pointer exception in LeaderboardHeadManager skull owner checks

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/api/leaderboards/LeaderboardHeadManager.java
+++ b/src/main/java/us/eunoians/mcrpg/api/leaderboards/LeaderboardHeadManager.java
@@ -113,7 +113,7 @@ public class LeaderboardHeadManager {
                         .replace("%Level%", Integer.toString(level)).replace("%Player%", offlinePlayer.getName())));
                 sign.update();
                 Skull skull = (Skull) skullLoc.getBlock().getState();
-                if(!skull.getOwningPlayer().getUniqueId().equals(playerLeaderboardData.getUUID())){
+                if(skull.getOwningPlayer() == null || !skull.getOwningPlayer().getUniqueId().equals(playerLeaderboardData.getUUID())){
                     skull.setOwningPlayer(Bukkit.getOfflinePlayer(playerLeaderboardData.getUUID()));
                     skull.update();
                 }
@@ -156,7 +156,7 @@ public class LeaderboardHeadManager {
                         .replace("%Level%", Integer.toString(level)).replace("%Player%", offlinePlayer.getName())));
                 sign.update();
                 Skull skull = (Skull) skullLoc.getBlock().getState();
-                if(!skull.getOwningPlayer().getUniqueId().equals(playerLeaderboardData.getUUID())){
+                if(skull.getOwningPlayer() == null || !skull.getOwningPlayer().getUniqueId().equals(playerLeaderboardData.getUUID())){
                     skull.setOwningPlayer(Bukkit.getOfflinePlayer(playerLeaderboardData.getUUID()));
                     skull.update();
                 }


### PR DESCRIPTION
## Summary
Added null safety checks to prevent potential `NullPointerException` when accessing the owning player of skull blocks in the leaderboard head manager.

## Key Changes
- Added null checks before calling `getUniqueId()` on skull owning players in two locations within `LeaderboardHeadManager.java`
- Modified conditional logic to check if `skull.getOwningPlayer()` is null before attempting to access its UUID
- Applied the same fix to both the method at line 116 and line 159

## Implementation Details
The changes ensure that if a skull block's owning player is null (which can occur in certain edge cases), the code will safely proceed to set the owning player rather than throwing a `NullPointerException`. This makes the leaderboard head update process more robust and prevents crashes when dealing with skulls that may not have a valid owner set.

https://claude.ai/code/session_01LwGX7QizPEgKkg2JjDQKKc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes when leaderboard skulls have incomplete ownership information
  * Improved stability by automatically establishing proper ownership for leaderboard entries when needed
  * Enhanced overall reliability of the leaderboard head tracking system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->