### PR TITLE
[Unit Tests] Swords, Mining, Woodcutting, and Herbalism ability event coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/event/ability/herbalism/HerbalismAbilityEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/herbalism/HerbalismAbilityEventTest.java
@@ -1,0 +1,226 @@
+package us.eunoians.mcrpg.event.ability.herbalism;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.block.Block;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.impl.herbalism.InstantIrrigation;
+import us.eunoians.mcrpg.ability.impl.herbalism.MassHarvest;
+import us.eunoians.mcrpg.ability.impl.herbalism.TooManyPlants;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the herbalism ability activate events: {@link MassHarvestActivateEvent},
+ * {@link TooManyPlantsActivateEvent}, and {@link InstantIrrigationActivateEvent}.
+ * Verifies clamping contracts, getter/setter behavior, and the {@link org.bukkit.event.Cancellable} contract.
+ */
+class HerbalismAbilityEventTest extends McRPGBaseTest {
+
+    private AbilityHolder abilityHolder;
+
+    @BeforeEach
+    void setUp() {
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        lenient().when(herbalismConfig.getStringList(any(Route.class))).thenReturn(List.of());
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        MassHarvest massHarvest = new MassHarvest(mcRPG);
+        abilityRegistry.register(massHarvest);
+
+        TooManyPlants tooManyPlants = new TooManyPlants(mcRPG);
+        abilityRegistry.register(tooManyPlants);
+
+        InstantIrrigation instantIrrigation = new InstantIrrigation(mcRPG);
+        abilityRegistry.register(instantIrrigation);
+
+        abilityHolder = mock(AbilityHolder.class);
+        when(abilityHolder.getUUID()).thenReturn(UUID.randomUUID());
+    }
+
+    @Nested
+    @DisplayName("MassHarvestActivateEvent")
+    class MassHarvestActivateEventTests {
+
+        @Test
+        @DisplayName("getMaxPulseRadius returns constructor value")
+        void getMaxPulseRadius_returnsConstructorValue() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, 5.0);
+            assertEquals(5.0, event.getMaxPulseRadius());
+        }
+
+        @Test
+        @DisplayName("constructor clamps negative maxPulseRadius to 0")
+        void constructor_clampsNegativeRadius_toZero() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, -3.0);
+            assertEquals(0.0, event.getMaxPulseRadius());
+        }
+
+        @Test
+        @DisplayName("setMaxPulseRadius updates value")
+        void setMaxPulseRadius_updatesValue() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, 5.0);
+            event.setMaxPulseRadius(10);
+            assertEquals(10.0, event.getMaxPulseRadius());
+        }
+
+        @Test
+        @DisplayName("setMaxPulseRadius clamps negative to 0")
+        void setMaxPulseRadius_clampsNegative_toZero() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, 5.0);
+            event.setMaxPulseRadius(-7);
+            assertEquals(0.0, event.getMaxPulseRadius());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, 5.0);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, 5.0);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns MassHarvest")
+        void getAbility_returnsMassHarvest() {
+            MassHarvestActivateEvent event = new MassHarvestActivateEvent(abilityHolder, 5.0);
+            assertTrue(event.getAbility() instanceof MassHarvest);
+        }
+    }
+
+    @Nested
+    @DisplayName("TooManyPlantsActivateEvent")
+    class TooManyPlantsActivateEventTests {
+
+        @Test
+        @DisplayName("getDropMultiplier returns constructor value")
+        void getDropMultiplier_returnsConstructorValue() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 3);
+            assertEquals(3, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("constructor clamps negative dropMultiplier to 1")
+        void constructor_clampsNegativeMultiplier_toOne() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, -5);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("constructor clamps zero dropMultiplier to 1")
+        void constructor_clampsZeroMultiplier_toOne() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 0);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier updates value")
+        void setDropMultiplier_updatesValue() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 2);
+            event.setDropMultiplier(5);
+            assertEquals(5, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier clamps negative to 1")
+        void setDropMultiplier_clampsNegative_toOne() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 2);
+            event.setDropMultiplier(-10);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 2);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 2);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns TooManyPlants")
+        void getAbility_returnsTooManyPlants() {
+            TooManyPlantsActivateEvent event = new TooManyPlantsActivateEvent(abilityHolder, 2);
+            assertTrue(event.getAbility() instanceof TooManyPlants);
+        }
+    }
+
+    @Nested
+    @DisplayName("InstantIrrigationActivateEvent")
+    class InstantIrrigationActivateEventTests {
+
+        @Test
+        @DisplayName("getBlock returns the constructor block")
+        void getBlock_returnsConstructorBlock() {
+            Block block = mock(Block.class);
+            InstantIrrigationActivateEvent event = new InstantIrrigationActivateEvent(abilityHolder, block);
+            assertSame(block, event.getBlock());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            Block block = mock(Block.class);
+            InstantIrrigationActivateEvent event = new InstantIrrigationActivateEvent(abilityHolder, block);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            Block block = mock(Block.class);
+            InstantIrrigationActivateEvent event = new InstantIrrigationActivateEvent(abilityHolder, block);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/ability/mining/MiningAbilityEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/mining/MiningAbilityEventTest.java
@@ -1,0 +1,288 @@
+package us.eunoians.mcrpg.event.ability.mining;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.impl.mining.ExtraOre;
+import us.eunoians.mcrpg.ability.impl.mining.ItsATriple;
+import us.eunoians.mcrpg.ability.impl.mining.OreScanner;
+import us.eunoians.mcrpg.ability.impl.mining.RemoteTransfer;
+import us.eunoians.mcrpg.ability.impl.mining.orescanner.OreScannerBlockType;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.MiningConfigFile;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for all mining ability activation events:
+ * {@link ExtraOreActivateEvent}, {@link ItsATripleActivateEvent},
+ * {@link OreScannerActivateEvent}, and {@link RemoteTransferActivateEvent}.
+ */
+class MiningAbilityEventTest extends McRPGBaseTest {
+
+    private AbilityHolder holder;
+
+    @BeforeEach
+    void setUp() {
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument miningConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.MINING_CONFIG)).thenReturn(miningConfig);
+
+        when(miningConfig.getInt(MiningConfigFile.ITS_A_TRIPLE_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(miningConfig.getInt(MiningConfigFile.REMOTE_TRANSFER_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(miningConfig.getInt(MiningConfigFile.ORE_SCANNER_AMOUNT_OF_TIERS)).thenReturn(5);
+
+        lenient().when(miningConfig.getStringList(any(Route.class))).thenReturn(List.of());
+
+        Section emptySection = mock(Section.class);
+        when(emptySection.getRoutesAsStrings(false)).thenReturn(Set.of());
+        lenient().when(miningConfig.getSection(any(Route.class))).thenReturn(emptySection);
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        abilityRegistry.register(new ExtraOre(mcRPG));
+        abilityRegistry.register(new ItsATriple(mcRPG));
+        abilityRegistry.register(new OreScanner(mcRPG));
+        abilityRegistry.register(new RemoteTransfer(mcRPG));
+
+        holder = mock(AbilityHolder.class);
+        when(holder.getUUID()).thenReturn(UUID.randomUUID());
+    }
+
+    @Nested
+    @DisplayName("ExtraOreActivateEvent")
+    class ExtraOreActivateEventTests {
+
+        @Test
+        @DisplayName("getDropMultiplier returns constructor value when positive")
+        void getDropMultiplier_returnsConstructorValue_whenPositive() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 5);
+            assertEquals(5, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("getDropMultiplier clamps negative to 1")
+        void getDropMultiplier_clampsToOne_whenNegative() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, -3);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("getDropMultiplier clamps zero to 1")
+        void getDropMultiplier_clampsToOne_whenZero() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 0);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier updates value when positive")
+        void setDropMultiplier_updatesValue_whenPositive() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+            event.setDropMultiplier(10);
+            assertEquals(10, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier clamps negative to 1")
+        void setDropMultiplier_clampsToOne_whenNegative() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 5);
+            event.setDropMultiplier(-7);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns ExtraOre")
+        void getAbility_returnsExtraOre() {
+            ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+            assertInstanceOf(ExtraOre.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("ItsATripleActivateEvent")
+    class ItsATripleActivateEventTests {
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns ItsATriple")
+        void getAbility_returnsItsATriple() {
+            ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+            assertInstanceOf(ItsATriple.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("OreScannerActivateEvent")
+    class OreScannerActivateEventTests {
+
+        @Test
+        @DisplayName("getInstancesOfBlocks returns immutable copy")
+        void getInstancesOfBlocks_returnsImmutableCopy() {
+            OreScannerBlockType blockType = mock(OreScannerBlockType.class);
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            Map<OreScannerBlockType, Set<Location>> map = new HashMap<>();
+            map.put(blockType, new HashSet<>(Set.of(location)));
+
+            OreScannerActivateEvent event = new OreScannerActivateEvent(holder, map);
+            Map<OreScannerBlockType, Set<Location>> returned = event.getInstancesOfBlocks();
+
+            assertEquals(1, returned.size());
+            assertTrue(returned.containsKey(blockType));
+        }
+
+        @Test
+        @DisplayName("getLocationsOfBlockType returns immutable copy for existing type")
+        void getLocationsOfBlockType_returnsCopy_whenTypeExists() {
+            OreScannerBlockType blockType = mock(OreScannerBlockType.class);
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            Map<OreScannerBlockType, Set<Location>> map = new HashMap<>();
+            map.put(blockType, new HashSet<>(Set.of(location)));
+
+            OreScannerActivateEvent event = new OreScannerActivateEvent(holder, map);
+            Set<Location> locations = event.getLocationsOfBlockType(blockType);
+
+            assertEquals(1, locations.size());
+            assertTrue(locations.contains(location));
+        }
+
+        @Test
+        @DisplayName("getLocationsOfBlockType returns empty set for missing type")
+        void getLocationsOfBlockType_returnsEmptySet_whenTypeMissing() {
+            OreScannerActivateEvent event = new OreScannerActivateEvent(holder, new HashMap<>());
+            OreScannerBlockType missingType = mock(OreScannerBlockType.class);
+
+            Set<Location> locations = event.getLocationsOfBlockType(missingType);
+
+            assertTrue(locations.isEmpty());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            OreScannerActivateEvent event = new OreScannerActivateEvent(holder, new HashMap<>());
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            OreScannerActivateEvent event = new OreScannerActivateEvent(holder, new HashMap<>());
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns OreScanner")
+        void getAbility_returnsOreScanner() {
+            OreScannerActivateEvent event = new OreScannerActivateEvent(holder, new HashMap<>());
+            assertInstanceOf(OreScanner.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("RemoteTransferActivateEvent")
+    class RemoteTransferActivateEventTests {
+
+        @Test
+        @DisplayName("getRemoteTransferDestination returns the location")
+        void getRemoteTransferDestination_returnsLocation() {
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, location);
+
+            assertEquals(location, event.getRemoteTransferDestination());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, location);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, location);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns RemoteTransfer")
+        void getAbility_returnsRemoteTransfer() {
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, location);
+            assertInstanceOf(RemoteTransfer.class, event.getAbility());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/ability/mining/MiningAbilityEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/mining/MiningAbilityEventTest.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -196,6 +197,7 @@ class MiningAbilityEventTest extends McRPGBaseTest {
 
             assertEquals(1, returned.size());
             assertTrue(returned.containsKey(blockType));
+            assertThrows(UnsupportedOperationException.class, () -> returned.put(mock(OreScannerBlockType.class), Set.of()));
         }
 
         @Test
@@ -211,6 +213,7 @@ class MiningAbilityEventTest extends McRPGBaseTest {
 
             assertEquals(1, locations.size());
             assertTrue(locations.contains(location));
+            assertThrows(UnsupportedOperationException.class, () -> locations.add(new Location(mock(World.class), 9, 9, 9)));
         }
 
         @Test

--- a/src/test/java/us/eunoians/mcrpg/event/ability/swords/SwordsAbilityEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/swords/SwordsAbilityEventTest.java
@@ -1,0 +1,563 @@
+package us.eunoians.mcrpg.event.ability.swords;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.impl.swords.Bleed;
+import us.eunoians.mcrpg.ability.impl.swords.DeeperWound;
+import us.eunoians.mcrpg.ability.impl.swords.EnhancedBleed;
+import us.eunoians.mcrpg.ability.impl.swords.RageSpike;
+import us.eunoians.mcrpg.ability.impl.swords.Vampire;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.SwordsConfigFile;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for all swords ability event classes except {@link SerratedStrikesActivateEvent},
+ * which has its own dedicated test class.
+ * <p>
+ * Covers: {@link BleedActivateEvent}, {@link BleedDamageEvent},
+ * {@link DeeperWoundActivateEvent}, {@link EnhancedBleedActivateEvent},
+ * {@link VampireActivateEvent}, {@link RageSpikeActivateEvent},
+ * {@link RageSpikeDamageEvent}.
+ */
+class SwordsAbilityEventTest extends McRPGBaseTest {
+
+    private AbilityHolder holder;
+    private LivingEntity livingEntity;
+
+    @BeforeEach
+    void setUp() {
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        YamlDocument swordsConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.SWORDS_CONFIG)).thenReturn(swordsConfig);
+        when(swordsConfig.getInt(SwordsConfigFile.DEEPER_WOUND_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(swordsConfig.getInt(SwordsConfigFile.ENHANCED_BLEED_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(swordsConfig.getInt(SwordsConfigFile.VAMPIRE_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(swordsConfig.getInt(SwordsConfigFile.RAGE_SPIKE_AMOUNT_OF_TIERS)).thenReturn(5);
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        // Bleed must be registered first — other abilities' event classes have static initializers that resolve Bleed from the registry
+        abilityRegistry.register(new Bleed(mcRPG));
+        abilityRegistry.register(new DeeperWound(mcRPG));
+        abilityRegistry.register(new EnhancedBleed(mcRPG));
+        abilityRegistry.register(new Vampire(mcRPG));
+        abilityRegistry.register(new RageSpike(mcRPG));
+
+        holder = mock(AbilityHolder.class);
+        when(holder.getUUID()).thenReturn(UUID.randomUUID());
+        livingEntity = mock(LivingEntity.class);
+    }
+
+    @Nested
+    @DisplayName("BleedActivateEvent")
+    class BleedActivateEventTests {
+
+        @Test
+        @DisplayName("Constructor clamps bleedCycles to minimum 1")
+        void constructor_clampsBleedCycles_whenNegative() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, -5, 3.0);
+            assertEquals(1, event.getBleedCycles());
+        }
+
+        @Test
+        @DisplayName("Constructor clamps bleedDamage to minimum 1")
+        void constructor_clampsBleedDamage_whenNegative() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, -2.0);
+            assertEquals(1.0, event.getBleedDamage());
+        }
+
+        @Test
+        @DisplayName("getBleedCycles returns positive constructor value")
+        void getBleedCycles_returnsPositiveValue() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 7, 3.0);
+            assertEquals(7, event.getBleedCycles());
+        }
+
+        @Test
+        @DisplayName("setBleedCycles updates to positive value")
+        void setBleedCycles_updatesValue() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            event.setBleedCycles(10);
+            assertEquals(10, event.getBleedCycles());
+        }
+
+        @Test
+        @DisplayName("setBleedCycles clamps negative to 1")
+        void setBleedCycles_clampsToOne_whenNegative() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            event.setBleedCycles(-4);
+            assertEquals(1, event.getBleedCycles());
+        }
+
+        @Test
+        @DisplayName("getBleedDamage returns positive constructor value")
+        void getBleedDamage_returnsPositiveValue() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 5.5);
+            assertEquals(5.5, event.getBleedDamage());
+        }
+
+        @Test
+        @DisplayName("setBleedDamage updates to positive value")
+        void setBleedDamage_updatesValue() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            event.setBleedDamage(8.0);
+            assertEquals(8.0, event.getBleedDamage());
+        }
+
+        @Test
+        @DisplayName("setBleedDamage clamps negative to 1")
+        void setBleedDamage_clampsToOne_whenNegative() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            event.setBleedDamage(-1.0);
+            assertEquals(1.0, event.getBleedDamage());
+        }
+
+        @Test
+        @DisplayName("getBleedingEntity returns the entity")
+        void getBleedingEntity_returnsEntity() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            assertEquals(livingEntity, event.getBleedingEntity());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns Bleed instance")
+        void getAbility_returnsBleedInstance() {
+            BleedActivateEvent event = new BleedActivateEvent(holder, livingEntity, 3, 3.0);
+            assertInstanceOf(Bleed.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("BleedDamageEvent")
+    class BleedDamageEventTests {
+
+        @Test
+        @DisplayName("Constructor clamps damage to minimum 0")
+        void constructor_clampsDamage_whenNegative() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, -5.0, false);
+            assertEquals(0.0, event.getDamage());
+        }
+
+        @Test
+        @DisplayName("setDamage clamps negative to 0")
+        void setDamage_clampsToZero_whenNegative() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            event.setDamage(-3.0);
+            assertEquals(0.0, event.getDamage());
+        }
+
+        @Test
+        @DisplayName("getDamagedEntity returns the entity (entity-only constructor)")
+        void getDamagedEntity_returnsEntity_entityOnlyConstructor() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            assertEquals(entity, event.getDamagedEntity());
+        }
+
+        @Test
+        @DisplayName("isDamageIgnoringArmor returns constructor value")
+        void isDamageIgnoringArmor_returnsConstructorValue() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, true);
+            assertTrue(event.isDamageIgnoringArmor());
+        }
+
+        @Test
+        @DisplayName("setDamageIgnoreArmor updates the flag")
+        void setDamageIgnoreArmor_updatesFlag() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            event.setDamageIgnoreArmor(true);
+            assertTrue(event.isDamageIgnoringArmor());
+        }
+
+        @Test
+        @DisplayName("getBleedUser returns empty Optional for entity-only constructor")
+        void getBleedUser_returnsEmpty_entityOnlyConstructor() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            assertTrue(event.getBleedUser().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getBleedUser returns present Optional for AbilityHolder constructor")
+        void getBleedUser_returnsPresent_abilityHolderConstructor() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(holder, entity, 5.0, false);
+            assertTrue(event.getBleedUser().isPresent());
+            assertEquals(holder, event.getBleedUser().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("getBleedUser returns provided Optional for Optional constructor")
+        void getBleedUser_returnsProvidedOptional() {
+            Entity entity = mock(Entity.class);
+            Optional<AbilityHolder> optionalHolder = Optional.of(holder);
+            BleedDamageEvent event = new BleedDamageEvent(optionalHolder, entity, 5.0, false);
+            assertTrue(event.getBleedUser().isPresent());
+            assertEquals(holder, event.getBleedUser().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns Bleed instance")
+        void getAbility_returnsBleedInstance() {
+            Entity entity = mock(Entity.class);
+            BleedDamageEvent event = new BleedDamageEvent(entity, 5.0, false);
+            assertInstanceOf(Bleed.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("DeeperWoundActivateEvent")
+    class DeeperWoundActivateEventTests {
+
+        @Test
+        @DisplayName("Constructor clamps additionalBleedCycles to minimum 0")
+        void constructor_clampsAdditionalBleedCycles_whenNegative() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, -3);
+            assertEquals(0, event.getAdditionalBleedCycles());
+        }
+
+        @Test
+        @DisplayName("getAdditionalBleedCycles returns positive constructor value")
+        void getAdditionalBleedCycles_returnsPositiveValue() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 5);
+            assertEquals(5, event.getAdditionalBleedCycles());
+        }
+
+        @Test
+        @DisplayName("setAdditionalBleedCycles updates to positive value")
+        void setAdditionalBleedCycles_updatesValue() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 3);
+            event.setAdditionalBleedCycles(8);
+            assertEquals(8, event.getAdditionalBleedCycles());
+        }
+
+        @Test
+        @DisplayName("setAdditionalBleedCycles clamps negative to 0")
+        void setAdditionalBleedCycles_clampsToZero_whenNegative() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 3);
+            event.setAdditionalBleedCycles(-2);
+            assertEquals(0, event.getAdditionalBleedCycles());
+        }
+
+        @Test
+        @DisplayName("getBleedingEntity returns the entity")
+        void getBleedingEntity_returnsEntity() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 3);
+            assertEquals(livingEntity, event.getBleedingEntity());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 3);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 3);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns DeeperWound instance")
+        void getAbility_returnsDeeperWoundInstance() {
+            DeeperWoundActivateEvent event = new DeeperWoundActivateEvent(holder, livingEntity, 3);
+            assertInstanceOf(DeeperWound.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("EnhancedBleedActivateEvent")
+    class EnhancedBleedActivateEventTests {
+
+        @Test
+        @DisplayName("Constructor clamps additionalBleedDamage to minimum 0")
+        void constructor_clampsAdditionalBleedDamage_whenNegative() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, -5.0);
+            assertEquals(0.0, event.getAdditionalBleedDamage());
+        }
+
+        @Test
+        @DisplayName("getAdditionalBleedDamage returns positive constructor value")
+        void getAdditionalBleedDamage_returnsPositiveValue() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 4.5);
+            assertEquals(4.5, event.getAdditionalBleedDamage());
+        }
+
+        @Test
+        @DisplayName("setAdditionalBleedDamage updates to positive value")
+        void setAdditionalBleedDamage_updatesValue() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 3.0);
+            event.setAdditionalBleedDamage(7.5);
+            assertEquals(7.5, event.getAdditionalBleedDamage());
+        }
+
+        @Test
+        @DisplayName("setAdditionalBleedDamage clamps negative to 0")
+        void setAdditionalBleedDamage_clampsToZero_whenNegative() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 3.0);
+            event.setAdditionalBleedDamage(-1.0);
+            assertEquals(0.0, event.getAdditionalBleedDamage());
+        }
+
+        @Test
+        @DisplayName("getBleedingEntity returns the entity")
+        void getBleedingEntity_returnsEntity() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 3.0);
+            assertEquals(livingEntity, event.getBleedingEntity());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 3.0);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 3.0);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns EnhancedBleed instance")
+        void getAbility_returnsEnhancedBleedInstance() {
+            EnhancedBleedActivateEvent event = new EnhancedBleedActivateEvent(holder, livingEntity, 3.0);
+            assertInstanceOf(EnhancedBleed.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("VampireActivateEvent")
+    class VampireActivateEventTests {
+
+        @Test
+        @DisplayName("Constructor clamps amountToHeal to minimum 0")
+        void constructor_clampsAmountToHeal_whenNegative() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, -3.0);
+            assertEquals(0.0, event.getAmountToHeal());
+        }
+
+        @Test
+        @DisplayName("getAmountToHeal returns positive constructor value")
+        void getAmountToHeal_returnsPositiveValue() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 6.0);
+            assertEquals(6.0, event.getAmountToHeal());
+        }
+
+        @Test
+        @DisplayName("setAmountToHeal updates to positive value")
+        void setAmountToHeal_updatesValue() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 3.0);
+            event.setAmountToHeal(10.0);
+            assertEquals(10.0, event.getAmountToHeal());
+        }
+
+        @Test
+        @DisplayName("setAmountToHeal clamps negative to 0")
+        void setAmountToHeal_clampsToZero_whenNegative() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 3.0);
+            event.setAmountToHeal(-5.0);
+            assertEquals(0.0, event.getAmountToHeal());
+        }
+
+        @Test
+        @DisplayName("getBleedingEntity returns the entity")
+        void getBleedingEntity_returnsEntity() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 3.0);
+            assertEquals(livingEntity, event.getBleedingEntity());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 3.0);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 3.0);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns Vampire instance")
+        void getAbility_returnsVampireInstance() {
+            VampireActivateEvent event = new VampireActivateEvent(holder, livingEntity, 3.0);
+            assertInstanceOf(Vampire.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("RageSpikeActivateEvent")
+    class RageSpikeActivateEventTests {
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            RageSpikeActivateEvent event = new RageSpikeActivateEvent(holder);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            RageSpikeActivateEvent event = new RageSpikeActivateEvent(holder);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns RageSpike instance")
+        void getAbility_returnsRageSpikeInstance() {
+            RageSpikeActivateEvent event = new RageSpikeActivateEvent(holder);
+            assertInstanceOf(RageSpike.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("RageSpikeDamageEvent")
+    class RageSpikeDamageEventTests {
+
+        @Test
+        @DisplayName("Constructor clamps damage to minimum 0")
+        void constructor_clampsDamage_whenNegative() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, -5.0);
+            assertEquals(0.0, event.getDamage());
+        }
+
+        @Test
+        @DisplayName("getDamage returns positive constructor value")
+        void getDamage_returnsPositiveValue() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 7.5);
+            assertEquals(7.5, event.getDamage());
+        }
+
+        @Test
+        @DisplayName("setDamage updates to positive value")
+        void setDamage_updatesValue() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            event.setDamage(12.0);
+            assertEquals(12.0, event.getDamage());
+        }
+
+        @Test
+        @DisplayName("setDamage clamps negative to 0")
+        void setDamage_clampsToZero_whenNegative() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            event.setDamage(-1.0);
+            assertEquals(0.0, event.getDamage());
+        }
+
+        @Test
+        @DisplayName("getDamagedEntity returns the entity")
+        void getDamagedEntity_returnsEntity() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            assertEquals(livingEntity, event.getDamagedEntity());
+        }
+
+        @Test
+        @DisplayName("getAbilityHolder returns the holder")
+        void getAbilityHolder_returnsHolder() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            assertEquals(holder, event.getAbilityHolder());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes event cancelled")
+        void setCancelled_makesEventCancelled() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns RageSpike instance")
+        void getAbility_returnsRageSpikeInstance() {
+            RageSpikeDamageEvent event = new RageSpikeDamageEvent(holder, livingEntity, 3.0);
+            assertInstanceOf(RageSpike.class, event.getAbility());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/ability/woodcutting/WoodcuttingAbilityEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/woodcutting/WoodcuttingAbilityEventTest.java
@@ -1,0 +1,339 @@
+package us.eunoians.mcrpg.event.ability.woodcutting;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.impl.woodcutting.DryadsGift;
+import us.eunoians.mcrpg.ability.impl.woodcutting.ExtraLumber;
+import us.eunoians.mcrpg.ability.impl.woodcutting.HeavySwing;
+import us.eunoians.mcrpg.ability.impl.woodcutting.NymphsVitality;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.WoodcuttingConfigFile;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for all woodcutting ability activation events:
+ * {@link ExtraLumberActivateEvent}, {@link HeavySwingActivateEvent},
+ * {@link DryadsGiftActivateEvent}, {@link NymphsVitalityActivateEvent},
+ * and {@link HeavySwingFakeBlockBreakEvent}.
+ */
+class WoodcuttingAbilityEventTest extends McRPGBaseTest {
+
+    private AbilityHolder holder;
+
+    @BeforeEach
+    void setUp() {
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument woodcuttingConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.WOODCUTTING_CONFIG)).thenReturn(woodcuttingConfig);
+
+        when(woodcuttingConfig.getInt(WoodcuttingConfigFile.HEAVY_SWING_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(woodcuttingConfig.getInt(WoodcuttingConfigFile.DRYADS_GIFT_AMOUNT_OF_TIERS)).thenReturn(5);
+        when(woodcuttingConfig.getInt(WoodcuttingConfigFile.NYMPHS_VITALITY_AMOUNT_OF_TIERS)).thenReturn(5);
+
+        lenient().when(woodcuttingConfig.getStringList(any(Route.class))).thenReturn(List.of());
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        abilityRegistry.register(new ExtraLumber(mcRPG));
+        abilityRegistry.register(new HeavySwing(mcRPG));
+        abilityRegistry.register(new DryadsGift(mcRPG));
+        abilityRegistry.register(new NymphsVitality(mcRPG));
+
+        holder = mock(AbilityHolder.class);
+        when(holder.getUUID()).thenReturn(UUID.randomUUID());
+    }
+
+    @Nested
+    @DisplayName("ExtraLumberActivateEvent")
+    class ExtraLumberActivateEventTests {
+
+        @Test
+        @DisplayName("getDropMultiplier returns constructor value when positive")
+        void getDropMultiplier_returnsConstructorValue_whenPositive() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 5);
+            assertEquals(5, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("getDropMultiplier clamps negative to 1")
+        void getDropMultiplier_clampsToOne_whenNegative() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, -3);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("getDropMultiplier clamps zero to 1")
+        void getDropMultiplier_clampsToOne_whenZero() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 0);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier updates value when positive")
+        void setDropMultiplier_updatesValue_whenPositive() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 2);
+            event.setDropMultiplier(10);
+            assertEquals(10, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier clamps negative to 1")
+        void setDropMultiplier_clampsToOne_whenNegative() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 5);
+            event.setDropMultiplier(-7);
+            assertEquals(1, event.getDropMultiplier());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 2);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 2);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns ExtraLumber")
+        void getAbility_returnsExtraLumber() {
+            ExtraLumberActivateEvent event = new ExtraLumberActivateEvent(holder, 2);
+            assertInstanceOf(ExtraLumber.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("HeavySwingActivateEvent")
+    class HeavySwingActivateEventTests {
+
+        @Test
+        @DisplayName("getToBreakLocations returns the provided set")
+        void getToBreakLocations_returnsProvidedSet() {
+            Location location = new Location(mock(World.class), 1, 2, 3);
+            Set<Location> locations = new HashSet<>(Set.of(location));
+            HeavySwingActivateEvent event = new HeavySwingActivateEvent(holder, locations);
+
+            assertSame(locations, event.getToBreakLocations());
+        }
+
+        @Test
+        @DisplayName("setToBreakLocations replaces the set")
+        void setToBreakLocations_replacesSet() {
+            Location location1 = new Location(mock(World.class), 1, 2, 3);
+            Location location2 = new Location(mock(World.class), 4, 5, 6);
+            Set<Location> original = new HashSet<>(Set.of(location1));
+            Set<Location> replacement = new HashSet<>(Set.of(location2));
+
+            HeavySwingActivateEvent event = new HeavySwingActivateEvent(holder, original);
+            event.setToBreakLocations(replacement);
+
+            assertSame(replacement, event.getToBreakLocations());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            HeavySwingActivateEvent event = new HeavySwingActivateEvent(holder, new HashSet<>());
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            HeavySwingActivateEvent event = new HeavySwingActivateEvent(holder, new HashSet<>());
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns HeavySwing")
+        void getAbility_returnsHeavySwing() {
+            HeavySwingActivateEvent event = new HeavySwingActivateEvent(holder, new HashSet<>());
+            assertInstanceOf(HeavySwing.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("DryadsGiftActivateEvent")
+    class DryadsGiftActivateEventTests {
+
+        @Test
+        @DisplayName("getExperienceToDrop returns constructor value when positive")
+        void getExperienceToDrop_returnsConstructorValue_whenPositive() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 10);
+            assertEquals(10, event.getExperienceToDrop());
+        }
+
+        @Test
+        @DisplayName("getExperienceToDrop clamps negative to 1")
+        void getExperienceToDrop_clampsToOne_whenNegative() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, -5);
+            assertEquals(1, event.getExperienceToDrop());
+        }
+
+        @Test
+        @DisplayName("getExperienceToDrop clamps zero to 1")
+        void getExperienceToDrop_clampsToOne_whenZero() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 0);
+            assertEquals(1, event.getExperienceToDrop());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier updates value when positive")
+        void setDropMultiplier_updatesValue_whenPositive() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 5);
+            event.setDropMultiplier(20);
+            assertEquals(20, event.getExperienceToDrop());
+        }
+
+        @Test
+        @DisplayName("setDropMultiplier clamps negative to 1")
+        void setDropMultiplier_clampsToOne_whenNegative() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 5);
+            event.setDropMultiplier(-3);
+            assertEquals(1, event.getExperienceToDrop());
+        }
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 5);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 5);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns DryadsGift")
+        void getAbility_returnsDryadsGift() {
+            DryadsGiftActivateEvent event = new DryadsGiftActivateEvent(holder, 5);
+            assertInstanceOf(DryadsGift.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("NymphsVitalityActivateEvent")
+    class NymphsVitalityActivateEventTests {
+
+        @Test
+        @DisplayName("isCancelled returns false by default")
+        void isCancelled_returnsFalse_byDefault() {
+            NymphsVitalityActivateEvent event = new NymphsVitalityActivateEvent(holder);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled(true) makes isCancelled return true")
+        void setCancelled_makesEventCancelled_whenSetToTrue() {
+            NymphsVitalityActivateEvent event = new NymphsVitalityActivateEvent(holder);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getAbility returns NymphsVitality")
+        void getAbility_returnsNymphsVitality() {
+            NymphsVitalityActivateEvent event = new NymphsVitalityActivateEvent(holder);
+            assertInstanceOf(NymphsVitality.class, event.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("HeavySwingFakeBlockBreakEvent")
+    class HeavySwingFakeBlockBreakEventTests {
+
+        @Test
+        @DisplayName("getPlayer returns the provided player")
+        void getPlayer_returnsProvidedPlayer() {
+            Player player = mock(Player.class);
+            Block block = mock(Block.class);
+            HeavySwingFakeBlockBreakEvent event = new HeavySwingFakeBlockBreakEvent(player, block);
+
+            assertEquals(player, event.getPlayer());
+        }
+
+        @Test
+        @DisplayName("getBlock returns the provided block")
+        void getBlock_returnsProvidedBlock() {
+            Player player = mock(Player.class);
+            Block block = mock(Block.class);
+            HeavySwingFakeBlockBreakEvent event = new HeavySwingFakeBlockBreakEvent(player, block);
+
+            assertEquals(block, event.getBlock());
+        }
+
+        @Test
+        @DisplayName("hasPassedChecks returns true by default")
+        void hasPassedChecks_returnsTrue_byDefault() {
+            Player player = mock(Player.class);
+            Block block = mock(Block.class);
+            HeavySwingFakeBlockBreakEvent event = new HeavySwingFakeBlockBreakEvent(player, block);
+
+            assertTrue(event.hasPassedChecks());
+        }
+
+        @Test
+        @DisplayName("setPassedChecks(false) makes hasPassedChecks return false")
+        void setPassedChecks_makesChecksFail_whenSetToFalse() {
+            Player player = mock(Player.class);
+            Block block = mock(Block.class);
+            HeavySwingFakeBlockBreakEvent event = new HeavySwingFakeBlockBreakEvent(player, block);
+            event.setPassedChecks(false);
+
+            assertFalse(event.hasPassedChecks());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Add 126 unit tests** covering all 19 ability event classes across swords, mining, woodcutting, and herbalism skill packages
- **Swords** (59 tests): `BleedActivateEvent`, `BleedDamageEvent`, `DeeperWoundActivateEvent`, `EnhancedBleedActivateEvent`, `VampireActivateEvent`, `RageSpikeActivateEvent`, `RageSpikeDamageEvent`
- **Mining** (21 tests): `ExtraOreActivateEvent`, `ItsATripleActivateEvent`, `OreScannerActivateEvent`, `RemoteTransferActivateEvent`
- **Woodcutting** (28 tests): `ExtraLumberActivateEvent`, `HeavySwingActivateEvent`, `DryadsGiftActivateEvent`, `NymphsVitalityActivateEvent`, `HeavySwingFakeBlockBreakEvent`
- **Herbalism** (18 tests): `MassHarvestActivateEvent`, `TooManyPlantsActivateEvent`, `InstantIrrigationActivateEvent`

Each event class is tested for constructor clamping contracts (negative/zero values), getter/setter behavior, the `Cancellable` contract (default false, settable to true), and `getAbility()` type resolution. Tests follow project naming conventions (`@DisplayName` short labels, `action_outcome_whenCondition` method names, `@Nested` grouping per event class).

Note: `SerratedStrikesActivateEvent` and `VerdantSurgeActivateEvent` already have dedicated test classes and are not duplicated here.

## Test plan

- [x] All 126 new tests pass (`./gradlew test`)
- [x] Zero regressions across the full test suite (2313 total tests, 0 failures)
- [x] Tests follow CLAUDE.md naming conventions and extend `McRPGBaseTest`

https://claude.ai/code/session_01R5vWsAUgQnCjXx9BfMAbAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5vWsAUgQnCjXx9BfMAbAS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad automated coverage for herbalism, mining, swords, and woodcutting ability events.
  * Verified event defaults, cancellation behavior, getters/setters, and value clamping across multiple ability interactions.
  * Added checks for ability-specific behaviors such as damage, healing, block handling, and passed-check states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->