### PR TITLE
[Unit Tests] Template condition system: ComparisonOperator, VariableCheck, and 5 condition classes

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/ChanceConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/ChanceConditionTest.java
@@ -1,0 +1,99 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ChanceCondition")
+class ChanceConditionTest {
+
+    @Nested
+    @DisplayName("constructor validation")
+    class ConstructorValidation {
+
+        @Test
+        @DisplayName("rejects chance below 0.0")
+        void constructor_throws_whenChanceBelowZero() {
+            assertThrows(IllegalArgumentException.class, () -> new ChanceCondition(-0.1));
+        }
+
+        @Test
+        @DisplayName("rejects chance above 1.0")
+        void constructor_throws_whenChanceAboveOne() {
+            assertThrows(IllegalArgumentException.class, () -> new ChanceCondition(1.1));
+        }
+
+        @Test
+        @DisplayName("accepts boundary value 0.0")
+        void constructor_accepts_zeroChance() {
+            assertDoesNotThrow(() -> new ChanceCondition(0.0));
+        }
+
+        @Test
+        @DisplayName("accepts boundary value 1.0")
+        void constructor_accepts_fullChance() {
+            assertDoesNotThrow(() -> new ChanceCondition(1.0));
+        }
+
+        @Test
+        @DisplayName("no-arg prototype constructor creates valid instance")
+        void noArgConstructor_createsPrototype() {
+            ChanceCondition prototype = new ChanceCondition();
+            assertEquals(0.5, prototype.getChance());
+        }
+    }
+
+    @Nested
+    @DisplayName("getters")
+    class Getters {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:chance")
+        void getKey_returnsMcrpgChance() {
+            assertEquals(NamespacedKey.fromString("mcrpg:chance"), new ChanceCondition(0.5).getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            Optional<NamespacedKey> key = new ChanceCondition(0.5).getExpansionKey();
+            assertTrue(key.isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, key.get());
+        }
+
+        @Test
+        @DisplayName("getChance returns configured probability")
+        void getChance_returnsConfiguredValue() {
+            assertEquals(0.75, new ChanceCondition(0.75).getChance());
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("serializes chance value")
+        void serializeConfig_containsChanceKey() {
+            Map<String, Object> config = new ChanceCondition(0.3).serializeConfig();
+            assertEquals(0.3, config.get("chance"));
+        }
+
+        @Test
+        @DisplayName("serialized map has exactly one entry")
+        void serializeConfig_hasOneEntry() {
+            Map<String, Object> config = new ChanceCondition(0.5).serializeConfig();
+            assertEquals(1, config.size());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/ComparisonOperatorTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/ComparisonOperatorTest.java
@@ -1,0 +1,128 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ComparisonOperator")
+class ComparisonOperatorTest {
+
+    @Nested
+    @DisplayName("GREATER_THAN")
+    class GreaterThan {
+
+        @Test
+        @DisplayName("returns true when a > b")
+        void compare_returnsTrue_whenAboveThreshold() {
+            assertTrue(ComparisonOperator.GREATER_THAN.compare(10.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns false when a == b")
+        void compare_returnsFalse_whenEqual() {
+            assertFalse(ComparisonOperator.GREATER_THAN.compare(5.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns false when a < b")
+        void compare_returnsFalse_whenBelowThreshold() {
+            assertFalse(ComparisonOperator.GREATER_THAN.compare(3.0, 5.0));
+        }
+    }
+
+    @Nested
+    @DisplayName("LESS_THAN")
+    class LessThan {
+
+        @Test
+        @DisplayName("returns true when a < b")
+        void compare_returnsTrue_whenBelowThreshold() {
+            assertTrue(ComparisonOperator.LESS_THAN.compare(3.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns false when a == b")
+        void compare_returnsFalse_whenEqual() {
+            assertFalse(ComparisonOperator.LESS_THAN.compare(5.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns false when a > b")
+        void compare_returnsFalse_whenAboveThreshold() {
+            assertFalse(ComparisonOperator.LESS_THAN.compare(10.0, 5.0));
+        }
+    }
+
+    @Nested
+    @DisplayName("GREATER_THAN_OR_EQUAL")
+    class GreaterThanOrEqual {
+
+        @Test
+        @DisplayName("returns true when a > b")
+        void compare_returnsTrue_whenAboveThreshold() {
+            assertTrue(ComparisonOperator.GREATER_THAN_OR_EQUAL.compare(10.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns true when a == b")
+        void compare_returnsTrue_whenEqual() {
+            assertTrue(ComparisonOperator.GREATER_THAN_OR_EQUAL.compare(5.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns false when a < b")
+        void compare_returnsFalse_whenBelowThreshold() {
+            assertFalse(ComparisonOperator.GREATER_THAN_OR_EQUAL.compare(3.0, 5.0));
+        }
+    }
+
+    @Nested
+    @DisplayName("LESS_THAN_OR_EQUAL")
+    class LessThanOrEqual {
+
+        @Test
+        @DisplayName("returns true when a < b")
+        void compare_returnsTrue_whenBelowThreshold() {
+            assertTrue(ComparisonOperator.LESS_THAN_OR_EQUAL.compare(3.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns true when a == b")
+        void compare_returnsTrue_whenEqual() {
+            assertTrue(ComparisonOperator.LESS_THAN_OR_EQUAL.compare(5.0, 5.0));
+        }
+
+        @Test
+        @DisplayName("returns false when a > b")
+        void compare_returnsFalse_whenAboveThreshold() {
+            assertFalse(ComparisonOperator.LESS_THAN_OR_EQUAL.compare(10.0, 5.0));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ComparisonOperator.class)
+    @DisplayName("negative values compare correctly")
+    void compare_handlesNegativeValues(ComparisonOperator operator) {
+        boolean result = operator.compare(-10.0, -5.0);
+        switch (operator) {
+            case GREATER_THAN, GREATER_THAN_OR_EQUAL -> assertFalse(result);
+            case LESS_THAN, LESS_THAN_OR_EQUAL -> assertTrue(result);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ComparisonOperator.class)
+    @DisplayName("zero compared to zero")
+    void compare_zeroAgainstZero(ComparisonOperator operator) {
+        boolean result = operator.compare(0.0, 0.0);
+        switch (operator) {
+            case GREATER_THAN, LESS_THAN -> assertFalse(result);
+            case GREATER_THAN_OR_EQUAL, LESS_THAN_OR_EQUAL -> assertTrue(result);
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/CompletionPrerequisiteConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/CompletionPrerequisiteConditionTest.java
@@ -1,0 +1,208 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CompletionPrerequisiteCondition")
+class CompletionPrerequisiteConditionTest {
+
+    private static final NamespacedKey DAILY = NamespacedKey.fromString("mcrpg:personal_daily");
+    private static final NamespacedKey RARE = NamespacedKey.fromString("mcrpg:rare");
+
+    @Nested
+    @DisplayName("constructor validation")
+    class ConstructorValidation {
+
+        @Test
+        @DisplayName("rejects minCompletions below 1")
+        void constructor_throws_whenMinCompletionsZero() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new CompletionPrerequisiteCondition(0, null, null));
+        }
+
+        @Test
+        @DisplayName("rejects negative minCompletions")
+        void constructor_throws_whenMinCompletionsNegative() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new CompletionPrerequisiteCondition(-1, null, null));
+        }
+
+        @Test
+        @DisplayName("accepts boundary value 1")
+        void constructor_accepts_minimumOneCompletion() {
+            CompletionPrerequisiteCondition condition = new CompletionPrerequisiteCondition(1, null, null);
+            assertEquals(1, condition.getMinCompletions());
+        }
+
+        @Test
+        @DisplayName("no-arg prototype has minCompletions of 1")
+        void noArgConstructor_hasDefaultValues() {
+            CompletionPrerequisiteCondition prototype = new CompletionPrerequisiteCondition();
+            assertEquals(1, prototype.getMinCompletions());
+            assertTrue(prototype.getCategoryKey().isEmpty());
+            assertTrue(prototype.getMinRarity().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("getters")
+    class Getters {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:completion_prerequisite")
+        void getKey_returnsMcrpgCompletionPrerequisite() {
+            assertEquals(NamespacedKey.fromString("mcrpg:completion_prerequisite"),
+                    new CompletionPrerequisiteCondition(5, null, null).getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            Optional<NamespacedKey> key = new CompletionPrerequisiteCondition(5, null, null).getExpansionKey();
+            assertTrue(key.isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, key.get());
+        }
+
+        @Test
+        @DisplayName("getMinCompletions returns configured value")
+        void getMinCompletions_returnsConfiguredValue() {
+            assertEquals(10, new CompletionPrerequisiteCondition(10, null, null).getMinCompletions());
+        }
+
+        @Test
+        @DisplayName("getCategoryKey returns empty when null")
+        void getCategoryKey_returnsEmpty_whenNull() {
+            assertTrue(new CompletionPrerequisiteCondition(5, null, null).getCategoryKey().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getCategoryKey returns present when set")
+        void getCategoryKey_returnsPresent_whenSet() {
+            Optional<NamespacedKey> key = new CompletionPrerequisiteCondition(5, DAILY, null).getCategoryKey();
+            assertTrue(key.isPresent());
+            assertEquals(DAILY, key.get());
+        }
+
+        @Test
+        @DisplayName("getMinRarity returns empty when null")
+        void getMinRarity_returnsEmpty_whenNull() {
+            assertTrue(new CompletionPrerequisiteCondition(5, null, null).getMinRarity().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getMinRarity returns present when set")
+        void getMinRarity_returnsPresent_whenSet() {
+            Optional<NamespacedKey> key = new CompletionPrerequisiteCondition(5, null, RARE).getMinRarity();
+            assertTrue(key.isPresent());
+            assertEquals(RARE, key.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("evaluate edge cases")
+    class EvaluateEdgeCases {
+
+        @Test
+        @DisplayName("exact threshold count passes")
+        void evaluate_returnsTrue_whenCountEqualsThreshold() {
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+            UUID playerUUID = UUID.randomUUID();
+            when(history.countCompletedQuests(playerUUID, null, null)).thenReturn(5);
+
+            CompletionPrerequisiteCondition condition = new CompletionPrerequisiteCondition(5, null, null);
+            ConditionContext ctx = new ConditionContext(null, null, null, null, playerUUID, history);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("one below threshold fails")
+        void evaluate_returnsFalse_whenOneBelow() {
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+            UUID playerUUID = UUID.randomUUID();
+            when(history.countCompletedQuests(playerUUID, null, null)).thenReturn(4);
+
+            CompletionPrerequisiteCondition condition = new CompletionPrerequisiteCondition(5, null, null);
+            ConditionContext ctx = new ConditionContext(null, null, null, null, playerUUID, history);
+            assertFalse(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("with both category and rarity filters")
+        void evaluate_usesBothFilters() {
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+            UUID playerUUID = UUID.randomUUID();
+            when(history.countCompletedQuests(playerUUID, DAILY, RARE)).thenReturn(3);
+
+            CompletionPrerequisiteCondition condition = new CompletionPrerequisiteCondition(3, DAILY, RARE);
+            ConditionContext ctx = new ConditionContext(null, null, null, null, playerUUID, history);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("zero completions with threshold of 1 fails")
+        void evaluate_zeroCompletions_fails() {
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+            UUID playerUUID = UUID.randomUUID();
+            when(history.countCompletedQuests(playerUUID, null, null)).thenReturn(0);
+
+            CompletionPrerequisiteCondition condition = new CompletionPrerequisiteCondition(1, null, null);
+            ConditionContext ctx = new ConditionContext(null, null, null, null, playerUUID, history);
+            assertFalse(condition.evaluate(ctx));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("serializes min-completions only when no filters")
+        void serializeConfig_noFilters_onlyMinCompletions() {
+            Map<String, Object> config = new CompletionPrerequisiteCondition(5, null, null).serializeConfig();
+            assertEquals(5, config.get("min-completions"));
+            assertEquals(1, config.size());
+        }
+
+        @Test
+        @DisplayName("serializes category when present")
+        void serializeConfig_withCategory() {
+            Map<String, Object> config = new CompletionPrerequisiteCondition(5, DAILY, null).serializeConfig();
+            assertEquals(5, config.get("min-completions"));
+            assertEquals("mcrpg:personal_daily", config.get("category"));
+            assertEquals(2, config.size());
+        }
+
+        @Test
+        @DisplayName("serializes min-rarity when present")
+        void serializeConfig_withMinRarity() {
+            Map<String, Object> config = new CompletionPrerequisiteCondition(5, null, RARE).serializeConfig();
+            assertEquals(5, config.get("min-completions"));
+            assertEquals("mcrpg:rare", config.get("min-rarity"));
+            assertEquals(2, config.size());
+        }
+
+        @Test
+        @DisplayName("serializes all fields when both filters present")
+        void serializeConfig_withBothFilters() {
+            Map<String, Object> config = new CompletionPrerequisiteCondition(10, DAILY, RARE).serializeConfig();
+            assertEquals(10, config.get("min-completions"));
+            assertEquals("mcrpg:personal_daily", config.get("category"));
+            assertEquals("mcrpg:rare", config.get("min-rarity"));
+            assertEquals(3, config.size());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/CompoundConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/CompoundConditionTest.java
@@ -1,0 +1,204 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CompoundCondition")
+class CompoundConditionTest {
+
+    private TemplateCondition alwaysTrue() {
+        TemplateCondition m = mock(TemplateCondition.class);
+        when(m.evaluate(any())).thenReturn(true);
+        when(m.getKey()).thenReturn(NamespacedKey.fromString("mcrpg:stub_true"));
+        when(m.serializeConfig()).thenReturn(Map.of());
+        return m;
+    }
+
+    private TemplateCondition alwaysFalse() {
+        TemplateCondition m = mock(TemplateCondition.class);
+        when(m.evaluate(any())).thenReturn(false);
+        when(m.getKey()).thenReturn(NamespacedKey.fromString("mcrpg:stub_false"));
+        when(m.serializeConfig()).thenReturn(Map.of());
+        return m;
+    }
+
+    @Nested
+    @DisplayName("constructor validation")
+    class ConstructorValidation {
+
+        @Test
+        @DisplayName("rejects empty conditions map")
+        void constructor_throws_whenConditionsEmpty() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new CompoundCondition(Map.of(), CompoundCondition.LogicMode.ALL));
+        }
+
+        @Test
+        @DisplayName("no-arg prototype creates empty ALL compound")
+        void noArgConstructor_createsPrototype() {
+            CompoundCondition prototype = new CompoundCondition();
+            assertEquals(CompoundCondition.LogicMode.ALL, prototype.getMode());
+            assertTrue(prototype.getConditions().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("getters")
+    class Getters {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:compound")
+        void getKey_returnsMcrpgCompound() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue()), CompoundCondition.LogicMode.ALL);
+            assertEquals(NamespacedKey.fromString("mcrpg:compound"), condition.getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue()), CompoundCondition.LogicMode.ANY);
+            Optional<NamespacedKey> key = condition.getExpansionKey();
+            assertTrue(key.isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, key.get());
+        }
+
+        @Test
+        @DisplayName("getMode returns ALL when constructed with ALL")
+        void getMode_returnsALL() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue()), CompoundCondition.LogicMode.ALL);
+            assertEquals(CompoundCondition.LogicMode.ALL, condition.getMode());
+        }
+
+        @Test
+        @DisplayName("getMode returns ANY when constructed with ANY")
+        void getMode_returnsANY() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue()), CompoundCondition.LogicMode.ANY);
+            assertEquals(CompoundCondition.LogicMode.ANY, condition.getMode());
+        }
+
+        @Test
+        @DisplayName("getConditions returns unmodifiable map")
+        void getConditions_returnsUnmodifiableMap() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue()), CompoundCondition.LogicMode.ALL);
+            assertThrows(UnsupportedOperationException.class,
+                    () -> condition.getConditions().put("b", alwaysFalse()));
+        }
+
+        @Test
+        @DisplayName("getConditions preserves entries")
+        void getConditions_preservesEntries() {
+            TemplateCondition child = alwaysTrue();
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("label", child), CompoundCondition.LogicMode.ALL);
+            assertEquals(1, condition.getConditions().size());
+            assertTrue(condition.getConditions().containsKey("label"));
+        }
+    }
+
+    @Nested
+    @DisplayName("evaluate edge cases")
+    class EvaluateEdgeCases {
+
+        @Test
+        @DisplayName("ALL with single true child returns true")
+        void all_singleTrueChild_returnsTrue() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("only", alwaysTrue()), CompoundCondition.LogicMode.ALL);
+            assertTrue(condition.evaluate(new ConditionContext(null, null, null, null, null, null)));
+        }
+
+        @Test
+        @DisplayName("ANY with single false child returns false")
+        void any_singleFalseChild_returnsFalse() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("only", alwaysFalse()), CompoundCondition.LogicMode.ANY);
+            assertFalse(condition.evaluate(new ConditionContext(null, null, null, null, null, null)));
+        }
+
+        @Test
+        @DisplayName("ALL with all false children returns false")
+        void all_allFalseChildren_returnsFalse() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysFalse(), "b", alwaysFalse()),
+                    CompoundCondition.LogicMode.ALL);
+            assertFalse(condition.evaluate(new ConditionContext(null, null, null, null, null, null)));
+        }
+
+        @Test
+        @DisplayName("ANY with all true children returns true")
+        void any_allTrueChildren_returnsTrue() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue(), "b", alwaysTrue()),
+                    CompoundCondition.LogicMode.ANY);
+            assertTrue(condition.evaluate(new ConditionContext(null, null, null, null, null, null)));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("ALL mode serializes under 'all' key")
+        void serializeConfig_allMode_usesAllKey() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("child", alwaysTrue()), CompoundCondition.LogicMode.ALL);
+            Map<String, Object> config = condition.serializeConfig();
+            assertTrue(config.containsKey("all"));
+            assertFalse(config.containsKey("any"));
+        }
+
+        @Test
+        @DisplayName("ANY mode serializes under 'any' key")
+        void serializeConfig_anyMode_usesAnyKey() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("child", alwaysTrue()), CompoundCondition.LogicMode.ANY);
+            Map<String, Object> config = condition.serializeConfig();
+            assertTrue(config.containsKey("any"));
+            assertFalse(config.containsKey("all"));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("child entries include type key")
+        void serializeConfig_childEntriesIncludeTypeKey() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("label", alwaysTrue()), CompoundCondition.LogicMode.ALL);
+            Map<String, Object> config = condition.serializeConfig();
+            Map<String, Object> children = (Map<String, Object>) config.get("all");
+            Map<String, Object> child = (Map<String, Object>) children.get("label");
+            assertEquals("mcrpg:stub_true", child.get("type"));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        @DisplayName("multiple children all serialized")
+        void serializeConfig_multipleChildren() {
+            CompoundCondition condition = new CompoundCondition(
+                    Map.of("a", alwaysTrue(), "b", alwaysFalse()),
+                    CompoundCondition.LogicMode.ALL);
+            Map<String, Object> config = condition.serializeConfig();
+            Map<String, Object> children = (Map<String, Object>) config.get("all");
+            assertEquals(2, children.size());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/RarityConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/RarityConditionTest.java
@@ -1,0 +1,157 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.board.rarity.QuestRarity;
+import us.eunoians.mcrpg.quest.board.rarity.QuestRarityRegistry;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("RarityCondition")
+class RarityConditionTest {
+
+    private static final NamespacedKey COMMON = NamespacedKey.fromString("mcrpg:common");
+    private static final NamespacedKey RARE = NamespacedKey.fromString("mcrpg:rare");
+    private static final NamespacedKey LEGENDARY = NamespacedKey.fromString("mcrpg:legendary");
+    private static final NamespacedKey UNKNOWN = NamespacedKey.fromString("mcrpg:unknown");
+
+    private QuestRarityRegistry rarityRegistry;
+
+    @BeforeEach
+    void setUp() {
+        rarityRegistry = mock(QuestRarityRegistry.class);
+
+        QuestRarity commonRarity = mock(QuestRarity.class);
+        QuestRarity rareRarity = mock(QuestRarity.class);
+        QuestRarity legendaryRarity = mock(QuestRarity.class);
+
+        when(commonRarity.getWeight()).thenReturn(100);
+        when(rareRarity.getWeight()).thenReturn(20);
+        when(legendaryRarity.getWeight()).thenReturn(5);
+
+        when(rarityRegistry.get(COMMON)).thenReturn(Optional.of(commonRarity));
+        when(rarityRegistry.get(RARE)).thenReturn(Optional.of(rareRarity));
+        when(rarityRegistry.get(LEGENDARY)).thenReturn(Optional.of(legendaryRarity));
+        when(rarityRegistry.get(UNKNOWN)).thenReturn(Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("constructor")
+    class Constructor {
+
+        @Test
+        @DisplayName("no-arg prototype uses KEY as placeholder rarity")
+        void noArgConstructor_usesKeyAsPlaceholder() {
+            RarityCondition prototype = new RarityCondition();
+            assertEquals(RarityCondition.KEY, prototype.getMinimumRarity());
+        }
+    }
+
+    @Nested
+    @DisplayName("getters")
+    class Getters {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:rarity_gate")
+        void getKey_returnsMcrpgRarityGate() {
+            assertEquals(NamespacedKey.fromString("mcrpg:rarity_gate"), new RarityCondition(RARE).getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            Optional<NamespacedKey> key = new RarityCondition(RARE).getExpansionKey();
+            assertTrue(key.isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, key.get());
+        }
+
+        @Test
+        @DisplayName("getMinimumRarity returns configured rarity key")
+        void getMinimumRarity_returnsConfiguredKey() {
+            assertEquals(RARE, new RarityCondition(RARE).getMinimumRarity());
+        }
+    }
+
+    @Nested
+    @DisplayName("evaluate edge cases")
+    class EvaluateEdgeCases {
+
+        @Test
+        @DisplayName("unregistered rolled rarity returns false")
+        void evaluate_returnsFalse_whenRolledRarityUnregistered() {
+            RarityCondition condition = new RarityCondition(RARE);
+            ConditionContext ctx = new ConditionContext(UNKNOWN, rarityRegistry, null, null, null, null);
+            assertFalse(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("unregistered minimum rarity returns false")
+        void evaluate_returnsFalse_whenMinimumRarityUnregistered() {
+            RarityCondition condition = new RarityCondition(UNKNOWN);
+            ConditionContext ctx = new ConditionContext(COMMON, rarityRegistry, null, null, null, null);
+            assertFalse(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("both null fields return true (pass-through)")
+        void evaluate_returnsTrue_whenBothFieldsNull() {
+            RarityCondition condition = new RarityCondition(RARE);
+            ConditionContext ctx = new ConditionContext(null, null, null, null, null, null);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("same rarity as minimum passes (equal weight)")
+        void evaluate_returnsTrue_whenWeightsEqual() {
+            RarityCondition condition = new RarityCondition(RARE);
+            ConditionContext ctx = new ConditionContext(RARE, rarityRegistry, null, null, null, null);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("rarer than minimum passes (lower weight)")
+        void evaluate_returnsTrue_whenRolledIsRarer() {
+            RarityCondition condition = new RarityCondition(RARE);
+            ConditionContext ctx = new ConditionContext(LEGENDARY, rarityRegistry, null, null, null, null);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("less rare than minimum fails (higher weight)")
+        void evaluate_returnsFalse_whenRolledIsLessRare() {
+            RarityCondition condition = new RarityCondition(RARE);
+            ConditionContext ctx = new ConditionContext(COMMON, rarityRegistry, null, null, null, null);
+            assertFalse(condition.evaluate(ctx));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("serializes min-rarity key")
+        void serializeConfig_containsMinRarityKey() {
+            Map<String, Object> config = new RarityCondition(RARE).serializeConfig();
+            assertEquals("mcrpg:rare", config.get("min-rarity"));
+        }
+
+        @Test
+        @DisplayName("serialized map has exactly one entry")
+        void serializeConfig_hasOneEntry() {
+            Map<String, Object> config = new RarityCondition(RARE).serializeConfig();
+            assertEquals(1, config.size());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/VariableCheckTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/VariableCheckTest.java
@@ -1,0 +1,148 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("VariableCheck")
+class VariableCheckTest {
+
+    @Nested
+    @DisplayName("ContainsAny")
+    class ContainsAnyTests {
+
+        @Test
+        @DisplayName("matches when list contains a target value")
+        void test_returnsTrue_whenListContainsMatch() {
+            var check = new VariableCheck.ContainsAny(List.of("DIAMOND_ORE", "GOLD_ORE"));
+            assertTrue(check.test(List.of("IRON_ORE", "DIAMOND_ORE", "STONE")));
+        }
+
+        @Test
+        @DisplayName("no match when list has no overlap")
+        void test_returnsFalse_whenListHasNoOverlap() {
+            var check = new VariableCheck.ContainsAny(List.of("DIAMOND_ORE"));
+            assertFalse(check.test(List.of("IRON_ORE", "STONE")));
+        }
+
+        @Test
+        @DisplayName("matches scalar value via toString")
+        void test_returnsTrue_whenScalarMatches() {
+            var check = new VariableCheck.ContainsAny(List.of("hello", "world"));
+            assertTrue(check.test("world"));
+        }
+
+        @Test
+        @DisplayName("no match for scalar when value absent")
+        void test_returnsFalse_whenScalarDoesNotMatch() {
+            var check = new VariableCheck.ContainsAny(List.of("hello"));
+            assertFalse(check.test("goodbye"));
+        }
+
+        @Test
+        @DisplayName("scalar numeric converts via toString")
+        void test_matchesNumericScalar_viaToString() {
+            var check = new VariableCheck.ContainsAny(List.of("42"));
+            assertTrue(check.test(42));
+        }
+
+        @Test
+        @DisplayName("empty target list never matches")
+        void test_returnsFalse_whenTargetListEmpty() {
+            var check = new VariableCheck.ContainsAny(List.of());
+            assertFalse(check.test(List.of("anything")));
+        }
+
+        @Test
+        @DisplayName("empty resolved list never matches")
+        void test_returnsFalse_whenResolvedListEmpty() {
+            var check = new VariableCheck.ContainsAny(List.of("DIAMOND_ORE"));
+            assertFalse(check.test(List.of()));
+        }
+
+        @Test
+        @DisplayName("values list is defensively copied")
+        void values_areDefensivelyCopied() {
+            var mutable = new ArrayList<>(List.of("A", "B"));
+            var check = new VariableCheck.ContainsAny(mutable);
+            mutable.add("C");
+            assertEquals(2, check.values().size());
+        }
+
+        @Test
+        @DisplayName("values list is unmodifiable")
+        void values_areUnmodifiable() {
+            var check = new VariableCheck.ContainsAny(List.of("A"));
+            assertThrows(UnsupportedOperationException.class, () -> check.values().add("B"));
+        }
+    }
+
+    @Nested
+    @DisplayName("NumericComparison")
+    class NumericComparisonTests {
+
+        @Test
+        @DisplayName("passes when Number satisfies comparison")
+        void test_returnsTrue_whenNumberSatisfiesComparison() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 10.0);
+            assertTrue(check.test(15));
+        }
+
+        @Test
+        @DisplayName("fails when Number does not satisfy comparison")
+        void test_returnsFalse_whenNumberFailsComparison() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 10.0);
+            assertFalse(check.test(5));
+        }
+
+        @Test
+        @DisplayName("works with Long value")
+        void test_handlesLong() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.LESS_THAN_OR_EQUAL, 100.0);
+            assertTrue(check.test(50L));
+        }
+
+        @Test
+        @DisplayName("works with Double value")
+        void test_handlesDouble() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN_OR_EQUAL, 2.5);
+            assertTrue(check.test(2.5));
+        }
+
+        @Test
+        @DisplayName("returns false for non-Number value")
+        void test_returnsFalse_whenValueNotNumber() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 0.0);
+            assertFalse(check.test("not a number"));
+        }
+
+        @Test
+        @DisplayName("returns false for list value")
+        void test_returnsFalse_whenValueIsList() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 0.0);
+            assertFalse(check.test(List.of(1, 2, 3)));
+        }
+
+        @Test
+        @DisplayName("operator accessor returns stored operator")
+        void operator_returnsStoredValue() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.LESS_THAN, 5.0);
+            assertEquals(ComparisonOperator.LESS_THAN, check.operator());
+        }
+
+        @Test
+        @DisplayName("threshold accessor returns stored value")
+        void threshold_returnsStoredValue() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.LESS_THAN, 42.5);
+            assertEquals(42.5, check.threshold());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/VariableConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/VariableConditionTest.java
@@ -1,0 +1,183 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.board.template.ResolvedVariableContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("VariableCondition")
+class VariableConditionTest {
+
+    @Nested
+    @DisplayName("constructor")
+    class Constructor {
+
+        @Test
+        @DisplayName("no-arg prototype has empty variable name")
+        void noArgConstructor_hasEmptyVariableName() {
+            VariableCondition prototype = new VariableCondition();
+            assertEquals("", prototype.getVariableName());
+        }
+
+        @Test
+        @DisplayName("no-arg prototype has ContainsAny check")
+        void noArgConstructor_hasContainsAnyCheck() {
+            VariableCondition prototype = new VariableCondition();
+            assertInstanceOf(VariableCheck.ContainsAny.class, prototype.getCheck());
+        }
+    }
+
+    @Nested
+    @DisplayName("getters")
+    class Getters {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:variable_check")
+        void getKey_returnsMcrpgVariableCheck() {
+            VariableCondition condition = new VariableCondition("test",
+                    new VariableCheck.ContainsAny(List.of()));
+            assertEquals(NamespacedKey.fromString("mcrpg:variable_check"), condition.getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            VariableCondition condition = new VariableCondition("test",
+                    new VariableCheck.ContainsAny(List.of()));
+            Optional<NamespacedKey> key = condition.getExpansionKey();
+            assertTrue(key.isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, key.get());
+        }
+
+        @Test
+        @DisplayName("getVariableName returns configured name")
+        void getVariableName_returnsConfiguredName() {
+            VariableCondition condition = new VariableCondition("target_blocks",
+                    new VariableCheck.ContainsAny(List.of()));
+            assertEquals("target_blocks", condition.getVariableName());
+        }
+
+        @Test
+        @DisplayName("getCheck returns configured check")
+        void getCheck_returnsConfiguredCheck() {
+            var check = new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 5.0);
+            VariableCondition condition = new VariableCondition("count", check);
+            assertEquals(check, condition.getCheck());
+        }
+    }
+
+    @Nested
+    @DisplayName("evaluate edge cases")
+    class EvaluateEdgeCases {
+
+        @Test
+        @DisplayName("ContainsAny matches partial overlap in list variable")
+        void evaluate_containsAny_partialListOverlap() {
+            VariableCondition condition = new VariableCondition("blocks",
+                    new VariableCheck.ContainsAny(List.of("DIAMOND_ORE", "EMERALD_ORE")));
+            ResolvedVariableContext vars = new ResolvedVariableContext(
+                    Map.of("blocks", List.of("STONE", "DIAMOND_ORE")), 1.0, 1.0, 1.0);
+            ConditionContext ctx = new ConditionContext(null, null, null, vars, null, null);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("NumericComparison LESS_THAN_OR_EQUAL boundary passes")
+        void evaluate_numericComparison_lessThanOrEqual_boundary() {
+            VariableCondition condition = new VariableCondition("count",
+                    new VariableCheck.NumericComparison(ComparisonOperator.LESS_THAN_OR_EQUAL, 50.0));
+            ResolvedVariableContext vars = new ResolvedVariableContext(
+                    Map.of("count", 50L), 1.0, 1.0, 1.0);
+            ConditionContext ctx = new ConditionContext(null, null, null, vars, null, null);
+            assertTrue(condition.evaluate(ctx));
+        }
+
+        @Test
+        @DisplayName("non-Number variable with numeric check returns false")
+        void evaluate_nonNumberVariable_withNumericCheck_returnsFalse() {
+            VariableCondition condition = new VariableCondition("name",
+                    new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 0.0));
+            ResolvedVariableContext vars = new ResolvedVariableContext(
+                    Map.of("name", "text"), 1.0, 1.0, 1.0);
+            ConditionContext ctx = new ConditionContext(null, null, null, vars, null, null);
+            assertFalse(condition.evaluate(ctx));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("ContainsAny serializes with name and contains-any keys")
+        void serializeConfig_containsAny() {
+            VariableCondition condition = new VariableCondition("blocks",
+                    new VariableCheck.ContainsAny(List.of("A", "B")));
+            Map<String, Object> config = condition.serializeConfig();
+            assertEquals("blocks", config.get("name"));
+            assertEquals(List.of("A", "B"), config.get("contains-any"));
+            assertEquals(2, config.size());
+        }
+
+        @Test
+        @DisplayName("GREATER_THAN serializes as greater-than key")
+        void serializeConfig_greaterThan() {
+            VariableCondition condition = new VariableCondition("count",
+                    new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN, 10.0));
+            Map<String, Object> config = condition.serializeConfig();
+            assertEquals("count", config.get("name"));
+            assertEquals(10.0, config.get("greater-than"));
+        }
+
+        @Test
+        @DisplayName("LESS_THAN serializes as less-than key")
+        void serializeConfig_lessThan() {
+            VariableCondition condition = new VariableCondition("count",
+                    new VariableCheck.NumericComparison(ComparisonOperator.LESS_THAN, 5.0));
+            Map<String, Object> config = condition.serializeConfig();
+            assertEquals(5.0, config.get("less-than"));
+        }
+
+        @Test
+        @DisplayName("GREATER_THAN_OR_EQUAL serializes as at-least key")
+        void serializeConfig_atLeast() {
+            VariableCondition condition = new VariableCondition("count",
+                    new VariableCheck.NumericComparison(ComparisonOperator.GREATER_THAN_OR_EQUAL, 3.0));
+            Map<String, Object> config = condition.serializeConfig();
+            assertEquals(3.0, config.get("at-least"));
+        }
+
+        @Test
+        @DisplayName("LESS_THAN_OR_EQUAL serializes as at-most key")
+        void serializeConfig_atMost() {
+            VariableCondition condition = new VariableCondition("count",
+                    new VariableCheck.NumericComparison(ComparisonOperator.LESS_THAN_OR_EQUAL, 100.0));
+            Map<String, Object> config = condition.serializeConfig();
+            assertEquals(100.0, config.get("at-most"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(ComparisonOperator.class)
+        @DisplayName("all operators produce a map with exactly 2 entries")
+        void serializeConfig_numericComparison_hasTwoEntries(ComparisonOperator operator) {
+            VariableCondition condition = new VariableCondition("x",
+                    new VariableCheck.NumericComparison(operator, 1.0));
+            Map<String, Object> config = condition.serializeConfig();
+            assertEquals(2, config.size());
+            assertTrue(config.containsKey("name"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Add 112 unit tests** across 6 new test classes covering the quest board template condition package (`us.eunoians.mcrpg.quest.board.template.condition`), raising package line coverage from **59.7% → 81.4%**
- Tests cover constructor validation, getter contracts, `serializeConfig()` round-trip behavior, and `evaluate()` edge cases that were not covered by the existing `TemplateConditionTest`

### Classes covered

| Class | Before | After | Tests added |
|-------|--------|-------|-------------|
| `ComparisonOperator` (LESS_THAN enum) | 50% | 100% | 20 |
| `VariableCheck.ContainsAny` | 100% | 100% | 9 (defensive copy, immutability, scalar) |
| `VariableCheck.NumericComparison` | 75% | 100% | 8 (non-Number edge case) |
| `ChanceCondition` | 58.8% | 94.1% | 10 |
| `CompoundCondition` | 31.4% | 77.1% | 16 |
| `RarityCondition` | 48.0% | 72.0% | 12 |
| `VariableCondition` | 38.2% | 91.2% | 18 |
| `CompletionPrerequisiteCondition` | 39.5% | 78.9% | 19 |

### What's tested

- **Constructor validation:** Invalid probability ranges (`ChanceCondition`), empty condition maps (`CompoundCondition`), zero/negative `minCompletions` (`CompletionPrerequisiteCondition`)
- **Getters:** `getKey()`, `getExpansionKey()`, domain-specific accessors (`getChance()`, `getMode()`, `getConditions()`, `getMinimumRarity()`, `getVariableName()`, `getCheck()`, `getMinCompletions()`, `getCategoryKey()`, `getMinRarity()`)
- **Serialization:** `serializeConfig()` key correctness for all `ComparisonOperator` → YAML key mappings (`greater-than`, `less-than`, `at-least`, `at-most`), `ContainsAny` list serialization, `CompoundCondition` child type injection, optional field omission in `CompletionPrerequisiteCondition`
- **Edge cases:** Unregistered rarity keys returning false, non-Number values with numeric checks, defensive copy and immutability of `ContainsAny.values()`, single-child compound evaluation, both-null pass-through semantics

### Remaining uncovered lines

The remaining ~19% uncovered in these classes is almost entirely `fromConfig(Section, ConditionParser)` methods that parse boostedyaml `Section` objects — these are already partially covered by the existing `TemplateConditionParsingTest`.

**Total: 112 new test cases across 6 test files (project total: 2,407 tests)**

## Test plan

- [x] All 2,407 tests pass via `./gradlew test`
- [x] Zero regressions across the full test suite
- [x] Tests follow CLAUDE.md naming conventions (`@DisplayName` short labels, `action_outcome_whenCondition` method names, `@Nested` grouping)
- [x] Persona testing audit run against all changes — all 7 files pass
- [x] No MockBukkit needed — all tests are pure logic using JUnit 5 + Mockito

https://claude.ai/code/session_014cTDtfTwpZX6NFAQDkg983

---
_Generated by [Claude Code](https://claude.ai/code/session_014cTDtfTwpZX6NFAQDkg983)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for quest board condition functionality, ensuring reliability of chance-based events, completion tracking, rarity filtering, variable comparisons, and condition logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->