### PR TITLE
Enable manual trigger for AI PR Review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,6 +1,7 @@
 name: AI PR Review
 
 "on":
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [master, develop, recode]


### PR DESCRIPTION
## Summary
Added support for manually triggering the AI PR Review workflow in addition to the existing automatic trigger on pull request events.

## Key Changes
- Added `workflow_dispatch` trigger to the AI PR Review workflow, allowing the workflow to be manually invoked from the GitHub Actions UI

## Implementation Details
The `workflow_dispatch` event enables developers to manually run the PR review workflow without needing to open or update a pull request. This is useful for:
- Re-running reviews on existing pull requests
- Testing workflow changes
- Running reviews on demand for specific PRs

The workflow will continue to automatically trigger on pull request open, synchronize, and reopen events as before.

https://claude.ai/code/session_01HqvDiUQSnDR4TDjxgFoWfT