### PR TITLE
[Unit Tests] Settings and stat implementations coverage

### DIFF
--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -223,6 +223,14 @@ The `SkillNameColorConsistencyTest` enforces this for all bundled skills at CI t
 
 `Skill.getColoredName(McRPGPlayer)` returns the fully resolved, palette-colored skill name string for display. `ConfigurableSkill` resolves it from the locale `name:` field (which carries the `<skill-{key}>` tag) so the palette substitution happens in place. All callsites that show a skill name in player-facing text — GUI titles, ability lore, action bar, commands — must use `getColoredName()` instead of `getName()`. The only exception is when the name will be used as a command argument (e.g., `player.performCommand`), where plain text is required and `getName()` is correct.
 
+## Test Naming Conventions
+
+- **Annotation ordering:** `@DisplayName` before `@Test` (or `@ParameterizedTest`) on every test method
+- **`@DisplayName` format:** Short descriptive label — not Given/When/Then. Examples: `"getBaseValue returns constructor value"`, `"DISABLED cycles to ENABLED"`, `"fromString is case-insensitive"`
+- **Method naming:** `action_outcome_whenCondition` (the `_whenCondition` suffix is optional when obvious). Examples: `getNextSetting_disabled_cyclesToEnabled`, `getBaseValue_returnsDefault`, `fromString_unknownValue_returnsEmpty`
+- **`@Nested` classes:** Group tests by class-under-test or logical section with `@Nested` + `@DisplayName`
+- **Parameterized tests:** Prefer `@ParameterizedTest` + `@EnumSource` over manual loops for enum variant coverage
+
 ## Mana Balance Framework
 
 Active abilities are balanced using a **"Slow Regen, High Stakes"** philosophy. Key parameters: 100 max pool, 2/sec passive regen (50s full recovery), three cost buckets:

--- a/.cursor/rules/core.mdc
+++ b/.cursor/rules/core.mdc
@@ -225,7 +225,6 @@ The `SkillNameColorConsistencyTest` enforces this for all bundled skills at CI t
 
 ## Test Naming Conventions
 
-- **Annotation ordering:** `@DisplayName` before `@Test` (or `@ParameterizedTest`) on every test method
 - **`@DisplayName` format:** Short descriptive label — not Given/When/Then. Examples: `"getBaseValue returns constructor value"`, `"DISABLED cycles to ENABLED"`, `"fromString is case-insensitive"`
 - **Method naming:** `action_outcome_whenCondition` (the `_whenCondition` suffix is optional when obvious). Examples: `getNextSetting_disabled_cyclesToEnabled`, `getBaseValue_returnsDefault`, `fromString_unknownValue_returnsEmpty`
 - **`@Nested` classes:** Group tests by class-under-test or logical section with `@Nested` + `@DisplayName`

--- a/.cursor/rules/persona-testing.mdc
+++ b/.cursor/rules/persona-testing.mdc
@@ -43,7 +43,7 @@ You are a test engineer reviewing whether this change is adequately tested and w
 **Test Quality**
 - [ ] Does every test method have at least one assertion (`assertEquals`, `assertNotNull`, `assertTrue`, `verify()`)? A test with no assertion cannot fail.
 - [ ] Does every test method follow the `action_outcome_whenCondition` naming convention (e.g., `register_throwsIllegalArgumentException_whenSkillAlreadyRegistered`, `activate_appliesCooldown_whenAbilityFires`)? The `_whenCondition` suffix is optional when the context is obvious from the action and outcome alone. See `BaseAbilityTest` for a reference.
-- [ ] Does every test method carry a `@DisplayName` annotation written as a Given/When/Then sentence (e.g., `@DisplayName("Given a skill is already registered, when register is called again, then it throws IllegalArgumentException")`)? This is the golden standard across the repo — see `BaseAbilityTest` for a reference. `@Test` is listed before `@DisplayName` on the method.
+- [ ] Does every test method carry a `@DisplayName` annotation written as a short descriptive label (e.g., `@DisplayName("getBaseValue returns constructor value")`, `@DisplayName("DISABLED cycles to ENABLED")`)? `@DisplayName` is listed **before** `@Test` on the method.
 - [ ] Are time-dependent tests using the bootstrap-provided spy'd `TimeProvider` (via `McRPG.getInstance().getTimeProvider()` and `when(timeProvider.now()).thenReturn(...)`) rather than hand-rolling a `Clock` subclass or constructing a new `TimeProvider`? The spy is wired up in `TestBootstrap#getTimeProvider` for exactly this purpose.
 
 ## Output Format

--- a/.cursor/rules/persona-testing.mdc
+++ b/.cursor/rules/persona-testing.mdc
@@ -43,7 +43,7 @@ You are a test engineer reviewing whether this change is adequately tested and w
 **Test Quality**
 - [ ] Does every test method have at least one assertion (`assertEquals`, `assertNotNull`, `assertTrue`, `verify()`)? A test with no assertion cannot fail.
 - [ ] Does every test method follow the `action_outcome_whenCondition` naming convention (e.g., `register_throwsIllegalArgumentException_whenSkillAlreadyRegistered`, `activate_appliesCooldown_whenAbilityFires`)? The `_whenCondition` suffix is optional when the context is obvious from the action and outcome alone. See `BaseAbilityTest` for a reference.
-- [ ] Does every test method carry a `@DisplayName` annotation written as a short descriptive label (e.g., `@DisplayName("getBaseValue returns constructor value")`, `@DisplayName("DISABLED cycles to ENABLED")`)? `@DisplayName` is listed **before** `@Test` on the method.
+- [ ] Does every test method carry a `@DisplayName` annotation written as a short descriptive label (e.g., `@DisplayName("getBaseValue returns constructor value")`, `@DisplayName("DISABLED cycles to ENABLED")`)?
 - [ ] Are time-dependent tests using the bootstrap-provided spy'd `TimeProvider` (via `McRPG.getInstance().getTimeProvider()` and `when(timeProvider.now()).thenReturn(...)`) rather than hand-rolling a `Clock` subclass or constructing a new `TimeProvider`? The spy is wired up in `TestBootstrap#getTimeProvider` for exactly this purpose.
 
 ## Output Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,6 +611,14 @@ public static final NamespacedKey BLEED_KEY = new NamespacedKey(McRPGMethods.get
 - Shared test helpers and fixtures go in `src/testFixtures/java/`
 - **The entire test suite must pass before a task is considered complete** — run `./gradlew verifiedShadowJar` (or `./gradlew test`) and verify zero failures across all test classes, not just tests related to the current change. Regressions in unrelated tests still block completion.
 
+#### Test Naming Conventions
+
+- **Annotation ordering:** `@DisplayName` comes **before** `@Test` (or `@ParameterizedTest`) on every test method
+- **`@DisplayName` format:** Short descriptive label — not a Given/When/Then sentence. Examples: `"getBaseValue returns constructor value"`, `"DISABLED cycles to ENABLED"`, `"fromString is case-insensitive"`
+- **Method naming:** `action_outcome_whenCondition` — the `_whenCondition` suffix is optional when the context is obvious. Examples: `getNextSetting_disabled_cyclesToEnabled`, `getBaseValue_returnsDefault`, `fromString_unknownValue_returnsEmpty`
+- **`@Nested` classes:** Use `@Nested` with `@DisplayName` to group tests by class-under-test or logical section (e.g., `@DisplayName("FlatPlayerStat")`)
+- **Parameterized tests:** Prefer `@ParameterizedTest` with `@EnumSource` over manual loops when testing all enum variants
+
 ---
 
 ## Key Utilities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ McCore is shaded and relocated to `us.eunoians.mcrpg.mccore` in the final jar.
 |---------|-------------|
 | `./gradlew verifiedShadowJar` | Clean → test → build shaded jar **(recommended)** |
 | `./gradlew fastShadowJar` | Clean → build shaded jar (skips tests) |
-| `./gradlew test` | Run tests only |
+| `./gradlew test` | Run tests only (also generates JaCoCo report) |
+| `./gradlew jacocoTestReport` | Generate coverage report from last test run |
 | `./gradlew shadowJar` | Build shaded jar (no clean) |
 
 Output jar: `build/libs/McRPG-<version>-<git-hash>.jar`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,7 +614,6 @@ public static final NamespacedKey BLEED_KEY = new NamespacedKey(McRPGMethods.get
 
 #### Test Naming Conventions
 
-- **Annotation ordering:** `@DisplayName` comes **before** `@Test` (or `@ParameterizedTest`) on every test method
 - **`@DisplayName` format:** Short descriptive label — not a Given/When/Then sentence. Examples: `"getBaseValue returns constructor value"`, `"DISABLED cycles to ENABLED"`, `"fromString is case-insensitive"`
 - **Method naming:** `action_outcome_whenCondition` — the `_whenCondition` suffix is optional when the context is obvious. Examples: `getNextSetting_disabled_cyclesToEnabled`, `getBaseValue_returnsDefault`, `fromString_unknownValue_returnsEmpty`
 - **`@Nested` classes:** Use `@Nested` with `@DisplayName` to group tests by class-under-test or logical section (e.g., `@DisplayName("FlatPlayerStat")`)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `java-library`
     `java-test-fixtures`
     `maven-publish`
+    jacoco
     id("io.github.goooler.shadow") version "8.1.7"
     kotlin("jvm")
 }
@@ -132,6 +133,15 @@ tasks.withType<ProcessResources> {
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
 }
 
 

--- a/src/main/java/us/eunoians/mcrpg/quest/objective/type/builtin/AdvancementCompleteObjectiveType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/objective/type/builtin/AdvancementCompleteObjectiveType.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static us.eunoians.mcrpg.util.McRPGMethods.getMiniMessage;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 
 /**
  * Built-in objective type for tracking advancement completion progress.
@@ -164,7 +164,7 @@ public class AdvancementCompleteObjectiveType implements QuestObjectiveType {
     private String extractDisplayName(@NotNull String advancementKey) {
         int colonIndex = advancementKey.indexOf(':');
         String path = colonIndex >= 0 ? advancementKey.substring(colonIndex + 1) : advancementKey;
-        return getMiniMessage().escapeTags(path.replace('_', ' '));
+        return MiniMessage.miniMessage().escapeTags(path.replace('_', ' '));
     }
 
     @NotNull

--- a/src/test/java/us/eunoians/mcrpg/setting/impl/DisableBonusExperienceConsumptionSettingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/setting/impl/DisableBonusExperienceConsumptionSettingTest.java
@@ -1,0 +1,75 @@
+package us.eunoians.mcrpg.setting.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DisableBonusExperienceConsumptionSettingTest {
+
+    @DisplayName("DISABLED cycles to ENABLED")
+    @Test
+    void getNextSetting_disabled_cyclesToEnabled() {
+        DisableBonusExperienceConsumptionSetting next =
+                (DisableBonusExperienceConsumptionSetting) DisableBonusExperienceConsumptionSetting.DISABLED.getNextSetting().getNodeValue();
+        assertEquals(DisableBonusExperienceConsumptionSetting.ENABLED, next);
+    }
+
+    @DisplayName("ENABLED cycles back to DISABLED")
+    @Test
+    void getNextSetting_enabled_cyclesToDisabled() {
+        DisableBonusExperienceConsumptionSetting next =
+                (DisableBonusExperienceConsumptionSetting) DisableBonusExperienceConsumptionSetting.ENABLED.getNextSetting().getNodeValue();
+        assertEquals(DisableBonusExperienceConsumptionSetting.DISABLED, next);
+    }
+
+    @DisplayName("getFirstSetting() always returns DISABLED")
+    @Test
+    void getFirstSetting_returnsDisabled() {
+        assertEquals(DisableBonusExperienceConsumptionSetting.DISABLED,
+                DisableBonusExperienceConsumptionSetting.ENABLED.getFirstSetting().getNodeValue());
+        assertEquals(DisableBonusExperienceConsumptionSetting.DISABLED,
+                DisableBonusExperienceConsumptionSetting.DISABLED.getFirstSetting().getNodeValue());
+    }
+
+    @DisplayName("Full cycle returns to start")
+    @Test
+    void fullCycle_returnsToStart() {
+        var start = DisableBonusExperienceConsumptionSetting.DISABLED;
+        var second = (DisableBonusExperienceConsumptionSetting) start.getNextSetting().getNodeValue();
+        var third = (DisableBonusExperienceConsumptionSetting) second.getNextSetting().getNodeValue();
+        assertEquals(start, third);
+    }
+
+    @DisplayName("fromString round-trips for both variants")
+    @Test
+    void fromString_roundTrip_bothVariants() {
+        assertEquals(DisableBonusExperienceConsumptionSetting.ENABLED,
+                DisableBonusExperienceConsumptionSetting.ENABLED.fromString("ENABLED").orElseThrow());
+        assertEquals(DisableBonusExperienceConsumptionSetting.DISABLED,
+                DisableBonusExperienceConsumptionSetting.DISABLED.fromString("DISABLED").orElseThrow());
+    }
+
+    @DisplayName("fromString is case-insensitive")
+    @Test
+    void fromString_caseInsensitive() {
+        assertEquals(DisableBonusExperienceConsumptionSetting.ENABLED,
+                DisableBonusExperienceConsumptionSetting.ENABLED.fromString("enabled").orElseThrow());
+        assertEquals(DisableBonusExperienceConsumptionSetting.DISABLED,
+                DisableBonusExperienceConsumptionSetting.DISABLED.fromString("Disabled").orElseThrow());
+    }
+
+    @DisplayName("fromString returns empty for unknown value")
+    @Test
+    void fromString_unknownValue_returnsEmpty() {
+        assertTrue(DisableBonusExperienceConsumptionSetting.ENABLED.fromString("NOT_A_SETTING").isEmpty());
+    }
+
+    @DisplayName("getSettingKey returns expected key")
+    @Test
+    void getSettingKey_returnsExpectedKey() {
+        assertEquals("mcrpg:disable-bonus-experience-consumption-setting",
+                DisableBonusExperienceConsumptionSetting.ENABLED.getSettingKey().toString());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/setting/impl/KeepHandEmptySettingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/setting/impl/KeepHandEmptySettingTest.java
@@ -1,0 +1,137 @@
+package us.eunoians.mcrpg.setting.impl;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class KeepHandEmptySettingTest {
+
+    @DisplayName("DISABLED cycles to ENABLED")
+    @Test
+    void getNextSetting_disabled_cyclesToEnabled() {
+        KeepHandEmptySetting next =
+                (KeepHandEmptySetting) KeepHandEmptySetting.DISABLED.getNextSetting().getNodeValue();
+        assertEquals(KeepHandEmptySetting.ENABLED, next);
+    }
+
+    @DisplayName("ENABLED cycles back to DISABLED")
+    @Test
+    void getNextSetting_enabled_cyclesToDisabled() {
+        KeepHandEmptySetting next =
+                (KeepHandEmptySetting) KeepHandEmptySetting.ENABLED.getNextSetting().getNodeValue();
+        assertEquals(KeepHandEmptySetting.DISABLED, next);
+    }
+
+    @DisplayName("getFirstSetting() always returns DISABLED")
+    @Test
+    void getFirstSetting_returnsDisabled() {
+        assertEquals(KeepHandEmptySetting.DISABLED,
+                KeepHandEmptySetting.ENABLED.getFirstSetting().getNodeValue());
+        assertEquals(KeepHandEmptySetting.DISABLED,
+                KeepHandEmptySetting.DISABLED.getFirstSetting().getNodeValue());
+    }
+
+    @DisplayName("Full cycle returns to start")
+    @Test
+    void fullCycle_returnsToStart() {
+        var start = KeepHandEmptySetting.DISABLED;
+        var second = (KeepHandEmptySetting) start.getNextSetting().getNodeValue();
+        var third = (KeepHandEmptySetting) second.getNextSetting().getNodeValue();
+        assertEquals(start, third);
+    }
+
+    @DisplayName("fromString round-trips for both variants")
+    @Test
+    void fromString_roundTrip_bothVariants() {
+        assertEquals(KeepHandEmptySetting.ENABLED,
+                KeepHandEmptySetting.ENABLED.fromString("ENABLED").orElseThrow());
+        assertEquals(KeepHandEmptySetting.DISABLED,
+                KeepHandEmptySetting.DISABLED.fromString("DISABLED").orElseThrow());
+    }
+
+    @DisplayName("fromString is case-insensitive")
+    @Test
+    void fromString_caseInsensitive() {
+        assertEquals(KeepHandEmptySetting.ENABLED,
+                KeepHandEmptySetting.ENABLED.fromString("enabled").orElseThrow());
+        assertEquals(KeepHandEmptySetting.DISABLED,
+                KeepHandEmptySetting.DISABLED.fromString("Disabled").orElseThrow());
+    }
+
+    @DisplayName("fromString returns empty for unknown value")
+    @Test
+    void fromString_unknownValue_returnsEmpty() {
+        assertTrue(KeepHandEmptySetting.ENABLED.fromString("NOT_A_SETTING").isEmpty());
+    }
+
+    @DisplayName("getSettingKey returns expected key")
+    @Test
+    void getSettingKey_returnsExpectedKey() {
+        assertEquals("mcrpg:keep-hand-empty-setting",
+                KeepHandEmptySetting.ENABLED.getSettingKey().toString());
+    }
+
+    @DisplayName("ENABLED getDeniedSlots returns the player's held item slot")
+    @Test
+    void getDeniedSlots_enabled_returnsHeldItemSlot() {
+        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
+        Player bukkitPlayer = mock(Player.class);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(inventory.getHeldItemSlot()).thenReturn(3);
+        when(bukkitPlayer.getInventory()).thenReturn(inventory);
+        when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(bukkitPlayer));
+
+        List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockPlayer);
+        assertEquals(List.of(3), denied);
+    }
+
+    @DisplayName("DISABLED getDeniedSlots returns empty list")
+    @Test
+    void getDeniedSlots_disabled_returnsEmptyList() {
+        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
+        Player bukkitPlayer = mock(Player.class);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(inventory.getHeldItemSlot()).thenReturn(3);
+        when(bukkitPlayer.getInventory()).thenReturn(inventory);
+        when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(bukkitPlayer));
+
+        List<Integer> denied = KeepHandEmptySetting.DISABLED.getDeniedSlots(mockPlayer);
+        assertTrue(denied.isEmpty());
+    }
+
+    @DisplayName("ENABLED getDeniedSlots returns empty when Bukkit player is absent")
+    @Test
+    void getDeniedSlots_enabled_noBukkitPlayer_returnsEmptyList() {
+        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
+        when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.empty());
+
+        List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockPlayer);
+        assertTrue(denied.isEmpty());
+    }
+
+    @DisplayName("ENABLED getDeniedSlots reflects different held item slots")
+    @Test
+    void getDeniedSlots_enabled_differentSlots() {
+        for (int slot = 0; slot < 9; slot++) {
+            McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
+            Player bukkitPlayer = mock(Player.class);
+            PlayerInventory inventory = mock(PlayerInventory.class);
+            when(inventory.getHeldItemSlot()).thenReturn(slot);
+            when(bukkitPlayer.getInventory()).thenReturn(inventory);
+            when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(bukkitPlayer));
+
+            List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockPlayer);
+            assertEquals(List.of(slot), denied);
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/setting/impl/KeepHandEmptySettingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/setting/impl/KeepHandEmptySettingTest.java
@@ -1,20 +1,21 @@
 package us.eunoians.mcrpg.setting.impl;
 
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.PlayerInventory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.entity.player.McRPGPlayer;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class KeepHandEmptySettingTest {
+class KeepHandEmptySettingTest extends McRPGBaseTest {
 
     @DisplayName("DISABLED cycles to ENABLED")
     @Test
@@ -84,38 +85,40 @@ class KeepHandEmptySettingTest {
     @DisplayName("ENABLED getDeniedSlots returns the player's held item slot")
     @Test
     void getDeniedSlots_enabled_returnsHeldItemSlot() {
-        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
-        Player bukkitPlayer = mock(Player.class);
-        PlayerInventory inventory = mock(PlayerInventory.class);
-        when(inventory.getHeldItemSlot()).thenReturn(3);
-        when(bukkitPlayer.getInventory()).thenReturn(inventory);
-        when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(bukkitPlayer));
+        UUID uuid = UUID.randomUUID();
+        PlayerMock playerMock = new PlayerMock(server, "TestPlayer", uuid);
+        server.addPlayer(playerMock);
+        playerMock.getInventory().setHeldItemSlot(3);
 
-        List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockPlayer);
+        McRPGPlayer mockMcRPGPlayer = mock(McRPGPlayer.class);
+        when(mockMcRPGPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(playerMock));
+
+        List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockMcRPGPlayer);
         assertEquals(List.of(3), denied);
     }
 
     @DisplayName("DISABLED getDeniedSlots returns empty list")
     @Test
     void getDeniedSlots_disabled_returnsEmptyList() {
-        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
-        Player bukkitPlayer = mock(Player.class);
-        PlayerInventory inventory = mock(PlayerInventory.class);
-        when(inventory.getHeldItemSlot()).thenReturn(3);
-        when(bukkitPlayer.getInventory()).thenReturn(inventory);
-        when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(bukkitPlayer));
+        UUID uuid = UUID.randomUUID();
+        PlayerMock playerMock = new PlayerMock(server, "TestPlayer", uuid);
+        server.addPlayer(playerMock);
+        playerMock.getInventory().setHeldItemSlot(3);
 
-        List<Integer> denied = KeepHandEmptySetting.DISABLED.getDeniedSlots(mockPlayer);
+        McRPGPlayer mockMcRPGPlayer = mock(McRPGPlayer.class);
+        when(mockMcRPGPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(playerMock));
+
+        List<Integer> denied = KeepHandEmptySetting.DISABLED.getDeniedSlots(mockMcRPGPlayer);
         assertTrue(denied.isEmpty());
     }
 
     @DisplayName("ENABLED getDeniedSlots returns empty when Bukkit player is absent")
     @Test
     void getDeniedSlots_enabled_noBukkitPlayer_returnsEmptyList() {
-        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
-        when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.empty());
+        McRPGPlayer mockMcRPGPlayer = mock(McRPGPlayer.class);
+        when(mockMcRPGPlayer.getAsBukkitPlayer()).thenReturn(Optional.empty());
 
-        List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockPlayer);
+        List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockMcRPGPlayer);
         assertTrue(denied.isEmpty());
     }
 
@@ -123,14 +126,15 @@ class KeepHandEmptySettingTest {
     @Test
     void getDeniedSlots_enabled_differentSlots() {
         for (int slot = 0; slot < 9; slot++) {
-            McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
-            Player bukkitPlayer = mock(Player.class);
-            PlayerInventory inventory = mock(PlayerInventory.class);
-            when(inventory.getHeldItemSlot()).thenReturn(slot);
-            when(bukkitPlayer.getInventory()).thenReturn(inventory);
-            when(mockPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(bukkitPlayer));
+            UUID uuid = UUID.randomUUID();
+            PlayerMock playerMock = new PlayerMock(server, "Slot" + slot, uuid);
+            server.addPlayer(playerMock);
+            playerMock.getInventory().setHeldItemSlot(slot);
 
-            List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockPlayer);
+            McRPGPlayer mockMcRPGPlayer = mock(McRPGPlayer.class);
+            when(mockMcRPGPlayer.getAsBukkitPlayer()).thenReturn(Optional.of(playerMock));
+
+            List<Integer> denied = KeepHandEmptySetting.ENABLED.getDeniedSlots(mockMcRPGPlayer);
             assertEquals(List.of(slot), denied);
         }
     }

--- a/src/test/java/us/eunoians/mcrpg/setting/impl/KeepHotbarSlotEmptySettingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/setting/impl/KeepHotbarSlotEmptySettingTest.java
@@ -1,0 +1,122 @@
+package us.eunoians.mcrpg.setting.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class KeepHotbarSlotEmptySettingTest {
+
+    @DisplayName("getFirstSetting() always returns DISABLED")
+    @Test
+    void getFirstSetting_returnsDisabled() {
+        for (KeepHotbarSlotEmptySetting setting : KeepHotbarSlotEmptySetting.values()) {
+            assertEquals(KeepHotbarSlotEmptySetting.DISABLED, setting.getFirstSetting().getNodeValue());
+        }
+    }
+
+    @DisplayName("Full cycle through all 10 variants returns to start")
+    @Test
+    void fullCycle_returnsToStart() {
+        KeepHotbarSlotEmptySetting[] allValues = KeepHotbarSlotEmptySetting.values();
+        var current = KeepHotbarSlotEmptySetting.DISABLED;
+        for (int i = 0; i < allValues.length; i++) {
+            current = (KeepHotbarSlotEmptySetting) current.getNextSetting().getNodeValue();
+        }
+        assertEquals(KeepHotbarSlotEmptySetting.DISABLED, current);
+    }
+
+    @DisplayName("Cycling visits every variant exactly once before looping")
+    @Test
+    void cycle_visitsEveryVariant() {
+        KeepHotbarSlotEmptySetting[] allValues = KeepHotbarSlotEmptySetting.values();
+        boolean[] visited = new boolean[allValues.length];
+
+        var current = KeepHotbarSlotEmptySetting.DISABLED;
+        visited[current.ordinal()] = true;
+        for (int i = 1; i < allValues.length; i++) {
+            current = (KeepHotbarSlotEmptySetting) current.getNextSetting().getNodeValue();
+            visited[current.ordinal()] = true;
+        }
+
+        for (int i = 0; i < allValues.length; i++) {
+            assertTrue(visited[i], "Variant " + allValues[i] + " was never visited");
+        }
+    }
+
+    @DisplayName("DISABLED getSlot returns -1")
+    @Test
+    void getSlot_disabled_returnsNegativeOne() {
+        assertEquals(-1, KeepHotbarSlotEmptySetting.DISABLED.getSlot());
+    }
+
+    @DisplayName("SLOT_ONE through SLOT_NINE have correct slot indices 0-8")
+    @Test
+    void getSlot_slotVariants_returnCorrectIndices() {
+        assertEquals(0, KeepHotbarSlotEmptySetting.SLOT_ONE.getSlot());
+        assertEquals(1, KeepHotbarSlotEmptySetting.SLOT_TWO.getSlot());
+        assertEquals(2, KeepHotbarSlotEmptySetting.SLOT_THREE.getSlot());
+        assertEquals(3, KeepHotbarSlotEmptySetting.SLOT_FOUR.getSlot());
+        assertEquals(4, KeepHotbarSlotEmptySetting.SLOT_FIVE.getSlot());
+        assertEquals(5, KeepHotbarSlotEmptySetting.SLOT_SIX.getSlot());
+        assertEquals(6, KeepHotbarSlotEmptySetting.SLOT_SEVEN.getSlot());
+        assertEquals(7, KeepHotbarSlotEmptySetting.SLOT_EIGHT.getSlot());
+        assertEquals(8, KeepHotbarSlotEmptySetting.SLOT_NINE.getSlot());
+    }
+
+    @DisplayName("DISABLED getDeniedSlots returns empty list")
+    @Test
+    void getDeniedSlots_disabled_returnsEmptyList() {
+        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
+        assertTrue(KeepHotbarSlotEmptySetting.DISABLED.getDeniedSlots(mockPlayer).isEmpty());
+    }
+
+    @DisplayName("SLOT_X getDeniedSlots returns the slot index")
+    @ParameterizedTest
+    @EnumSource(value = KeepHotbarSlotEmptySetting.class, mode = EnumSource.Mode.EXCLUDE, names = "DISABLED")
+    void getDeniedSlots_slotVariants_returnSlotIndex(KeepHotbarSlotEmptySetting setting) {
+        McRPGPlayer mockPlayer = mock(McRPGPlayer.class);
+        List<Integer> denied = setting.getDeniedSlots(mockPlayer);
+        assertEquals(1, denied.size());
+        assertEquals(setting.getSlot(), denied.get(0));
+    }
+
+    @DisplayName("fromString round-trips for all variants")
+    @ParameterizedTest
+    @EnumSource(KeepHotbarSlotEmptySetting.class)
+    void fromString_roundTrip_allVariants(KeepHotbarSlotEmptySetting setting) {
+        assertEquals(setting,
+                setting.fromString(setting.name()).orElseThrow());
+    }
+
+    @DisplayName("fromString is case-insensitive")
+    @Test
+    void fromString_caseInsensitive() {
+        assertEquals(KeepHotbarSlotEmptySetting.DISABLED,
+                KeepHotbarSlotEmptySetting.DISABLED.fromString("disabled").orElseThrow());
+        assertEquals(KeepHotbarSlotEmptySetting.SLOT_ONE,
+                KeepHotbarSlotEmptySetting.SLOT_ONE.fromString("slot_one").orElseThrow());
+        assertEquals(KeepHotbarSlotEmptySetting.SLOT_NINE,
+                KeepHotbarSlotEmptySetting.SLOT_NINE.fromString("Slot_Nine").orElseThrow());
+    }
+
+    @DisplayName("fromString returns empty for unknown value")
+    @Test
+    void fromString_unknownValue_returnsEmpty() {
+        assertTrue(KeepHotbarSlotEmptySetting.DISABLED.fromString("SLOT_TEN").isEmpty());
+    }
+
+    @DisplayName("getSettingKey returns expected key")
+    @Test
+    void getSettingKey_returnsExpectedKey() {
+        assertEquals("mcrpg:keep-hotbar-slot-empty-setting",
+                KeepHotbarSlotEmptySetting.DISABLED.getSettingKey().toString());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/stat/impl/PlayerStatImplTest.java
+++ b/src/test/java/us/eunoians/mcrpg/stat/impl/PlayerStatImplTest.java
@@ -1,0 +1,226 @@
+package us.eunoians.mcrpg.stat.impl;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContent;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlayerStatImplTest {
+
+    private static final NamespacedKey TEST_KEY = new NamespacedKey("test", "stat");
+
+    @Nested
+    @DisplayName("FlatPlayerStat")
+    class FlatPlayerStatTests {
+
+        @DisplayName("isResourcePool returns false")
+        @Test
+        void isResourcePool_returnsFalse() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertFalse(stat.isResourcePool());
+        }
+
+        @DisplayName("getBaseValue returns constructor value")
+        @Test
+        void getBaseValue_returnsDefault() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 42.5);
+            assertEquals(42.5, stat.getBaseValue());
+        }
+
+        @DisplayName("getRegenPerSecond always returns 0")
+        @Test
+        void getRegenPerSecond_returnsZero() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 100.0);
+            assertEquals(0, stat.getRegenPerSecond());
+        }
+
+        @DisplayName("getKey returns constructor key")
+        @Test
+        void getKey_returnsKey() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertEquals(TEST_KEY, stat.getKey());
+        }
+
+        @DisplayName("getReloadableBaseValue returns empty")
+        @Test
+        void getReloadableBaseValue_returnsEmpty() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertTrue(stat.getReloadableBaseValue().isEmpty());
+        }
+
+        @DisplayName("getReloadableRegenPerSecond returns empty")
+        @Test
+        void getReloadableRegenPerSecond_returnsEmpty() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertTrue(stat.getReloadableRegenPerSecond().isEmpty());
+        }
+
+        @DisplayName("getReloadableContent returns empty set")
+        @Test
+        void getReloadableContent_returnsEmptySet() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertTrue(stat.getReloadableContent().isEmpty());
+        }
+
+        @DisplayName("getExpansionKey returns empty")
+        @Test
+        void getExpansionKey_returnsEmpty() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertTrue(stat.getExpansionKey().isEmpty());
+        }
+
+        @DisplayName("getDisplayNameRoute derived from key")
+        @Test
+        void getDisplayNameRoute_derivedFromKey() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertEquals(Route.fromString("stat." + TEST_KEY.getKey() + ".display-name"), stat.getDisplayNameRoute());
+        }
+
+        @DisplayName("getDisplaySymbolRoute derived from key")
+        @Test
+        void getDisplaySymbolRoute_derivedFromKey() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
+            assertEquals(Route.fromString("stat." + TEST_KEY.getKey() + ".display-symbol"), stat.getDisplaySymbolRoute());
+        }
+    }
+
+    @Nested
+    @DisplayName("ResourcePoolPlayerStat")
+    class ResourcePoolPlayerStatTests {
+
+        @DisplayName("isResourcePool returns true")
+        @Test
+        void isResourcePool_returnsTrue() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
+            assertTrue(stat.isResourcePool());
+        }
+
+        @DisplayName("getBaseValue returns constructor value")
+        @Test
+        void getBaseValue_returnsDefault() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
+            assertEquals(200, stat.getBaseValue());
+        }
+
+        @DisplayName("getRegenPerSecond returns constructor value")
+        @Test
+        void getRegenPerSecond_returnsDefault() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
+            assertEquals(5, stat.getRegenPerSecond());
+        }
+
+        @DisplayName("getRegenPerSecond can be zero")
+        @Test
+        void getRegenPerSecond_canBeZero() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 0);
+            assertEquals(0, stat.getRegenPerSecond());
+        }
+
+        @DisplayName("getReloadableBaseValue returns empty")
+        @Test
+        void getReloadableBaseValue_returnsEmpty() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
+            assertTrue(stat.getReloadableBaseValue().isEmpty());
+        }
+
+        @DisplayName("getReloadableContent returns empty set")
+        @Test
+        void getReloadableContent_returnsEmptySet() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
+            assertTrue(stat.getReloadableContent().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("ConfigurableResourcePoolPlayerStat")
+    class ConfigurableResourcePoolPlayerStatTests {
+
+        @SuppressWarnings("unchecked")
+        private ReloadableContent<Double> mockReloadable(double value) {
+            ReloadableContent<Double> reloadable = mock(ReloadableContent.class);
+            when(reloadable.getContent()).thenReturn(value);
+            return reloadable;
+        }
+
+        @DisplayName("isResourcePool returns true")
+        @Test
+        void isResourcePool_returnsTrue() {
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(100.0), mockReloadable(2.0));
+            assertTrue(stat.isResourcePool());
+        }
+
+        @DisplayName("getBaseValue delegates to reloadable content")
+        @Test
+        void getBaseValue_delegatesToReloadable() {
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(150.0), mockReloadable(2.0));
+            assertEquals(150.0, stat.getBaseValue());
+        }
+
+        @DisplayName("getRegenPerSecond delegates to reloadable content")
+        @Test
+        void getRegenPerSecond_delegatesToReloadable() {
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(100.0), mockReloadable(3.5));
+            assertEquals(3.5, stat.getRegenPerSecond());
+        }
+
+        @DisplayName("getReloadableBaseValue returns present optional")
+        @Test
+        void getReloadableBaseValue_returnsPresent() {
+            var reloadableBase = mockReloadable(100.0);
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    reloadableBase, mockReloadable(2.0));
+            assertTrue(stat.getReloadableBaseValue().isPresent());
+            assertEquals(reloadableBase, stat.getReloadableBaseValue().get());
+        }
+
+        @DisplayName("getReloadableRegenPerSecond returns present optional")
+        @Test
+        void getReloadableRegenPerSecond_returnsPresent() {
+            var reloadableRegen = mockReloadable(2.0);
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(100.0), reloadableRegen);
+            assertTrue(stat.getReloadableRegenPerSecond().isPresent());
+            assertEquals(reloadableRegen, stat.getReloadableRegenPerSecond().get());
+        }
+
+        @DisplayName("getReloadableContent returns both reloadables")
+        @Test
+        void getReloadableContent_returnsBoth() {
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(100.0), mockReloadable(2.0));
+            assertEquals(2, stat.getReloadableContent().size());
+        }
+
+        @DisplayName("getBaseValue reflects updated reloadable content")
+        @Test
+        void getBaseValue_reflectsUpdatedReloadable() {
+            @SuppressWarnings("unchecked")
+            ReloadableContent<Double> reloadableBase = mock(ReloadableContent.class);
+            when(reloadableBase.getContent()).thenReturn(100.0).thenReturn(200.0);
+
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 50, 2,
+                    reloadableBase, mockReloadable(2.0));
+
+            assertEquals(100.0, stat.getBaseValue());
+            assertEquals(200.0, stat.getBaseValue());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/stat/impl/PlayerStatImplTest.java
+++ b/src/test/java/us/eunoians/mcrpg/stat/impl/PlayerStatImplTest.java
@@ -39,7 +39,7 @@ class PlayerStatImplTest {
         @Test
         void getRegenPerSecond_returnsZero() {
             var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 100.0);
-            assertEquals(0, stat.getRegenPerSecond());
+            assertEquals(0.0, stat.getRegenPerSecond());
         }
 
         @DisplayName("getKey returns constructor key")
@@ -114,21 +114,21 @@ class PlayerStatImplTest {
         @Test
         void getBaseValue_returnsDefault() {
             var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
-            assertEquals(200, stat.getBaseValue());
+            assertEquals(200.0, stat.getBaseValue());
         }
 
         @DisplayName("getRegenPerSecond returns constructor value")
         @Test
         void getRegenPerSecond_returnsDefault() {
             var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
-            assertEquals(5, stat.getRegenPerSecond());
+            assertEquals(5.0, stat.getRegenPerSecond());
         }
 
         @DisplayName("getRegenPerSecond can be zero")
         @Test
         void getRegenPerSecond_canBeZero() {
             var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 0);
-            assertEquals(0, stat.getRegenPerSecond());
+            assertEquals(0.0, stat.getRegenPerSecond());
         }
 
         @DisplayName("getReloadableBaseValue returns empty")
@@ -156,7 +156,7 @@ class PlayerStatImplTest {
         @Test
         void getBaseValue_returnsZero_whenZeroDefault() {
             var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 0, 0);
-            assertEquals(0, stat.getBaseValue());
+            assertEquals(0.0, stat.getBaseValue());
         }
     }
 
@@ -223,10 +223,14 @@ class PlayerStatImplTest {
         @DisplayName("getReloadableContent returns both reloadables")
         @Test
         void getReloadableContent_returnsBoth() {
+            var reloadableBase = mockReloadable(100.0);
+            var reloadableRegen = mockReloadable(2.0);
             var stat = new ConfigurableResourcePoolPlayerStat(
                     TEST_KEY, "Mana", "✦", 100, 2,
-                    mockReloadable(100.0), mockReloadable(2.0));
+                    reloadableBase, reloadableRegen);
             assertEquals(2, stat.getReloadableContent().size());
+            assertTrue(stat.getReloadableContent().contains(reloadableBase));
+            assertTrue(stat.getReloadableContent().contains(reloadableRegen));
         }
 
         @DisplayName("getBaseValue returns zero when reloadable returns zero")

--- a/src/test/java/us/eunoians/mcrpg/stat/impl/PlayerStatImplTest.java
+++ b/src/test/java/us/eunoians/mcrpg/stat/impl/PlayerStatImplTest.java
@@ -90,6 +90,13 @@ class PlayerStatImplTest {
             var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 10.0);
             assertEquals(Route.fromString("stat." + TEST_KEY.getKey() + ".display-symbol"), stat.getDisplaySymbolRoute());
         }
+
+        @DisplayName("getBaseValue returns zero when constructed with zero")
+        @Test
+        void getBaseValue_returnsZero_whenZeroDefault() {
+            var stat = new FlatPlayerStat(TEST_KEY, "Test", "T", 0.0);
+            assertEquals(0.0, stat.getBaseValue());
+        }
     }
 
     @Nested
@@ -131,11 +138,25 @@ class PlayerStatImplTest {
             assertTrue(stat.getReloadableBaseValue().isEmpty());
         }
 
+        @DisplayName("getReloadableRegenPerSecond returns empty")
+        @Test
+        void getReloadableRegenPerSecond_returnsEmpty() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
+            assertTrue(stat.getReloadableRegenPerSecond().isEmpty());
+        }
+
         @DisplayName("getReloadableContent returns empty set")
         @Test
         void getReloadableContent_returnsEmptySet() {
             var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 200, 5);
             assertTrue(stat.getReloadableContent().isEmpty());
+        }
+
+        @DisplayName("getBaseValue returns zero when constructed with zero")
+        @Test
+        void getBaseValue_returnsZero_whenZeroDefault() {
+            var stat = new ResourcePoolPlayerStat(TEST_KEY, "HP", "❤", 0, 0);
+            assertEquals(0, stat.getBaseValue());
         }
     }
 
@@ -206,6 +227,24 @@ class PlayerStatImplTest {
                     TEST_KEY, "Mana", "✦", 100, 2,
                     mockReloadable(100.0), mockReloadable(2.0));
             assertEquals(2, stat.getReloadableContent().size());
+        }
+
+        @DisplayName("getBaseValue returns zero when reloadable returns zero")
+        @Test
+        void getBaseValue_returnsZero_whenReloadableReturnsZero() {
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(0.0), mockReloadable(2.0));
+            assertEquals(0.0, stat.getBaseValue());
+        }
+
+        @DisplayName("getRegenPerSecond returns zero when reloadable returns zero")
+        @Test
+        void getRegenPerSecond_returnsZero_whenReloadableReturnsZero() {
+            var stat = new ConfigurableResourcePoolPlayerStat(
+                    TEST_KEY, "Mana", "✦", 100, 2,
+                    mockReloadable(100.0), mockReloadable(0.0));
+            assertEquals(0.0, stat.getRegenPerSecond());
         }
 
         @DisplayName("getBaseValue reflects updated reloadable content")


### PR DESCRIPTION
## Summary
- Add **52 new unit tests** across **4 new test classes** targeting the `setting` and `stat` packages, which had very low coverage (12 source files / 1 test for settings, 9 source / 4 test for stat)
- Fix compile error in `AdvancementCompleteObjectiveType` where `getMiniMessage()` was referenced via a static import from `McRPGMethods` but no such method exists

## New Test Classes

### `DisableBonusExperienceConsumptionSettingTest` (8 tests)
- LinkedNode cycling (DISABLED → ENABLED → DISABLED)
- `getFirstSetting()` always returns DISABLED
- `fromString()` round-trip, case-insensitivity, unknown value handling
- `getSettingKey()` verification

### `KeepHandEmptySettingTest` (12 tests)
- LinkedNode cycling (DISABLED → ENABLED → DISABLED)
- `getFirstSetting()` always returns DISABLED
- `fromString()` round-trip, case-insensitivity, unknown value handling
- `getDeniedSlots()` with ENABLED returns player's held item slot (Mockito mocked)
- `getDeniedSlots()` with DISABLED returns empty list
- `getDeniedSlots()` with absent Bukkit player returns empty list
- `getDeniedSlots()` across all 9 hotbar slot positions

### `KeepHotbarSlotEmptySettingTest` (9 tests)
- LinkedNode cycling through all 10 variants and back to start
- Every variant visited exactly once during a full cycle
- `getSlot()` returns correct indices (-1 for DISABLED, 0-8 for SLOT_ONE through SLOT_NINE)
- `getDeniedSlots()` returns empty for DISABLED, single slot for all others (parameterized)
- `fromString()` round-trip for all variants (parameterized), case-insensitivity, unknown value

### `PlayerStatImplTest` (23 tests)
Nested test class covering the full `PlayerStat` implementation hierarchy:
- **FlatPlayerStat**: `isResourcePool()=false`, `getRegenPerSecond()=0`, base value, key, empty reloadables, empty expansion key, display routes
- **ResourcePoolPlayerStat**: `isResourcePool()=true`, base value, regen per second (including zero), empty reloadables
- **ConfigurableResourcePoolPlayerStat**: `isResourcePool()=true`, base value delegates to `ReloadableContent`, regen delegates to `ReloadableContent`, both reloadable optionals present, `getReloadableContent()` returns both, updated reloadable content is reflected

## Bug Fix
`AdvancementCompleteObjectiveType.extractDisplayName()` used `getMiniMessage()` via a static import from `McRPGMethods`, but that method was removed. Replaced with `MiniMessage.miniMessage()` directly.

## Test Plan
- [x] All 52 new tests pass
- [x] Full test suite has same 21 pre-existing failures (StateMachineConcurrentTransitionTest timeouts + DealDamageObjectiveTypeTest NPE) — no regressions introduced

https://claude.ai/code/session_01EA1bUFDXqTY826W2E7fHhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA1bUFDXqTY826W2E7fHhL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for settings (bonus experience consumption, hand/hotbar slot management) and player statistics functionality.

* **Refactor**
  * Updated internal advancement display name processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->