### PR TITLE
[Unit Tests] Filter system, Loadout active abilities, and shared test stubs coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/loadout/LoadoutActiveAbilitiesTest.java
+++ b/src/test/java/us/eunoians/mcrpg/loadout/LoadoutActiveAbilitiesTest.java
@@ -1,0 +1,262 @@
+package us.eunoians.mcrpg.loadout;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.stub.StubComboActivatableAbility;
+import us.eunoians.mcrpg.ability.stub.StubPassiveUnlockableAbility;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.EntityManager;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+class LoadoutActiveAbilitiesTest extends McRPGBaseTest {
+
+    private AbilityRegistry abilityRegistry;
+    private YamlDocument mainConfig;
+
+    @BeforeEach
+    void setup() {
+        server.getPluginManager().clearEvents();
+
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+
+        mainConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+        when(mainConfig.getInt(MainConfigFile.MAX_LOADOUT_AMOUNT)).thenReturn(5);
+        when(mainConfig.getInt(MainConfigFile.MAX_PASSIVE_LOADOUT_SIZE)).thenReturn(2);
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+
+        Herbalism herbalism = new Herbalism(mcRPG);
+        skillRegistry.register(herbalism);
+
+        abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        EntityManager entityManager = new EntityManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(entityManager);
+
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+    }
+
+    @Nested
+    @DisplayName("getOrderedActiveAbilities")
+    class GetOrderedActiveAbilities {
+
+        @DisplayName("returns only combo-activatable abilities in insertion order")
+        @Test
+        void getOrderedActiveAbilities_returnsComboAbilitiesInOrder(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "combo_1");
+            StubComboActivatableAbility combo2 = new StubComboActivatableAbility(mcRPG, "combo_2");
+            StubPassiveUnlockableAbility passive = new StubPassiveUnlockableAbility(mcRPG, "passive_1");
+            abilityRegistry.register(combo1);
+            abilityRegistry.register(combo2);
+            abilityRegistry.register(passive);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+            loadout.addAbility(passive.getAbilityKey());
+            loadout.addAbility(combo2.getAbilityKey());
+
+            List<NamespacedKey> activeAbilities = loadout.getOrderedActiveAbilities();
+
+            assertEquals(2, activeAbilities.size());
+            assertEquals(combo1.getAbilityKey(), activeAbilities.get(0));
+            assertEquals(combo2.getAbilityKey(), activeAbilities.get(1));
+        }
+
+        @DisplayName("returns empty list when no combo-activatable abilities present")
+        @Test
+        void getOrderedActiveAbilities_returnsEmpty_whenNoComboAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubPassiveUnlockableAbility passive = new StubPassiveUnlockableAbility(mcRPG, "passive_only");
+            abilityRegistry.register(passive);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(passive.getAbilityKey());
+
+            List<NamespacedKey> activeAbilities = loadout.getOrderedActiveAbilities();
+
+            assertTrue(activeAbilities.isEmpty());
+        }
+
+        @DisplayName("returns empty list for empty loadout")
+        @Test
+        void getOrderedActiveAbilities_returnsEmpty_whenLoadoutEmpty(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            List<NamespacedKey> activeAbilities = loadout.getOrderedActiveAbilities();
+
+            assertTrue(activeAbilities.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("swapActivePositions")
+    class SwapActivePositions {
+
+        @DisplayName("swaps two active abilities by combo slot index")
+        @Test
+        void swapActivePositions_swapsAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "swap_combo_1");
+            StubComboActivatableAbility combo2 = new StubComboActivatableAbility(mcRPG, "swap_combo_2");
+            abilityRegistry.register(combo1);
+            abilityRegistry.register(combo2);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+            loadout.addAbility(combo2.getAbilityKey());
+
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+            assertEquals(combo2.getAbilityKey(), loadout.getOrderedActiveAbilities().get(1));
+
+            loadout.swapActivePositions(1, 2);
+
+            assertEquals(combo2.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(1));
+        }
+
+        @DisplayName("no-op when from and to slots are the same")
+        @Test
+        void swapActivePositions_noOp_whenSameSlot(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "same_slot_combo");
+            abilityRegistry.register(combo1);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+
+            loadout.swapActivePositions(1, 1);
+
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+        }
+
+        @DisplayName("no-op when from slot is out of range")
+        @Test
+        void swapActivePositions_noOp_whenFromSlotOutOfRange(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "oor_from_combo");
+            abilityRegistry.register(combo1);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+
+            loadout.swapActivePositions(5, 1);
+
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+        }
+
+        @DisplayName("no-op when to slot is out of range")
+        @Test
+        void swapActivePositions_noOp_whenToSlotOutOfRange(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "oor_to_combo");
+            abilityRegistry.register(combo1);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+
+            loadout.swapActivePositions(1, 5);
+
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+        }
+
+        @DisplayName("no-op when from slot is zero")
+        @Test
+        void swapActivePositions_noOp_whenFromSlotZero(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "zero_from");
+            StubComboActivatableAbility combo2 = new StubComboActivatableAbility(mcRPG, "zero_from_2");
+            abilityRegistry.register(combo1);
+            abilityRegistry.register(combo2);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+            loadout.addAbility(combo2.getAbilityKey());
+
+            loadout.swapActivePositions(0, 1);
+
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+            assertEquals(combo2.getAbilityKey(), loadout.getOrderedActiveAbilities().get(1));
+        }
+
+        @DisplayName("no-op when from slot is negative")
+        @Test
+        void swapActivePositions_noOp_whenFromSlotNegative(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "neg_from");
+            StubComboActivatableAbility combo2 = new StubComboActivatableAbility(mcRPG, "neg_from_2");
+            abilityRegistry.register(combo1);
+            abilityRegistry.register(combo2);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+            loadout.addAbility(combo2.getAbilityKey());
+
+            loadout.swapActivePositions(-1, 1);
+
+            assertEquals(combo1.getAbilityKey(), loadout.getOrderedActiveAbilities().get(0));
+            assertEquals(combo2.getAbilityKey(), loadout.getOrderedActiveAbilities().get(1));
+        }
+
+        @DisplayName("swaps correctly when passive abilities are interspersed")
+        @Test
+        void swapActivePositions_swapsCorrectly_whenPassivesInterspersed(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility combo1 = new StubComboActivatableAbility(mcRPG, "interspersed_combo_1");
+            StubPassiveUnlockableAbility passive = new StubPassiveUnlockableAbility(mcRPG, "interspersed_passive");
+            StubComboActivatableAbility combo2 = new StubComboActivatableAbility(mcRPG, "interspersed_combo_2");
+            abilityRegistry.register(combo1);
+            abilityRegistry.register(passive);
+            abilityRegistry.register(combo2);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(combo1.getAbilityKey());
+            loadout.addAbility(passive.getAbilityKey());
+            loadout.addAbility(combo2.getAbilityKey());
+
+            loadout.swapActivePositions(1, 2);
+
+            List<NamespacedKey> activeAbilities = loadout.getOrderedActiveAbilities();
+            assertEquals(combo2.getAbilityKey(), activeAbilities.get(0));
+            assertEquals(combo1.getAbilityKey(), activeAbilities.get(1));
+
+            List<NamespacedKey> allAbilities = loadout.getOrderedAbilities();
+            assertEquals(combo2.getAbilityKey(), allAbilities.get(0));
+            assertEquals(passive.getAbilityKey(), allAbilities.get(1));
+            assertEquals(combo1.getAbilityKey(), allAbilities.get(2));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/util/filter/ability/AbilityFilterTest.java
+++ b/src/test/java/us/eunoians/mcrpg/util/filter/ability/AbilityFilterTest.java
@@ -1,0 +1,446 @@
+package us.eunoians.mcrpg.util.filter.ability;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.ability.AbilityData;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityTierAttribute;
+import us.eunoians.mcrpg.ability.attribute.AbilityUnlockedAttribute;
+import us.eunoians.mcrpg.ability.impl.type.PassiveAbility;
+import us.eunoians.mcrpg.ability.impl.type.TierableAbility;
+import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+import us.eunoians.mcrpg.ability.stub.StubAbilityBase;
+import us.eunoians.mcrpg.ability.stub.StubActiveUnlockableAbility;
+import us.eunoians.mcrpg.ability.stub.StubInnateAbility;
+import us.eunoians.mcrpg.ability.stub.StubPassiveUnlockableAbility;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.EntityManager;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+class AbilityFilterTest extends McRPGBaseTest {
+
+    private YamlDocument mainConfig;
+
+    @BeforeEach
+    void setup() {
+        server.getPluginManager().clearEvents();
+
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+
+        mainConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+
+        Herbalism herbalism = new Herbalism(mcRPG);
+        skillRegistry.register(herbalism);
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        EntityManager entityManager = new EntityManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(entityManager);
+
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+
+        when(mainConfig.getInt(MainConfigFile.MAX_LOADOUT_AMOUNT)).thenReturn(5);
+        when(mainConfig.getInt(MainConfigFile.MAX_PASSIVE_LOADOUT_SIZE)).thenReturn(2);
+    }
+
+    @Nested
+    @DisplayName("ActiveAbilityFilter")
+    class ActiveAbilityFilterTests {
+
+        private ActiveAbilityFilter filter;
+
+        @BeforeEach
+        void setUp() {
+            filter = new ActiveAbilityFilter();
+        }
+
+        @DisplayName("retains unlockable non-passive abilities")
+        @Test
+        void filter_retainsActiveAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability active = createStubActiveUnlockable("active_one");
+            Ability passive = createStubPassiveUnlockable("passive_one");
+            Ability innate = createStubInnate("innate_one");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(active, passive, innate));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(active));
+        }
+
+        @DisplayName("returns empty when no active abilities present")
+        @Test
+        void filter_returnsEmpty_whenNoActiveAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability passive = createStubPassiveUnlockable("passive_one");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(passive));
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("returns empty for empty input")
+        @Test
+        void filter_returnsEmpty_whenInputEmpty(@NotNull McRPGPlayer mcRPGPlayer) {
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of());
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("PassiveAbilityFilter")
+    class PassiveAbilityFilterTests {
+
+        private PassiveAbilityFilter filter;
+
+        @BeforeEach
+        void setUp() {
+            filter = new PassiveAbilityFilter();
+        }
+
+        @DisplayName("retains unlockable passive abilities")
+        @Test
+        void filter_retainsPassiveAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability active = createStubActiveUnlockable("active_one");
+            Ability passive = createStubPassiveUnlockable("passive_one");
+            Ability innate = createStubInnate("innate_one");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(active, passive, innate));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(passive));
+        }
+
+        @DisplayName("excludes non-unlockable passive abilities")
+        @Test
+        void filter_excludesInnatePassive(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability innate = createStubInnate("innate_one");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(innate));
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("UnlockableAbilityFilter")
+    class UnlockableAbilityFilterTests {
+
+        private UnlockableAbilityFilter filter;
+
+        @BeforeEach
+        void setUp() {
+            filter = new UnlockableAbilityFilter();
+        }
+
+        @DisplayName("retains all unlockable abilities regardless of active/passive")
+        @Test
+        void filter_retainsAllUnlockable(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability active = createStubActiveUnlockable("active_one");
+            Ability passive = createStubPassiveUnlockable("passive_one");
+            Ability innate = createStubInnate("innate_one");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(active, passive, innate));
+
+            assertEquals(2, result.size());
+            assertTrue(result.contains(active));
+            assertTrue(result.contains(passive));
+            assertFalse(result.contains(innate));
+        }
+
+        @DisplayName("returns empty when no unlockable abilities present")
+        @Test
+        void filter_returnsEmpty_whenNoUnlockableAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability innate = createStubInnate("innate_one");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(innate));
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("InnateAbilityFilter")
+    class InnateAbilityFilterTests {
+
+        private InnateAbilityFilter filter;
+
+        @BeforeEach
+        void setUp() {
+            filter = new InnateAbilityFilter();
+        }
+
+        @DisplayName("retains abilities without unlock attribute")
+        @Test
+        void filter_retainsInnateAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability innate = createStubInnate("innate_one");
+            SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
+            skillHolder.addAvailableAbility(innate.getAbilityKey());
+            skillHolder.addAbilityData(new AbilityData(innate.getAbilityKey()));
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(innate));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(innate));
+        }
+
+        @DisplayName("excludes abilities with unlock attribute")
+        @Test
+        void filter_excludesUnlockableAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability unlockable = createStubPassiveUnlockable("passive_one");
+            SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
+            skillHolder.addAvailableAbility(unlockable.getAbilityKey());
+            AbilityData data = new AbilityData(
+                    unlockable.getAbilityKey(),
+                    new AbilityUnlockedAttribute(false)
+            );
+            skillHolder.addAbilityData(data);
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(unlockable));
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("retains innate ability even when no explicit data was added")
+        @Test
+        void filter_retainsInnateAbility_whenNoExplicitDataAdded(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability innate = createStubInnate("innate_auto_data");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(innate));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(innate));
+        }
+
+        @DisplayName("excludes abilities not registered in the ability registry")
+        @Test
+        void filter_excludesUnregisteredAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubInnateAbility unregistered = new StubInnateAbility(mcRPG, "unregistered_innate");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(unregistered));
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("AbilityUpgradeFilter")
+    class AbilityUpgradeFilterTests {
+
+        private AbilityUpgradeFilter filter;
+
+        @BeforeEach
+        void setUp() {
+            filter = new AbilityUpgradeFilter();
+        }
+
+        @DisplayName("excludes non-tierable abilities")
+        @Test
+        void filter_excludesNonTierable(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability nonTierable = createStubActiveUnlockable("non_tierable");
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(nonTierable));
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("excludes abilities without ability data")
+        @Test
+        void filter_excludesAbilitiesWithoutData(@NotNull McRPGPlayer mcRPGPlayer) {
+            Ability tierable = createStubTierableUnlockable("tierable_no_data", 5);
+            AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+            abilityRegistry.register(tierable);
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(tierable));
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("excludes abilities at max tier")
+        @Test
+        void filter_excludesAbilitiesAtMaxTier(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubTierableUnlockableAbility tierable = createStubTierableUnlockable("maxed_out", 3);
+            AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+            abilityRegistry.register(tierable);
+
+            SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
+            skillHolder.addAvailableAbility(tierable.getAbilityKey());
+            AbilityData data = new AbilityData(
+                    tierable.getAbilityKey(),
+                    new AbilityTierAttribute(3),
+                    new AbilityUnlockedAttribute(true)
+            );
+            skillHolder.addAbilityData(data);
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(tierable));
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("retains abilities below max tier that are unlocked")
+        @Test
+        void filter_retainsUpgradeableAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubTierableUnlockableAbility tierable = createStubTierableUnlockable("upgradeable", 5);
+            AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+            abilityRegistry.register(tierable);
+
+            SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
+            skillHolder.addAvailableAbility(tierable.getAbilityKey());
+            AbilityData data = new AbilityData(
+                    tierable.getAbilityKey(),
+                    new AbilityTierAttribute(2),
+                    new AbilityUnlockedAttribute(true)
+            );
+            skillHolder.addAbilityData(data);
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(tierable));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(tierable));
+        }
+
+        @DisplayName("excludes abilities that are not unlocked")
+        @Test
+        void filter_excludesLockedAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubTierableUnlockableAbility tierable = createStubTierableUnlockable("locked_tierable", 5);
+            AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+            abilityRegistry.register(tierable);
+
+            SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
+            skillHolder.addAvailableAbility(tierable.getAbilityKey());
+            AbilityData data = new AbilityData(
+                    tierable.getAbilityKey(),
+                    new AbilityTierAttribute(1),
+                    new AbilityUnlockedAttribute(false)
+            );
+            skillHolder.addAbilityData(data);
+
+            Collection<Ability> result = filter.filter(mcRPGPlayer, List.of(tierable));
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    private StubActiveUnlockableAbility createStubActiveUnlockable(@NotNull String name) {
+        StubActiveUnlockableAbility ability = new StubActiveUnlockableAbility(mcRPG, name);
+        AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+        abilityRegistry.register(ability);
+        return ability;
+    }
+
+    private StubPassiveUnlockableAbility createStubPassiveUnlockable(@NotNull String name) {
+        StubPassiveUnlockableAbility ability = new StubPassiveUnlockableAbility(mcRPG, name);
+        AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+        abilityRegistry.register(ability);
+        return ability;
+    }
+
+    private StubInnateAbility createStubInnate(@NotNull String name) {
+        StubInnateAbility ability = new StubInnateAbility(mcRPG, name);
+        AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+        abilityRegistry.register(ability);
+        return ability;
+    }
+
+    private StubTierableUnlockableAbility createStubTierableUnlockable(@NotNull String name, int maxTier) {
+        return new StubTierableUnlockableAbility(mcRPG, name, maxTier);
+    }
+
+    static final class StubTierableUnlockableAbility extends StubAbilityBase implements TierableAbility, UnlockableAbility, PassiveAbility {
+
+        private final int maxTier;
+
+        StubTierableUnlockableAbility(@NotNull McRPG plugin, @NotNull String name, int maxTier) {
+            super(plugin, name);
+            this.maxTier = maxTier;
+        }
+
+        @Override
+        public int getMaxTier() {
+            return maxTier;
+        }
+
+        @Override
+        public int getUnlockLevelForTier(int tier) {
+            return 1;
+        }
+
+        @Override
+        public int getCurrentAbilityTier(@NotNull AbilityHolder abilityHolder) {
+            return 1;
+        }
+
+        @NotNull
+        @Override
+        public Optional<NamespacedKey> getUpgradeQuestKey(int tier) {
+            return Optional.empty();
+        }
+
+        @Override
+        public int getUnlockLevel() {
+            return 1;
+        }
+
+        @NotNull
+        @Override
+        public Set<NamespacedKey> getApplicableAttributes() {
+            return Set.of(
+                    AbilityAttributeRegistry.ABILITY_TOGGLED_OFF_ATTRIBUTE_KEY,
+                    AbilityAttributeRegistry.ABILITY_UNLOCKED_ATTRIBUTE,
+                    AbilityAttributeRegistry.ABILITY_TIER_ATTRIBUTE_KEY
+            );
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/util/filter/core/McRPGChainPlayerContextFilterTest.java
+++ b/src/test/java/us/eunoians/mcrpg/util/filter/core/McRPGChainPlayerContextFilterTest.java
@@ -1,0 +1,137 @@
+package us.eunoians.mcrpg.util.filter.core;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.stub.StubActiveUnlockableAbility;
+import us.eunoians.mcrpg.ability.stub.StubInnateAbility;
+import us.eunoians.mcrpg.ability.stub.StubPassiveUnlockableAbility;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.EntityManager;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.util.filter.ability.ActiveAbilityFilter;
+import us.eunoians.mcrpg.util.filter.ability.UnlockableAbilityFilter;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+class McRPGChainPlayerContextFilterTest extends McRPGBaseTest {
+
+    @BeforeEach
+    void setup() {
+        server.getPluginManager().clearEvents();
+
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+
+        YamlDocument mainConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+        when(mainConfig.getInt(MainConfigFile.MAX_LOADOUT_AMOUNT)).thenReturn(5);
+        when(mainConfig.getInt(MainConfigFile.MAX_PASSIVE_LOADOUT_SIZE)).thenReturn(2);
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+
+        Herbalism herbalism = new Herbalism(mcRPG);
+        skillRegistry.register(herbalism);
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        EntityManager entityManager = new EntityManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(entityManager);
+
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+    }
+
+    @DisplayName("chains multiple filters in sequence")
+    @Test
+    void filter_chainsFiltersSequentially(@NotNull McRPGPlayer mcRPGPlayer) {
+        Ability activeUnlockable = new StubActiveUnlockableAbility(mcRPG, "active_chain");
+        Ability passiveUnlockable = new StubPassiveUnlockableAbility(mcRPG, "passive_chain");
+        Ability innate = new StubInnateAbility(mcRPG, "innate_chain");
+
+        AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+        abilityRegistry.register(activeUnlockable);
+        abilityRegistry.register(passiveUnlockable);
+        abilityRegistry.register(innate);
+
+        McRPGChainPlayerContextFilter<Ability> chain = new McRPGChainPlayerContextFilter<>(
+                new UnlockableAbilityFilter(),
+                new ActiveAbilityFilter()
+        );
+
+        Collection<Ability> result = chain.filter(mcRPGPlayer, List.of(activeUnlockable, passiveUnlockable, innate));
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(activeUnlockable));
+    }
+
+    @DisplayName("single filter in chain behaves like standalone filter")
+    @Test
+    void filter_singleFilterBehavesLikeStandalone(@NotNull McRPGPlayer mcRPGPlayer) {
+        Ability activeUnlockable = new StubActiveUnlockableAbility(mcRPG, "single_active");
+        Ability innate = new StubInnateAbility(mcRPG, "single_innate");
+
+        AbilityRegistry abilityRegistry = RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY);
+        abilityRegistry.register(activeUnlockable);
+        abilityRegistry.register(innate);
+
+        McRPGChainPlayerContextFilter<Ability> chain = new McRPGChainPlayerContextFilter<>(
+                new UnlockableAbilityFilter()
+        );
+
+        Collection<Ability> result = chain.filter(mcRPGPlayer, List.of(activeUnlockable, innate));
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(activeUnlockable));
+    }
+
+    @DisplayName("empty input returns empty through chain")
+    @Test
+    void filter_returnsEmpty_whenInputEmpty(@NotNull McRPGPlayer mcRPGPlayer) {
+        McRPGChainPlayerContextFilter<Ability> chain = new McRPGChainPlayerContextFilter<>(
+                new UnlockableAbilityFilter(),
+                new ActiveAbilityFilter()
+        );
+
+        Collection<Ability> result = chain.filter(mcRPGPlayer, List.of());
+
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/util/filter/key/AbilityKeyFilterTest.java
+++ b/src/test/java/us/eunoians/mcrpg/util/filter/key/AbilityKeyFilterTest.java
@@ -1,0 +1,231 @@
+package us.eunoians.mcrpg.util.filter.key;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.stub.StubComboActivatableAbility;
+import us.eunoians.mcrpg.ability.stub.StubInnateAbility;
+import us.eunoians.mcrpg.ability.stub.StubPassiveUnlockableAbility;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.EntityManager;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.loadout.Loadout;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+class AbilityKeyFilterTest extends McRPGBaseTest {
+
+    private AbilityRegistry abilityRegistry;
+    private YamlDocument mainConfig;
+
+    @BeforeEach
+    void setup() {
+        server.getPluginManager().clearEvents();
+
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+
+        mainConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+
+        Herbalism herbalism = new Herbalism(mcRPG);
+        skillRegistry.register(herbalism);
+
+        abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        EntityManager entityManager = new EntityManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(entityManager);
+
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+
+        when(mainConfig.getInt(MainConfigFile.MAX_LOADOUT_AMOUNT)).thenReturn(5);
+        when(mainConfig.getInt(MainConfigFile.MAX_PASSIVE_LOADOUT_SIZE)).thenReturn(2);
+    }
+
+    @Nested
+    @DisplayName("AbilityKeyComboActivatableFilter")
+    class ComboActivatableFilterTests {
+
+        @DisplayName("comboActivatableOnly=true retains only combo-activatable keys")
+        @Test
+        void filter_retainsComboActivatable_whenTrue(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility comboAbility = new StubComboActivatableAbility(mcRPG, "combo_ability");
+            StubPassiveUnlockableAbility passiveAbility = new StubPassiveUnlockableAbility(mcRPG, "passive_ability");
+            abilityRegistry.register(comboAbility);
+            abilityRegistry.register(passiveAbility);
+
+            AbilityKeyComboActivatableFilter filter = new AbilityKeyComboActivatableFilter(true);
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer,
+                    List.of(comboAbility.getAbilityKey(), passiveAbility.getAbilityKey()));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(comboAbility.getAbilityKey()));
+        }
+
+        @DisplayName("comboActivatableOnly=false retains only non-combo-activatable keys")
+        @Test
+        void filter_retainsNonComboActivatable_whenFalse(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility comboAbility = new StubComboActivatableAbility(mcRPG, "combo_ability");
+            StubPassiveUnlockableAbility passiveAbility = new StubPassiveUnlockableAbility(mcRPG, "passive_ability");
+            abilityRegistry.register(comboAbility);
+            abilityRegistry.register(passiveAbility);
+
+            AbilityKeyComboActivatableFilter filter = new AbilityKeyComboActivatableFilter(false);
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer,
+                    List.of(comboAbility.getAbilityKey(), passiveAbility.getAbilityKey()));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(passiveAbility.getAbilityKey()));
+        }
+
+        @DisplayName("returns empty for empty input")
+        @Test
+        void filter_returnsEmpty_whenInputEmpty(@NotNull McRPGPlayer mcRPGPlayer) {
+            AbilityKeyComboActivatableFilter filter = new AbilityKeyComboActivatableFilter(true);
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer, List.of());
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("AbilityKeyUnlockedFilter")
+    class UnlockedFilterTests {
+
+        private AbilityKeyUnlockedFilter filter;
+
+        @BeforeEach
+        void setUp() {
+            filter = new AbilityKeyUnlockedFilter();
+        }
+
+        @DisplayName("retains keys for registered unlockable abilities")
+        @Test
+        void filter_retainsUnlockableKeys(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubPassiveUnlockableAbility unlockable = new StubPassiveUnlockableAbility(mcRPG, "unlockable_one");
+            StubInnateAbility innate = new StubInnateAbility(mcRPG, "innate_one");
+            abilityRegistry.register(unlockable);
+            abilityRegistry.register(innate);
+
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer,
+                    List.of(unlockable.getAbilityKey(), innate.getAbilityKey()));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(unlockable.getAbilityKey()));
+        }
+
+        @DisplayName("excludes unregistered ability keys")
+        @Test
+        void filter_excludesUnregisteredKeys(@NotNull McRPGPlayer mcRPGPlayer) {
+            NamespacedKey unregistered = new NamespacedKey(mcRPG, "unregistered");
+
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer, List.of(unregistered));
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("returns empty for empty input")
+        @Test
+        void filter_returnsEmpty_whenInputEmpty(@NotNull McRPGPlayer mcRPGPlayer) {
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer, List.of());
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("AbilityKeyInLoadoutFilter")
+    class InLoadoutFilterTests {
+
+        @DisplayName("without replacement target, retains keys that can be added")
+        @Test
+        void filter_retainsAddableKeys_whenNoReplacement(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility active1 = new StubComboActivatableAbility(mcRPG, "active_1");
+            StubComboActivatableAbility active2 = new StubComboActivatableAbility(mcRPG, "active_2");
+            abilityRegistry.register(active1);
+            abilityRegistry.register(active2);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+
+            AbilityKeyInLoadoutFilter filter = new AbilityKeyInLoadoutFilter(loadout, null);
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer,
+                    List.of(active1.getAbilityKey(), active2.getAbilityKey()));
+
+            assertEquals(2, result.size());
+        }
+
+        @DisplayName("with replacement target, uses canAbilityBeReplacedIntoLoadout")
+        @Test
+        void filter_usesReplacementLogic_whenReplacementProvided(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility active1 = new StubComboActivatableAbility(mcRPG, "active_replace_1");
+            StubComboActivatableAbility active2 = new StubComboActivatableAbility(mcRPG, "active_replace_2");
+            abilityRegistry.register(active1);
+            abilityRegistry.register(active2);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(active1.getAbilityKey());
+
+            AbilityKeyInLoadoutFilter filter = new AbilityKeyInLoadoutFilter(loadout, active1.getAbilityKey());
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer, List.of(active2.getAbilityKey()));
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains(active2.getAbilityKey()));
+        }
+
+        @DisplayName("excludes abilities already in loadout when adding without replacement")
+        @Test
+        void filter_excludesDuplicates_whenAdding(@NotNull McRPGPlayer mcRPGPlayer) {
+            StubComboActivatableAbility active1 = new StubComboActivatableAbility(mcRPG, "active_dup_1");
+            abilityRegistry.register(active1);
+
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(active1.getAbilityKey());
+
+            AbilityKeyInLoadoutFilter filter = new AbilityKeyInLoadoutFilter(loadout, null);
+            Collection<NamespacedKey> result = filter.filter(mcRPGPlayer, List.of(active1.getAbilityKey()));
+
+            assertTrue(result.isEmpty());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/util/filter/skill/SkillHolderDataPresentFilterTest.java
+++ b/src/test/java/us/eunoians/mcrpg/util/filter/skill/SkillHolderDataPresentFilterTest.java
@@ -1,0 +1,101 @@
+package us.eunoians.mcrpg.util.filter.skill;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.EntityManager;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.Skill;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(McRPGPlayerExtension.class)
+class SkillHolderDataPresentFilterTest extends McRPGBaseTest {
+
+    private SkillHolderDataPresentFilter filter;
+    private Herbalism herbalism;
+
+    @BeforeEach
+    void setup() {
+        server.getPluginManager().clearEvents();
+
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+
+        YamlDocument mainConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+        when(mainConfig.getInt(MainConfigFile.MAX_LOADOUT_AMOUNT)).thenReturn(5);
+        when(mainConfig.getInt(MainConfigFile.MAX_PASSIVE_LOADOUT_SIZE)).thenReturn(2);
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+
+        herbalism = new Herbalism(mcRPG);
+        skillRegistry.register(herbalism);
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        EntityManager entityManager = new EntityManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(entityManager);
+
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+
+        filter = new SkillHolderDataPresentFilter();
+    }
+
+    @DisplayName("retains skills with holder data present")
+    @Test
+    void filter_retainsSkillsWithData(@NotNull McRPGPlayer mcRPGPlayer) {
+        SkillHolder skillHolder = mcRPGPlayer.asSkillHolder();
+        skillHolder.addSkillHolderData(herbalism);
+
+        Collection<Skill> result = filter.filter(mcRPGPlayer, List.of(herbalism));
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains(herbalism));
+    }
+
+    @DisplayName("excludes skills without holder data")
+    @Test
+    void filter_excludesSkillsWithoutData(@NotNull McRPGPlayer mcRPGPlayer) {
+        Collection<Skill> result = filter.filter(mcRPGPlayer, List.of(herbalism));
+
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubAbilityBase.java
+++ b/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubAbilityBase.java
@@ -1,0 +1,99 @@
+package us.eunoians.mcrpg.ability.stub;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.builder.item.ability.AbilityItemBuilder;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Minimal {@link Ability} base for unit test stubs. Subclasses implement
+ * the interface mix-ins that match the ability type under test
+ * (e.g., {@link us.eunoians.mcrpg.ability.impl.type.ActiveAbility},
+ * {@link us.eunoians.mcrpg.ability.impl.type.PassiveAbility}).
+ */
+public abstract class StubAbilityBase implements Ability {
+
+    private final NamespacedKey key;
+
+    protected StubAbilityBase(@NotNull McRPG plugin, @NotNull String name) {
+        this.key = new NamespacedKey(plugin, name);
+    }
+
+    @NotNull
+    @Override
+    public org.bukkit.plugin.Plugin getPlugin() {
+        return McRPG.getInstance();
+    }
+
+    @NotNull
+    @Override
+    public NamespacedKey getAbilityKey() {
+        return key;
+    }
+
+    @NotNull
+    @Override
+    public Set<NamespacedKey> getApplicableAttributes() {
+        return Set.of();
+    }
+
+    @NotNull
+    @Override
+    public String getDatabaseName() {
+        return key.getKey();
+    }
+
+    @NotNull
+    @Override
+    public String getName(@NotNull McRPGPlayer player) {
+        return key.getKey();
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return key.getKey();
+    }
+
+    @NotNull
+    @Override
+    public Component getDisplayName(@NotNull McRPGPlayer player) {
+        return Component.text(key.getKey());
+    }
+
+    @NotNull
+    @Override
+    public Component getDisplayName() {
+        return Component.text(key.getKey());
+    }
+
+    @NotNull
+    @Override
+    public AbilityItemBuilder getDisplayItemBuilder(@NotNull McRPGPlayer player) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean activateAbility(@NotNull AbilityHolder abilityHolder, @NotNull Event event) {
+        return true;
+    }
+
+    @Override
+    public boolean isAbilityEnabled() {
+        return true;
+    }
+
+    @NotNull
+    @Override
+    public Optional<NamespacedKey> getExpansionKey() {
+        return Optional.empty();
+    }
+}

--- a/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubActiveUnlockableAbility.java
+++ b/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubActiveUnlockableAbility.java
@@ -1,0 +1,25 @@
+package us.eunoians.mcrpg.ability.stub;
+
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.ability.impl.type.ActiveAbility;
+import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+
+/**
+ * Stub combining {@link ActiveAbility} and {@link UnlockableAbility} for tests.
+ */
+public final class StubActiveUnlockableAbility extends StubAbilityBase implements UnlockableAbility, ActiveAbility {
+
+    /**
+     * @param plugin the McRPG plugin instance
+     * @param name   the ability key name
+     */
+    public StubActiveUnlockableAbility(@NotNull McRPG plugin, @NotNull String name) {
+        super(plugin, name);
+    }
+
+    @Override
+    public int getUnlockLevel() {
+        return 1;
+    }
+}

--- a/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubComboActivatableAbility.java
+++ b/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubComboActivatableAbility.java
@@ -1,0 +1,38 @@
+package us.eunoians.mcrpg.ability.stub;
+
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.ability.combo.ComboActivatable;
+import us.eunoians.mcrpg.ability.impl.type.ActiveAbility;
+import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+
+/**
+ * Stub combining {@link ActiveAbility}, {@link UnlockableAbility}, and
+ * {@link ComboActivatable} for tests.
+ */
+public final class StubComboActivatableAbility extends StubAbilityBase implements UnlockableAbility, ActiveAbility, ComboActivatable {
+
+    /**
+     * @param plugin the McRPG plugin instance
+     * @param name   the ability key name
+     */
+    public StubComboActivatableAbility(@NotNull McRPG plugin, @NotNull String name) {
+        super(plugin, name);
+    }
+
+    @Override
+    public int getUnlockLevel() {
+        return 1;
+    }
+
+    @Override
+    public boolean comboActivate(@NotNull AbilityHolder abilityHolder) {
+        return true;
+    }
+
+    @Override
+    public int getManaCost(@NotNull AbilityHolder abilityHolder) {
+        return 0;
+    }
+}

--- a/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubInnateAbility.java
+++ b/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubInnateAbility.java
@@ -1,0 +1,19 @@
+package us.eunoians.mcrpg.ability.stub;
+
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.ability.impl.type.PassiveAbility;
+
+/**
+ * Stub innate {@link PassiveAbility} with no unlock gate for tests.
+ */
+public final class StubInnateAbility extends StubAbilityBase implements PassiveAbility {
+
+    /**
+     * @param plugin the McRPG plugin instance
+     * @param name   the ability key name
+     */
+    public StubInnateAbility(@NotNull McRPG plugin, @NotNull String name) {
+        super(plugin, name);
+    }
+}

--- a/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubPassiveUnlockableAbility.java
+++ b/src/testFixtures/java/us/eunoians/mcrpg/ability/stub/StubPassiveUnlockableAbility.java
@@ -1,0 +1,25 @@
+package us.eunoians.mcrpg.ability.stub;
+
+import org.jetbrains.annotations.NotNull;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.ability.impl.type.PassiveAbility;
+import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+
+/**
+ * Stub combining {@link PassiveAbility} and {@link UnlockableAbility} for tests.
+ */
+public final class StubPassiveUnlockableAbility extends StubAbilityBase implements UnlockableAbility, PassiveAbility {
+
+    /**
+     * @param plugin the McRPG plugin instance
+     * @param name   the ability key name
+     */
+    public StubPassiveUnlockableAbility(@NotNull McRPG plugin, @NotNull String name) {
+        super(plugin, name);
+    }
+
+    @Override
+    public int getUnlockLevel() {
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

- **Filter system tests (0% → covered):** Added comprehensive tests for all 10 filter classes — `ActiveAbilityFilter`, `PassiveAbilityFilter`, `UnlockableAbilityFilter`, `InnateAbilityFilter`, `AbilityUpgradeFilter`, `AbilityKeyComboActivatableFilter`, `AbilityKeyUnlockedFilter`, `AbilityKeyInLoadoutFilter`, `McRPGChainPlayerContextFilter`, and `SkillHolderDataPresentFilter`
- **Loadout active abilities tests:** Added tests for `Loadout.getOrderedActiveAbilities()` and `Loadout.swapActivePositions()` covering combo ability ordering, passive interspersion, same-slot no-op, out-of-range slots, zero slots, negative index edge case, and empty loadout
- **Shared test stubs fixture:** Extracted `StubAbilityBase`, `StubActiveUnlockableAbility`, `StubPassiveUnlockableAbility`, `StubInnateAbility`, and `StubComboActivatableAbility` into `src/testFixtures/java/us/eunoians/mcrpg/ability/stub/` to eliminate duplication across test files

### Classes covered (previously at 0% or no tests)

| Class | Tests added |
|-------|------------|
| `ActiveAbilityFilter` | 3 |
| `PassiveAbilityFilter` | 2 |
| `UnlockableAbilityFilter` | 2 |
| `InnateAbilityFilter` | 4 |
| `AbilityUpgradeFilter` | 5 |
| `AbilityKeyComboActivatableFilter` | 3 |
| `AbilityKeyUnlockedFilter` | 3 |
| `AbilityKeyInLoadoutFilter` | 3 |
| `McRPGChainPlayerContextFilter` | 3 |
| `SkillHolderDataPresentFilter` | 2 |
| `Loadout` (active abilities) | 10 |

**Total: 40+ new test cases across 5 test files and 5 shared fixture classes**

## Test plan

- [x] All 2333+ tests pass via `./gradlew verifiedShadowJar`
- [x] No regressions in existing test classes
- [x] Shared stubs compile from testFixtures and are accessible in test source set
- [x] Persona testing audit run against changes

https://claude.ai/code/session_013xEDA3KdWh2GVKGbM6XA59

---
_Generated by [Claude Code](https://claude.ai/code/session_013xEDA3KdWh2GVKGbM6XA59)_