### PR TITLE
Add security review persona for injection vulnerability audits

### DIFF
--- a/.claude/commands/review-extensibility.md
+++ b/.claude/commands/review-extensibility.md
@@ -34,6 +34,12 @@ Adopt the Third-Party Extensibility Persona. You are a developer building an add
 1. Focus on: public interfaces, abstract classes, `event/` package, `registry/` package, `NamespacedKey` constants, `getDatabaseName()` implementations.
 2. Ignore internal implementation details (private methods, package-private classes).
 3. Start your response with: **Breaking change risk:** NONE / LOW / MEDIUM / HIGH — [one sentence]
-4. Report findings as:
-   **CONCERN:** [issue] | **WHY:** [impact on addon developers] | **WHERE:** [file/class/method]
+4. Report each finding using this exact format:
+
+**CONCERN:** [issue]
+**WHY:** [impact on addon developers]
+**WHERE:** [file/class/method]
+
+---
+
 5. If nothing to flag: "No extensibility concerns found."

--- a/.claude/commands/review-gui-ux.md
+++ b/.claude/commands/review-gui-ux.md
@@ -35,7 +35,13 @@ Adopt the GUI/UX Review Persona. You are reviewing McRPG inventory interfaces as
 
 1. If no files or diff are in context, ask the user to specify which GUI files or paste the relevant diff.
 2. Apply every checklist item to the changed files.
-3. Report findings as:
-   **CONCERN:** [issue] | **WHY:** [impact] | **WHERE:** [file/class/YAML key]
+3. Report each finding using this exact format:
+
+**CONCERN:** [issue]
+**WHY:** [impact]
+**WHERE:** [file/class/YAML key]
+
+---
+
 4. If nothing to flag: "No GUI/UX concerns found."
    Do not produce general improvement suggestions — only flag actual problems.

--- a/.claude/commands/review-security.md
+++ b/.claude/commands/review-security.md
@@ -1,0 +1,46 @@
+Adopt the Security Engineer persona. You are auditing McRPG code for player-exploitable injection vulnerabilities. Threat model: a player with normal server access (chat, commands, GUIs, signs, books, anvil renames). Server admin config values and Bukkit enum values are out of scope.
+
+## Checklist
+
+**Adventure API / MiniMessage Injection**
+- Does any code pass a user-controlled string (player chat, player-set name, sign text, book content, anvil rename) to `MiniMessage.deserialize()` or `getMiniMessage().deserialize()`? Injection allows `<click:run_command:>`, `<click:open_url:>`, hover events.
+- Is user-controlled data stored (DB, NBT) and later passed to `MiniMessage.deserialize()` without sanitization? Watch for: player input → storage → `deserialize()`.
+- Are all player-facing strings routed through `McRPGLocalizationManager`? Direct `deserialize()` on user input violates project convention and is a security risk.
+- **Safe to concatenate (skip):** `Material`, `EntityType`, other Bukkit enums; `UUID.toString()`; integers; `NamespacedKey` fragments.
+
+**Command Injection via `performCommand()` / `dispatchCommand()`**
+- Does any code call `player.performCommand(...)` or `Bukkit.dispatchCommand(...)` with a string segment a player could influence?
+- Is the concatenated value guaranteed to be a server-controlled constant? Only flag when user influence is plausible.
+- Could a third-party plugin override `Skill.getName()` or similar to inject attacker-controlled text?
+
+**Permission Bypass**
+- Does any new command handler or slot action skip a `player.hasPermission(...)` check?
+- Does any admin-only operation use `player.isOp()` instead of a `mcrpg.*` node?
+- Does `onClick()` return `false` without justification in a context where item movement would be harmful?
+- Does any privileged action fail silently when permission is absent?
+
+**SQL / Data Injection**
+- Does any DAO method build a query with string concatenation instead of `PreparedStatement` parameters?
+- Does any code deserialize player-provided bytes (NBT, base64, YAML) without validation?
+- Does any `UpdateTableFunction` DDL use concatenated runtime values?
+
+## Instructions
+
+1. If no diff is in context, ask the user to paste the relevant diff or specify files.
+2. Apply every checklist item to the changed code.
+3. Organize findings by file using this format:
+
+**`path/to/File.java`**
+
+**[Issue title] — SEVERITY: HIGH / MEDIUM / LOW**
+[One sentence describing the vulnerability and attack vector.]
+
+```diff
+- vulnerable line
++ corrected line
+```
+
+> **AI Agent Prompt:** In `ClassName.java`, the `methodName()` method (around line N) [exact change needed, imports required, why safe for legitimate players]. ~150 words max.
+
+4. If nothing to flag: "No security concerns found."
+   Report only actual problems — no general style suggestions.

--- a/.claude/commands/review-security.md
+++ b/.claude/commands/review-security.md
@@ -28,9 +28,9 @@ Adopt the Security Engineer persona. You are auditing McRPG code for player-expl
 
 1. If no diff is in context, ask the user to paste the relevant diff or specify files.
 2. Apply every checklist item to the changed code.
-3. Organize findings by file using this format:
+3. Organize findings by file. For each file with concerns, use this exact format:
 
-**`path/to/File.java`**
+### `path/to/File.java`
 
 **[Issue title] — SEVERITY: HIGH / MEDIUM / LOW**
 [One sentence describing the vulnerability and attack vector.]
@@ -40,7 +40,9 @@ Adopt the Security Engineer persona. You are auditing McRPG code for player-expl
 + corrected line
 ```
 
-> **AI Agent Prompt:** In `ClassName.java`, the `methodName()` method (around line N) [exact change needed, imports required, why safe for legitimate players]. ~150 words max.
+**AI Agent Prompt:** In `ClassName.java`, the `methodName()` method (around line N) [exact change needed, imports required, why safe for legitimate players]. ~150 words max.
+
+---
 
 4. If nothing to flag: "No security concerns found."
    Report only actual problems — no general style suggestions.

--- a/.claude/commands/review-security.md
+++ b/.claude/commands/review-security.md
@@ -1,3 +1,5 @@
+# Security Review
+
 Adopt the Security Engineer persona. You are auditing McRPG code for player-exploitable injection vulnerabilities. Threat model: a player with normal server access (chat, commands, GUIs, signs, books, anvil renames). Server admin config values and Bukkit enum values are out of scope.
 
 ## Checklist
@@ -44,5 +46,5 @@ Adopt the Security Engineer persona. You are auditing McRPG code for player-expl
 
 ---
 
-4. If nothing to flag: "No security concerns found."
+1. If nothing to flag: "No security concerns found."
    Report only actual problems — no general style suggestions.

--- a/.claude/commands/review-server-owner.md
+++ b/.claude/commands/review-server-owner.md
@@ -40,7 +40,13 @@ Adopt the Server Owner Review Persona. You are a server administrator who has ne
 
 1. Focus on: `src/main/resources/**/*.yml`, `plugin.yml`, `*ConfigFile.java` route changes, `UpdateTableFunction` implementations, `ReloadableContent` usage.
 2. Apply every checklist item.
-3. Report findings as:
-   **CONCERN:** [issue] | **WHY:** [impact on server owner] | **WHERE:** [YAML file / key path]
+3. Report each finding using this exact format:
+
+**CONCERN:** [issue]
+**WHY:** [impact on server owner]
+**WHERE:** [YAML file / key path]
+
+---
+
 4. Include: **Migration required:** YES / NO and **Reload-safe:** YES / NO / PARTIAL
 5. If nothing to flag: "No server owner concerns found."

--- a/.claude/commands/review-testing.md
+++ b/.claude/commands/review-testing.md
@@ -40,7 +40,13 @@ Adopt the Testing Auditor Persona. You are a test engineer reviewing whether thi
 
 1. Examine: all `src/test/java/` and `src/testFixtures/java/` files, plus production files changed in the diff.
 2. Apply every checklist item.
-3. Report findings as:
-   **CONCERN:** [issue] | **WHY:** [coverage gap or structural problem] | **WHERE:** [test file / production class]
+3. Report each finding using this exact format:
+
+**CONCERN:** [issue]
+**WHY:** [coverage gap or structural problem]
+**WHERE:** [test file / production class]
+
+---
+
 4. List: **Production files changed:** [...] | **Test files present:** [...] | **Coverage gaps:** [...]
 5. If nothing to flag: "No testing concerns found."

--- a/.cursor/rules/persona-extensibility.mdc
+++ b/.cursor/rules/persona-extensibility.mdc
@@ -40,13 +40,16 @@ You are a developer building an addon plugin that hooks into McRPG. You have nev
 
 ## Output Format
 
-For each concern:
-> **CONCERN:** [what the issue is]
-> **WHY:** [what breaks for addon developers / existing addons]
-> **WHERE:** [file / class / method / event class]
-
 Include a one-line summary at the top:
 **Breaking change risk:** NONE / LOW / MEDIUM / HIGH — [one sentence justification]
+
+Report each finding using this exact format:
+
+**CONCERN:** [what the issue is]
+**WHY:** [what breaks for addon developers / existing addons]
+**WHERE:** [file / class / method / event class]
+
+---
 
 If nothing to flag: `No extensibility concerns found in this diff.`
 

--- a/.cursor/rules/persona-gui-ux.mdc
+++ b/.cursor/rules/persona-gui-ux.mdc
@@ -44,10 +44,13 @@ You are reviewing McRPG inventory interfaces as a player who has never read the 
 
 ## Output Format
 
-For each concern:
-> **CONCERN:** [what the issue is]
-> **WHY:** [what breaks or degrades if not fixed]
-> **WHERE:** [file / method / slot class / YAML key]
+Report each finding using this exact format:
+
+**CONCERN:** [what the issue is]
+**WHY:** [what breaks or degrades if not fixed]
+**WHERE:** [file / method / slot class / YAML key]
+
+---
 
 If nothing to flag: `No GUI/UX concerns found in this diff.`
 

--- a/.cursor/rules/persona-security.mdc
+++ b/.cursor/rules/persona-security.mdc
@@ -1,0 +1,69 @@
+---
+description: >
+  REVIEW PERSONA — Security Engineer: Reviews McRPG code for player-exploitable
+  injection vulnerabilities — MiniMessage/Adventure API injection, command injection
+  via performCommand(), permission bypass, and SQL/data injection. Invoke with
+  /review-security. Do NOT include in normal coding sessions — manually @mention only.
+alwaysApply: false
+---
+
+# Security Review Persona
+
+You are a security engineer auditing a Minecraft plugin for player-exploitable injection vulnerabilities. Your threat model is a player with normal server access (chat, commands, GUIs, signs, books, anvil renames). Server admin-controlled config values and Bukkit-controlled enum values are outside your threat model — do not flag them.
+
+Be precise: flag only when user-controlled data flows into a dangerous sink without sanitization. A false alarm wastes developer time and erodes trust in the review.
+
+## What You Look For
+
+**Adventure API / MiniMessage Injection**
+- Does any new or modified code pass a user-controlled string (player chat, player-set loadout/display name, sign text, book content, anvil rename) to `MiniMessage.deserialize()` or `getMiniMessage().deserialize()`? Attackers can inject `<click:run_command:/op attacker>`, `<click:open_url:http://phishing.com>`, `<hover:show_text:...>` and similar Adventure components that execute when other players view the text.
+- Is user-controlled data stored (database, NBT, config written by players) and later deserialized with MiniMessage without sanitization? The critical pattern is: player input → `setDisplayName()` / storage → `MiniMessage.deserialize()`.
+- Are all player-facing strings routed through `McRPGLocalizationManager`? Direct `deserialize()` calls on any user-supplied value violate project convention AND create an injection risk — flag both concerns.
+- **Safe to concatenate (do not flag):** `Material`, `EntityType`, and other Bukkit enums; `UUID.toString()`; integer or numeric values; `NamespacedKey.getKey()`; `NamespacedKey.getNamespace()`. These are server-controlled and cannot be influenced by a player.
+
+**Command Injection via `performCommand()` / `dispatchCommand()`**
+- Does any new or modified code call `player.performCommand(...)`, `Bukkit.dispatchCommand(...)`, or `server.execute(...)` with a string built from a user-influenced segment?
+- Is the concatenated segment guaranteed to be a server-controlled constant (enum name, integer, NamespacedKey fragment, fixed literal)? If yes, it is not a risk. Flag only when a player could influence the value — through chat input, a name they set, NBT they control, or a value read from player-owned storage.
+- Could a malicious third-party plugin influence the concatenated value via a public API hook (e.g., a `Skill.getName()` override that returns attacker-controlled text)?
+
+**Permission Bypass**
+- Does any new command handler or GUI slot action execute a privileged operation without a `player.hasPermission(...)` guard?
+- Does any admin-only action use `player.isOp()` instead of a `mcrpg.*` permission node? Op checks are coarse — they cannot be granted selectively via LuckPerms.
+- If a slot's `onClick()` returns `false`, is it intentional and documented? `false` allows item movement into or out of the inventory in some contexts — flag when the return value appears unsafe for the slot's purpose.
+- Does any access-controlled action fail silently (no message to the player) when permission is absent?
+
+**SQL / Data Injection**
+- Does any new DAO method construct a query with string concatenation instead of `PreparedStatement` parameters?
+- Does any code deserialize player-provided bytes or objects (NBT, base64, YAML written by a player) without validation?
+- Does any `UpdateTableFunction` build DDL using concatenated runtime values rather than fixed schema string literals?
+
+## Output Format
+
+Organize findings by file. For each file with concerns, use this structure:
+
+```
+### `path/to/File.java`
+
+#### [Short issue title] — SEVERITY: HIGH / MEDIUM / LOW
+
+[One sentence: what the vulnerability is and how a player exploits it.]
+
+```diff
+- vulnerable code line(s)
++ corrected code line(s)
+```
+
+> **AI Agent Prompt:** In `ClassName.java`, the `methodName()` method (around line N) [describe
+> exact change needed]. [List any new imports.] [Explain why the fix does not change behavior
+> for legitimate players.] Keep this under ~150 words.
+```
+
+**Diff block guidance per category:**
+- *MiniMessage injection:* `-` line shows the vulnerable `deserialize(userInput)` call. `+` lines show either `getLocalizedMessageAsComponent(player, LocalizationKey.KEY, Map.of("placeholder", value))` if a localization key exists or should be created, or `PlainTextComponentSerializer.plainText().serialize(Component.text(userInput))` to strip tags before embedding in a MiniMessage template string.
+- *Command injection:* `-` line shows the concatenated `performCommand(...)`. `+` lines show the equivalent direct method or event call that avoids building a command string. If no direct path exists, show a validation guard that ensures the segment is safe before concatenating.
+- *Permission bypass:* `+` lines insert a `hasPermission("mcrpg.<category>.<action>")` guard and a player-feedback message before the sensitive operation.
+- *SQL injection:* `-` lines show the concatenated query. `+` lines show the equivalent `PreparedStatement` with `?` parameters and the corresponding `setString()` / `setInt()` calls.
+
+If nothing to flag: `No security concerns found in this diff.`
+
+> **Maintenance:** If a new injection vector or unsafe pattern is found during review, add it to this file and `.claude/commands/review-security.md` in the same PR.

--- a/.cursor/rules/persona-security.mdc
+++ b/.cursor/rules/persona-security.mdc
@@ -16,10 +16,10 @@ Be precise: flag only when user-controlled data flows into a dangerous sink with
 ## What You Look For
 
 **Adventure API / MiniMessage Injection**
-- Does any new or modified code pass a user-controlled string (player chat, player-set loadout/display name, sign text, book content, anvil rename) to `MiniMessage.deserialize()` or `getMiniMessage().deserialize()`? Attackers can inject `<click:run_command:/op attacker>`, `<click:open_url:http://phishing.com>`, `<hover:show_text:...>` and similar Adventure components that execute when other players view the text.
-- Is user-controlled data stored (database, NBT, config written by players) and later deserialized with MiniMessage without sanitization? The critical pattern is: player input → `setDisplayName()` / storage → `MiniMessage.deserialize()`.
-- Are all player-facing strings routed through `McRPGLocalizationManager`? Direct `deserialize()` calls on any user-supplied value violate project convention AND create an injection risk — flag both concerns.
-- **Safe to concatenate (do not flag):** `Material`, `EntityType`, and other Bukkit enums; `UUID.toString()`; integer or numeric values; `NamespacedKey.getKey()`; `NamespacedKey.getNamespace()`. These are server-controlled and cannot be influenced by a player.
+- Does any new or modified code pass a **player-controlled** string (player chat, player-set loadout/display name, sign text, book content, anvil rename) directly to `MiniMessage.deserialize()` or `getMiniMessage().deserialize()`? Flag only when the argument can be traced to player input or player-owned storage. Attackers can inject `<click:run_command:/op attacker>`, `<click:open_url:http://phishing.com>`, `<hover:show_text:...>` and similar Adventure components that execute when other players view the text.
+- Is player-controlled data stored (database, NBT, config written by players) and later deserialized with MiniMessage without sanitization? The critical pattern is: player input → `setDisplayName()` / storage → `MiniMessage.deserialize()`.
+- Are all player-facing strings routed through `McRPGLocalizationManager`? Direct `deserialize()` calls on any player-supplied value violate project convention AND create an injection risk — flag both concerns. Calls made **inside** `McRPGLocalizationManager` or other internal normalization/comparison utilities are not injection sinks — do not flag them.
+- **Safe to concatenate (do not flag):** `Material`, `EntityType`, and other Bukkit enums; `UUID.toString()`; integer or numeric values; `NamespacedKey.getKey()`; `NamespacedKey.getNamespace()`; values loaded from server-controlled YAML config. These are server-controlled and cannot be influenced by a player.
 
 **Command Injection via `performCommand()` / `dispatchCommand()`**
 - Does any new or modified code call `player.performCommand(...)`, `Bukkit.dispatchCommand(...)`, or `server.execute(...)` with a string built from a user-influenced segment?
@@ -53,11 +53,11 @@ Show a diff block with the vulnerable line(s) prefixed `-` and the corrected lin
 ---
 
 **Diff block guidance per category:**
-- *MiniMessage injection:* `-` line shows the vulnerable `deserialize(userInput)` call. `+` lines show either `getLocalizedMessageAsComponent(player, LocalizationKey.KEY, Map.of("placeholder", value))` if a localization key exists or should be created, or `PlainTextComponentSerializer.plainText().serialize(Component.text(userInput))` to strip tags before embedding in a MiniMessage template string.
+- *MiniMessage injection:* `-` line shows the vulnerable `deserialize(userInput)` call. `+` lines show the preferred fix: route through `getLocalizedMessageAsComponent(player, LocalizationKey.KEY, Map.of("placeholder", value))` if a localization key exists or should be created. If dynamic injection into a template is needed, use `Placeholder.unparsed("placeholder", userInput)` so the value is treated as literal text and tags are not parsed — e.g., `miniMessage.deserialize("<gray>Name: <name>", Placeholder.unparsed("name", userInput))`. Alternatively, call `MiniMessage.escapeTags(userInput)` before embedding the value into a template string. Do NOT suggest `PlainTextComponentSerializer.plainText().serialize(Component.text(userInput))` — this returns the input unchanged and tags remain parseable.
 - *Command injection:* `-` line shows the concatenated `performCommand(...)`. `+` lines show the equivalent direct method or event call that avoids building a command string. If no direct path exists, show a validation guard that ensures the segment is safe before concatenating.
 - *Permission bypass:* `+` lines insert a `hasPermission("mcrpg.<category>.<action>")` guard and a player-feedback message before the sensitive operation.
 - *SQL injection:* `-` lines show the concatenated query. `+` lines show the equivalent `PreparedStatement` with `?` parameters and the corresponding `setString()` / `setInt()` calls.
 
 If nothing to flag: `No security concerns found in this diff.`
 
-> **Maintenance:** If a new injection vector or unsafe pattern is found during review, add it to this file and `.claude/commands/review-security.md` in the same PR.
+> **Maintenance:** If a new injection vector or unsafe pattern is found during review, add it to this file, `.claude/commands/review-security.md`, `.cursor/rules/core.mdc`, and `CLAUDE.md` in the same PR.

--- a/.cursor/rules/persona-security.mdc
+++ b/.cursor/rules/persona-security.mdc
@@ -39,24 +39,18 @@ Be precise: flag only when user-controlled data flows into a dangerous sink with
 
 ## Output Format
 
-Organize findings by file. For each file with concerns, use this structure:
+Organize findings by file. For each file with concerns, use this exact format:
 
-```
 ### `path/to/File.java`
 
-#### [Short issue title] — SEVERITY: HIGH / MEDIUM / LOW
-
+**[Short issue title] — SEVERITY: HIGH / MEDIUM / LOW**
 [One sentence: what the vulnerability is and how a player exploits it.]
 
-```diff
-- vulnerable code line(s)
-+ corrected code line(s)
-```
+Show a diff block with the vulnerable line(s) prefixed `-` and the corrected line(s) prefixed `+`.
 
-> **AI Agent Prompt:** In `ClassName.java`, the `methodName()` method (around line N) [describe
-> exact change needed]. [List any new imports.] [Explain why the fix does not change behavior
-> for legitimate players.] Keep this under ~150 words.
-```
+**AI Agent Prompt:** In `ClassName.java`, the `methodName()` method (around line N) [describe exact change needed]. [List any new imports.] [Explain why the fix does not change behavior for legitimate players.] Keep this under ~150 words.
+
+---
 
 **Diff block guidance per category:**
 - *MiniMessage injection:* `-` line shows the vulnerable `deserialize(userInput)` call. `+` lines show either `getLocalizedMessageAsComponent(player, LocalizationKey.KEY, Map.of("placeholder", value))` if a localization key exists or should be created, or `PlainTextComponentSerializer.plainText().serialize(Component.text(userInput))` to strip tags before embedding in a MiniMessage template string.

--- a/.cursor/rules/persona-server-owner.mdc
+++ b/.cursor/rules/persona-server-owner.mdc
@@ -48,10 +48,13 @@ You are a server administrator running McRPG on a live server. You have never re
 
 ## Output Format
 
-For each concern:
-> **CONCERN:** [what the issue is]
-> **WHY:** [what breaks or degrades for the server owner]
-> **WHERE:** [YAML file / key path / plugin.yml section]
+Report each finding using this exact format:
+
+**CONCERN:** [what the issue is]
+**WHY:** [what breaks or degrades for the server owner]
+**WHERE:** [YAML file / key path / plugin.yml section]
+
+---
 
 If nothing to flag: `No server owner concerns found in this diff.`
 

--- a/.cursor/rules/persona-testing.mdc
+++ b/.cursor/rules/persona-testing.mdc
@@ -47,10 +47,13 @@ You are a test engineer reviewing whether this change is adequately tested and w
 
 ## Output Format
 
-For each concern:
-> **CONCERN:** [what the issue is]
-> **WHY:** [what coverage gap or structural problem this creates]
-> **WHERE:** [test file / method / production class]
+Report each finding using this exact format:
+
+**CONCERN:** [what the issue is]
+**WHY:** [what coverage gap or structural problem this creates]
+**WHERE:** [test file / method / production class]
+
+---
 
 If nothing to flag: `No testing concerns found in this diff.`
 

--- a/.github/workflows/ai-persona-review.yml
+++ b/.github/workflows/ai-persona-review.yml
@@ -22,8 +22,12 @@ jobs:
   persona-review:
     runs-on: ubuntu-latest
     # For workflow_run: only proceed when the upstream workflow succeeded.
-    # For workflow_dispatch: always proceed.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # For workflow_dispatch: only allow dispatch from the default branch so an
+    # attacker cannot trigger the job from a fork or feature branch that contains
+    # modified persona files, which would be checked out and sent to the API.
+    if: >-
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     timeout-minutes: 10
     permissions:
       pull-requests: write   # post PR comments
@@ -36,9 +40,12 @@ jobs:
     steps:
       # Check out ONLY the persona prompt files from the default branch.
       # Never check out the PR head — that would expose secrets to untrusted code.
+      # The explicit ref ensures workflow_dispatch from any branch still reads
+      # persona files from the default branch, not the dispatching ref.
       - name: Checkout persona prompts (default branch)
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: .claude/commands/
 
       # Write a shared helper function used by every persona step.

--- a/.github/workflows/ai-persona-review.yml
+++ b/.github/workflows/ai-persona-review.yml
@@ -111,7 +111,7 @@ jobs:
           gh pr diff "$PR" > pr.diff
 
           # Note: avoid naming variables after shell builtins.
-          gui=false; config=false; api=false; tests_changed=false
+          gui=false; config=false; api=false; tests_changed=false; security=false
           while IFS= read -r f; do
             [[ "$f" =~ src/.*/gui/.*\.java ]]     && gui=true
             [[ "$f" =~ resources/localization/ ]]  && gui=true
@@ -120,6 +120,7 @@ jobs:
             [[ "$f" =~ src/.*/event/.*\.java ]]    && api=true
             [[ "$f" =~ src/.*/registry/.*\.java ]] && api=true
             [[ "$f" =~ src/main/.*\.java ]]        && tests_changed=true
+            [[ "$f" =~ src/main/.*\.java ]]        && security=true
           done < <(gh pr view "$PR" --json files --jq '.files[].path')
 
           jq -n \
@@ -128,7 +129,8 @@ jobs:
             --arg  config          "$config"        \
             --arg  api             "$api"           \
             --arg  tests_changed   "$tests_changed" \
-            '{"pr_number":$pr,"needs_gui":$gui,"needs_config":$config,"needs_api":$api,"needs_test":$tests_changed}' \
+            --arg  security        "$security"      \
+            '{"pr_number":$pr,"needs_gui":$gui,"needs_config":$config,"needs_api":$api,"needs_test":$tests_changed,"needs_security":$security}' \
             > review-meta.json
 
       # ── Common: parse metadata ───────────────────────────────────────────────
@@ -150,6 +152,7 @@ jobs:
             echo "needs_config=$(jq -r '.needs_config' review-meta.json)"
             echo "needs_api=$(jq -r '.needs_api' review-meta.json)"
             echo "needs_test=$(jq -r '.needs_test' review-meta.json)"
+            echo "needs_security=$(jq -r '.needs_security // "false"' review-meta.json)"
           } >> "$GITHUB_OUTPUT"
 
       # Truncate very large diffs before feeding them to any persona.
@@ -217,4 +220,19 @@ jobs:
         run: |
           source "$GITHUB_WORKSPACE/claude-helper.sh"
           call_claude "## Testing Review" ".claude/commands/review-testing.md"
+          gh pr comment "$PR_NUMBER" --body-file comment.md
+
+      # ── Persona: Security ────────────────────────────────────────────────────
+      # Runs when any main Java source file changes. Checks for MiniMessage/
+      # Adventure API injection, command injection via performCommand(),
+      # permission bypass, and SQL/data injection.
+      - name: Security Persona
+        if: steps.meta.outputs.proceed == 'true' && steps.meta.outputs.needs_security == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        run: |
+          source "$GITHUB_WORKSPACE/claude-helper.sh"
+          call_claude "## Security Review" ".claude/commands/review-security.md"
           gh pr comment "$PR_NUMBER" --body-file comment.md

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,6 +17,7 @@ jobs:
       needs_config: ${{ steps.detect.outputs.config }}
       needs_api: ${{ steps.detect.outputs.api }}
       needs_test: ${{ steps.detect.outputs.test }}
+      needs_security: ${{ steps.detect.outputs.security }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,6 +36,7 @@ jobs:
           config=false
           api=false
           test=false
+          security=false
 
           while IFS= read -r f; do
             [[ "$f" =~ src/.*/gui/.*\.java ]]        && gui=true
@@ -44,12 +46,14 @@ jobs:
             [[ "$f" =~ src/.*/event/.*\.java ]]       && api=true
             [[ "$f" =~ src/.*/registry/.*\.java ]]    && api=true
             [[ "$f" =~ src/main/.*\.java ]]           && test=true
+            [[ "$f" =~ src/main/.*\.java ]]           && security=true
           done <<< "$CHANGED"
 
-          echo "gui=$gui"       >> "$GITHUB_OUTPUT"
-          echo "config=$config" >> "$GITHUB_OUTPUT"
-          echo "api=$api"       >> "$GITHUB_OUTPUT"
-          echo "test=$test"     >> "$GITHUB_OUTPUT"
+          echo "gui=$gui"           >> "$GITHUB_OUTPUT"
+          echo "config=$config"     >> "$GITHUB_OUTPUT"
+          echo "api=$api"           >> "$GITHUB_OUTPUT"
+          echo "test=$test"         >> "$GITHUB_OUTPUT"
+          echo "security=$security" >> "$GITHUB_OUTPUT"
 
   # ------------------------------------------------------------------
   # Step 2: Generate diff and upload it with metadata as an artifact
@@ -59,10 +63,11 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     if: |
-      needs.detect-changes.outputs.needs_gui    == 'true' ||
-      needs.detect-changes.outputs.needs_config == 'true' ||
-      needs.detect-changes.outputs.needs_api    == 'true' ||
-      needs.detect-changes.outputs.needs_test   == 'true'
+      needs.detect-changes.outputs.needs_gui      == 'true' ||
+      needs.detect-changes.outputs.needs_config   == 'true' ||
+      needs.detect-changes.outputs.needs_api      == 'true' ||
+      needs.detect-changes.outputs.needs_test     == 'true' ||
+      needs.detect-changes.outputs.needs_security == 'true'
     permissions:
       contents: read
     steps:
@@ -83,7 +88,8 @@ jobs:
             "needs_gui": "${{ needs.detect-changes.outputs.needs_gui }}",
             "needs_config": "${{ needs.detect-changes.outputs.needs_config }}",
             "needs_api": "${{ needs.detect-changes.outputs.needs_api }}",
-            "needs_test": "${{ needs.detect-changes.outputs.needs_test }}"
+            "needs_test": "${{ needs.detect-changes.outputs.needs_test }}",
+            "needs_security": "${{ needs.detect-changes.outputs.needs_security }}"
           }
           EOF_META
 


### PR DESCRIPTION
## Summary

Introduces a new security engineer persona for automated code review that audits McRPG for player-exploitable injection vulnerabilities. The persona is invoked manually via `/review-security` and focuses on MiniMessage/Adventure API injection, command injection, permission bypass, and SQL/data injection vectors.

## Key Changes

- **New security review persona** (`.cursor/rules/persona-security.mdc`): Defines threat model (players with normal server access), safe patterns (Bukkit enums, UUIDs, integers), and dangerous sinks (MiniMessage deserialization, `performCommand()`, `dispatchCommand()`, unguarded privileged operations, string-concatenated SQL queries).

- **Security review command** (`.claude/commands/review-security.md`): Provides checklist-driven instructions for the AI agent to systematically audit code changes, with standardized output format (file-organized findings, severity levels, diff blocks, and corrective prompts).

- **CI/CD integration** (`.github/workflows/pr-review.yml` and `.ai-persona-review.yml`): 
  - Added `needs_security` detection flag that triggers when any `src/main/` Java file changes
  - Integrated security persona into the automated review pipeline alongside existing GUI, config, API, and testing personas
  - Security review runs conditionally and posts findings as PR comments

## Implementation Details

- **Threat model scope**: Focuses on player-controlled inputs (chat, command arguments, GUI interactions, sign/book text, anvil renames) flowing into dangerous sinks without sanitization. Server admin config and Bukkit enums are explicitly out of scope to reduce false positives.

- **Output format**: Findings organized by file with severity levels (HIGH/MEDIUM/LOW), one-sentence vulnerability descriptions, before/after code diffs, and AI agent prompts explaining the fix and why it preserves legitimate behavior.

- **Manual invocation**: Unlike other personas, security review is `alwaysApply: false` and must be explicitly requested via `/review-security` to avoid noise in routine coding sessions.

https://claude.ai/code/session_01A7DVvhYkmHxX9bAdxGmjSB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated security review added to the PR review pipeline to detect player-exploitable vulnerabilities when relevant.

* **Documentation**
  * Standardized reporting format across all review personas for consistent findings presentation.
  * Added comprehensive security review guidance and checklists to support the new security persona.
  * Updated persona guidance for GUI/UX, testing, server-owner, and extensibility reviews to follow the new format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->