### PR TITLE
[Unit Tests] Exception classes, player entity events, and PendingReward coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/event/entity/player/PlayerEntityEventCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/entity/player/PlayerEntityEventCoverageTest.java
@@ -1,0 +1,204 @@
+package us.eunoians.mcrpg.event.entity.player;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.event.entity.player.PlayerSafeZoneStateChangeEvent.SafeZoneStateChangeType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(McRPGPlayerExtension.class)
+public class PlayerEntityEventCoverageTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("PlayerAwardedRestedExperienceEvent")
+    class PlayerAwardedRestedExperienceEventTests {
+
+        @Test
+        @DisplayName("getRestedExperience returns constructor value")
+        void getRestedExperience_returnsConstructorValue(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            assertEquals(50.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("getMaxAccumulation returns constructor value")
+        void getMaxAccumulation_returnsConstructorValue(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 200.0);
+            assertEquals(200.0, event.getMaxAccumulation());
+        }
+
+        @Test
+        @DisplayName("getMcRPGPlayer returns constructor value")
+        void getMcRPGPlayer_returnsConstructorValue(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            assertSame(player, event.getMcRPGPlayer());
+        }
+
+        @Test
+        @DisplayName("negative restedExperience clamped to zero")
+        void negativeRestedExperience_clampedToZero(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, -10.0f, 100.0);
+            assertEquals(0.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("negative maxAccumulation clamped to zero")
+        void negativeMaxAccumulation_clampedToZero(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, -5.0);
+            assertEquals(0.0, event.getMaxAccumulation());
+        }
+
+        @Test
+        @DisplayName("setRestedExperience updates value")
+        void setRestedExperience_updatesValue(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            event.setRestedExperience(75.0);
+            assertEquals(75.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("setRestedExperience clamps to zero when negative")
+        void setRestedExperience_clampsToZero_whenNegative(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            event.setRestedExperience(-20.0);
+            assertEquals(0.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("setRestedExperience clamps to maxAccumulation when exceeding")
+        void setRestedExperience_clampsToMax_whenExceeding(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            event.setRestedExperience(500.0);
+            assertEquals(100.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("isCancelled defaults to false")
+        void isCancelled_defaultsFalse(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled changes state")
+        void setCancelled_changesState(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            event.setCancelled(true);
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("setCancelled can revert to false")
+        void setCancelled_canRevert(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            event.setCancelled(true);
+            event.setCancelled(false);
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("getHandlers returns non-null")
+        void getHandlers_returnsNonNull(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            assertNotNull(event.getHandlers());
+        }
+
+        @Test
+        @DisplayName("getHandlerList returns non-null")
+        void getHandlerList_returnsNonNull() {
+            assertNotNull(McRPGPlayerEvent.getHandlerList());
+        }
+
+        @Test
+        @DisplayName("constructor does not clamp restedExperience to maxAccumulation")
+        void constructor_doesNotClampToMax(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 200.0f, 100.0);
+            assertEquals(200.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("zero restedExperience is preserved")
+        void zeroRestedExperience_isPreserved(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 0.0f, 100.0);
+            assertEquals(0.0f, event.getRestedExperience());
+        }
+
+        @Test
+        @DisplayName("setRestedExperience at exactly max is preserved")
+        void setRestedExperience_atMax_isPreserved(McRPGPlayer player) {
+            var event = new PlayerAwardedRestedExperienceEvent(player, 50.0f, 100.0);
+            event.setRestedExperience(100.0);
+            assertEquals(100.0f, event.getRestedExperience());
+        }
+    }
+
+    @Nested
+    @DisplayName("PlayerSafeZoneStateChangeEvent")
+    class PlayerSafeZoneStateChangeEventTests {
+
+        @Test
+        @DisplayName("getSafeZoneStateChangeType returns ENTERED")
+        void getSafeZoneStateChangeType_returnsEntered(McRPGPlayer player) {
+            var event = new PlayerSafeZoneStateChangeEvent(player, SafeZoneStateChangeType.ENTERED);
+            assertEquals(SafeZoneStateChangeType.ENTERED, event.getSafeZoneStateChangeType());
+        }
+
+        @Test
+        @DisplayName("getSafeZoneStateChangeType returns LEFT")
+        void getSafeZoneStateChangeType_returnsLeft(McRPGPlayer player) {
+            var event = new PlayerSafeZoneStateChangeEvent(player, SafeZoneStateChangeType.LEFT);
+            assertEquals(SafeZoneStateChangeType.LEFT, event.getSafeZoneStateChangeType());
+        }
+
+        @Test
+        @DisplayName("getMcRPGPlayer returns constructor value")
+        void getMcRPGPlayer_returnsConstructorValue(McRPGPlayer player) {
+            var event = new PlayerSafeZoneStateChangeEvent(player, SafeZoneStateChangeType.ENTERED);
+            assertSame(player, event.getMcRPGPlayer());
+        }
+
+        @Test
+        @DisplayName("getHandlers returns non-null")
+        void getHandlers_returnsNonNull(McRPGPlayer player) {
+            var event = new PlayerSafeZoneStateChangeEvent(player, SafeZoneStateChangeType.ENTERED);
+            assertNotNull(event.getHandlers());
+        }
+
+        @ParameterizedTest
+        @EnumSource(SafeZoneStateChangeType.class)
+        @DisplayName("all SafeZoneStateChangeType values are usable")
+        void allSafeZoneStateChangeTypes_areUsable(SafeZoneStateChangeType type, McRPGPlayer player) {
+            var event = new PlayerSafeZoneStateChangeEvent(player, type);
+            assertEquals(type, event.getSafeZoneStateChangeType());
+        }
+    }
+
+    @Nested
+    @DisplayName("SafeZoneStateChangeType")
+    class SafeZoneStateChangeTypeTests {
+
+        @Test
+        @DisplayName("enum has exactly two values")
+        void enumHasTwoValues() {
+            assertEquals(2, SafeZoneStateChangeType.values().length);
+        }
+
+        @ParameterizedTest
+        @EnumSource(SafeZoneStateChangeType.class)
+        @DisplayName("valueOf round-trips")
+        void valueOf_roundTrips(SafeZoneStateChangeType type) {
+            assertEquals(type, SafeZoneStateChangeType.valueOf(type.name()));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/exception/ExceptionCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/exception/ExceptionCoverageTest.java
@@ -1,0 +1,453 @@
+package us.eunoians.mcrpg.exception;
+
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.Event;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.entity.holder.LoadoutHolder;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.exception.ability.AbilityActivatedWithWrongEventException;
+import us.eunoians.mcrpg.exception.ability.AbilityNotRegisteredException;
+import us.eunoians.mcrpg.exception.ability.EventNotRegisteredForActivationException;
+import us.eunoians.mcrpg.exception.database.AbilityDatabaseNameException;
+import us.eunoians.mcrpg.exception.entity.SkillHolderMissingSkillException;
+import us.eunoians.mcrpg.exception.expansion.ContentPackFailedProcessingException;
+import us.eunoians.mcrpg.exception.external.worldguard.WorldGuardFlagRegisterException;
+import us.eunoians.mcrpg.exception.loadout.InvalidAbilityForLoadoutException;
+import us.eunoians.mcrpg.exception.loadout.LoadoutMaxSizeExceededException;
+import us.eunoians.mcrpg.exception.loadout.SelectedLoadoutAboveMaxException;
+import us.eunoians.mcrpg.exception.localization.LocaleParseException;
+import us.eunoians.mcrpg.exception.localization.NoLocalizationContainsMessageException;
+import us.eunoians.mcrpg.exception.quest.QuestScopeInvalidStateException;
+import us.eunoians.mcrpg.exception.skill.EventNotRegisteredForLevelingException;
+import us.eunoians.mcrpg.exception.skill.SkillNotRegisteredException;
+import us.eunoians.mcrpg.expansion.content.McRPGContent;
+import us.eunoians.mcrpg.expansion.content.McRPGContentPack;
+import us.eunoians.mcrpg.loadout.Loadout;
+import us.eunoians.mcrpg.quest.impl.scope.QuestScope;
+import us.eunoians.mcrpg.skill.Skill;
+
+import java.util.Locale;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExceptionCoverageTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("AbilityActivatedWithWrongEventException")
+    class AbilityActivatedWithWrongEventExceptionTests {
+
+        @Test
+        @DisplayName("getAbility returns constructor value")
+        void getAbility_returnsConstructorValue() {
+            Ability ability = mock(Ability.class);
+            var exception = new AbilityActivatedWithWrongEventException(ability);
+            assertSame(ability, exception.getAbility());
+        }
+
+        @Test
+        @DisplayName("extends RuntimeException")
+        void extendsRuntimeException() {
+            Ability ability = mock(Ability.class);
+            var exception = new AbilityActivatedWithWrongEventException(ability);
+            assertTrue(exception instanceof RuntimeException);
+        }
+    }
+
+    @Nested
+    @DisplayName("AbilityNotRegisteredException")
+    class AbilityNotRegisteredExceptionTests {
+
+        @Test
+        @DisplayName("getAbilityKey returns constructor value")
+        void getAbilityKey_returnsConstructorValue() {
+            NamespacedKey key = new NamespacedKey("mcrpg", "test_ability");
+            var exception = new AbilityNotRegisteredException(key);
+            assertEquals(key, exception.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getMessage contains ability key")
+        void getMessage_containsAbilityKey() {
+            NamespacedKey key = new NamespacedKey("mcrpg", "test_ability");
+            var exception = new AbilityNotRegisteredException(key);
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("test_ability"));
+        }
+    }
+
+    @Nested
+    @DisplayName("EventNotRegisteredForActivationException")
+    class EventNotRegisteredForActivationExceptionTests {
+
+        @Test
+        @DisplayName("getFailedEvent returns constructor value")
+        void getFailedEvent_returnsConstructorValue() {
+            Event event = mock(Event.class);
+            Ability ability = mock(Ability.class);
+            var exception = new EventNotRegisteredForActivationException(event, ability);
+            assertSame(event, exception.getFailedEvent());
+        }
+
+        @Test
+        @DisplayName("getAbility returns constructor value")
+        void getAbility_returnsConstructorValue() {
+            Event event = mock(Event.class);
+            Ability ability = mock(Ability.class);
+            var exception = new EventNotRegisteredForActivationException(event, ability);
+            assertSame(ability, exception.getAbility());
+        }
+    }
+
+    @Nested
+    @DisplayName("AbilityDatabaseNameException")
+    class AbilityDatabaseNameExceptionTests {
+
+        @Test
+        @DisplayName("getAbility returns constructor value")
+        void getAbility_returnsConstructorValue() {
+            Ability mockAbility = mock(Ability.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "test_ability");
+            when(mockAbility.getDatabaseName()).thenReturn("");
+            when(mockAbility.getAbilityKey()).thenReturn(key);
+            var exception = new AbilityDatabaseNameException(mockAbility);
+            assertSame(mockAbility, exception.getAbility());
+        }
+
+        @Test
+        @DisplayName("getMessage contains ability key")
+        void getMessage_containsAbilityKey() {
+            Ability mockAbility = mock(Ability.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "test_ability");
+            when(mockAbility.getDatabaseName()).thenReturn("");
+            when(mockAbility.getAbilityKey()).thenReturn(key);
+            var exception = new AbilityDatabaseNameException(mockAbility);
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("test_ability"));
+            assertTrue(exception.getMessage().contains("missing a database name"));
+        }
+    }
+
+    @Nested
+    @DisplayName("SkillHolderMissingSkillException")
+    class SkillHolderMissingSkillExceptionTests {
+
+        @Test
+        @DisplayName("getSkillHolder returns constructor value")
+        void getSkillHolder_returnsConstructorValue() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "swords");
+            var exception = new SkillHolderMissingSkillException(skillHolder, key);
+            assertSame(skillHolder, exception.getSkillHolder());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns constructor value")
+        void getSkillKey_returnsConstructorValue() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "swords");
+            var exception = new SkillHolderMissingSkillException(skillHolder, key);
+            assertEquals(key, exception.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("message constructor passes message to super")
+        void messageConstructor_passesMessageToSuper() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "swords");
+            var exception = new SkillHolderMissingSkillException(skillHolder, key, "custom message");
+            assertEquals("custom message", exception.getMessage());
+            assertSame(skillHolder, exception.getSkillHolder());
+            assertEquals(key, exception.getSkillKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("ContentPackFailedProcessingException")
+    class ContentPackFailedProcessingExceptionTests {
+
+        @Test
+        @DisplayName("getContentPack returns constructor value")
+        void getContentPack_returnsConstructorValue() {
+            @SuppressWarnings("unchecked")
+            McRPGContentPack<McRPGContent> contentPack = mock(McRPGContentPack.class);
+            var exception = new ContentPackFailedProcessingException(contentPack);
+            assertSame(contentPack, exception.getContentPack());
+        }
+
+        @Test
+        @DisplayName("getMessage contains class name and expansion key")
+        void getMessage_containsClassNameAndExpansionKey() {
+            @SuppressWarnings("unchecked")
+            McRPGContentPack<McRPGContent> contentPack = mock(McRPGContentPack.class);
+            var mockExpansion = mock(us.eunoians.mcrpg.expansion.ContentExpansion.class);
+            NamespacedKey expansionKey = new NamespacedKey("mcrpg", "test_expansion");
+            when(contentPack.getContentExpansion()).thenReturn(mockExpansion);
+            when(mockExpansion.getExpansionKey()).thenReturn(expansionKey);
+            var exception = new ContentPackFailedProcessingException(contentPack);
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("Content Pack"));
+            assertTrue(exception.getMessage().contains(expansionKey.toString()));
+        }
+    }
+
+    @Nested
+    @DisplayName("InvalidAbilityForLoadoutException")
+    class InvalidAbilityForLoadoutExceptionTests {
+
+        @Test
+        @DisplayName("getLoadout returns constructor value")
+        void getLoadout_returnsConstructorValue() {
+            Loadout loadout = mock(Loadout.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
+            var exception = new InvalidAbilityForLoadoutException(loadout, key);
+            assertSame(loadout, exception.getLoadout());
+        }
+
+        @Test
+        @DisplayName("getAbilityKey returns constructor value")
+        void getAbilityKey_returnsConstructorValue() {
+            Loadout loadout = mock(Loadout.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
+            var exception = new InvalidAbilityForLoadoutException(loadout, key);
+            assertEquals(key, exception.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("message constructor passes message to super")
+        void messageConstructor_passesMessageToSuper() {
+            Loadout loadout = mock(Loadout.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
+            var exception = new InvalidAbilityForLoadoutException(loadout, key, "not valid");
+            assertEquals("not valid", exception.getMessage());
+            assertSame(loadout, exception.getLoadout());
+            assertEquals(key, exception.getAbilityKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("LoadoutMaxSizeExceededException")
+    class LoadoutMaxSizeExceededExceptionTests {
+
+        @Test
+        @DisplayName("getLoadout returns constructor value")
+        void getLoadout_returnsConstructorValue() {
+            Loadout loadout = mock(Loadout.class);
+            var exception = new LoadoutMaxSizeExceededException(loadout);
+            assertSame(loadout, exception.getLoadout());
+        }
+
+        @Test
+        @DisplayName("message constructor passes message to super")
+        void messageConstructor_passesMessageToSuper() {
+            Loadout loadout = mock(Loadout.class);
+            var exception = new LoadoutMaxSizeExceededException(loadout, "too many abilities");
+            assertEquals("too many abilities", exception.getMessage());
+            assertSame(loadout, exception.getLoadout());
+        }
+
+        @Test
+        @DisplayName("default constructor has null message")
+        void defaultConstructor_hasNullMessage() {
+            Loadout loadout = mock(Loadout.class);
+            var exception = new LoadoutMaxSizeExceededException(loadout);
+            assertEquals(null, exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("SelectedLoadoutAboveMaxException")
+    class SelectedLoadoutAboveMaxExceptionTests {
+
+        @Test
+        @DisplayName("getLoadoutHolder returns constructor value")
+        void getLoadoutHolder_returnsConstructorValue() {
+            LoadoutHolder holder = mock(LoadoutHolder.class);
+            var exception = new SelectedLoadoutAboveMaxException(holder, 5);
+            assertSame(holder, exception.getLoadoutHolder());
+        }
+
+        @Test
+        @DisplayName("getLoadoutSlot returns constructor value")
+        void getLoadoutSlot_returnsConstructorValue() {
+            LoadoutHolder holder = mock(LoadoutHolder.class);
+            var exception = new SelectedLoadoutAboveMaxException(holder, 5);
+            assertEquals(5, exception.getLoadoutSlot());
+        }
+    }
+
+    @Nested
+    @DisplayName("LocaleParseException")
+    class LocaleParseExceptionTests {
+
+        @Test
+        @DisplayName("getParsedLocale returns constructor value")
+        void getParsedLocale_returnsConstructorValue() {
+            var exception = new LocaleParseException("xyz_invalid");
+            assertEquals("xyz_invalid", exception.getParsedLocale());
+        }
+
+        @Test
+        @DisplayName("default message contains locale string")
+        void defaultMessage_containsLocaleString() {
+            var exception = new LocaleParseException("xyz_invalid");
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("xyz_invalid"));
+        }
+
+        @Test
+        @DisplayName("custom message constructor")
+        void customMessage_passedToSuper() {
+            var exception = new LocaleParseException("xyz_invalid", "custom parse error");
+            assertEquals("custom parse error", exception.getMessage());
+            assertEquals("xyz_invalid", exception.getParsedLocale());
+        }
+    }
+
+    @Nested
+    @DisplayName("NoLocalizationContainsMessageException")
+    class NoLocalizationContainsMessageExceptionTests {
+
+        @Test
+        @DisplayName("getRoute returns constructor value")
+        void getRoute_returnsConstructorValue() {
+            Route route = Route.fromString("test.key");
+            var exception = new NoLocalizationContainsMessageException(route, Set.of(Locale.ENGLISH));
+            assertEquals(route, exception.getRoute());
+        }
+
+        @Test
+        @DisplayName("getCheckedLocales returns defensive copy")
+        void getCheckedLocales_returnsDefensiveCopy() {
+            Route route = Route.fromString("test.key");
+            java.util.HashSet<Locale> mutableLocales = new java.util.HashSet<>(Set.of(Locale.ENGLISH, Locale.FRENCH));
+            var exception = new NoLocalizationContainsMessageException(route, mutableLocales);
+            Set<Locale> returned = exception.getCheckedLocales();
+            assertEquals(mutableLocales, returned);
+            assertNotSame(mutableLocales, returned);
+        }
+
+        @Test
+        @DisplayName("getMessage contains route and locale names")
+        void getMessage_containsRouteAndLocaleNames() {
+            Route route = Route.fromString("test.missing.key");
+            var exception = new NoLocalizationContainsMessageException(route, Set.of(Locale.ENGLISH));
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("English"));
+        }
+    }
+
+    @Nested
+    @DisplayName("QuestScopeInvalidStateException")
+    class QuestScopeInvalidStateExceptionTests {
+
+        @Test
+        @DisplayName("getQuestScope returns constructor value")
+        void getQuestScope_returnsConstructorValue() {
+            QuestScope scope = mock(QuestScope.class);
+            var exception = new QuestScopeInvalidStateException(scope);
+            assertSame(scope, exception.getQuestScope());
+        }
+
+        @Test
+        @DisplayName("message constructor passes message to super")
+        void messageConstructor_passesMessageToSuper() {
+            QuestScope scope = mock(QuestScope.class);
+            var exception = new QuestScopeInvalidStateException(scope, "invalid state");
+            assertEquals("invalid state", exception.getMessage());
+            assertSame(scope, exception.getQuestScope());
+        }
+    }
+
+    @Nested
+    @DisplayName("EventNotRegisteredForLevelingException")
+    class EventNotRegisteredForLevelingExceptionTests {
+
+        @Test
+        @DisplayName("getFailedEvent returns constructor value")
+        void getFailedEvent_returnsConstructorValue() {
+            Event event = mock(Event.class);
+            Skill skill = mock(Skill.class);
+            var exception = new EventNotRegisteredForLevelingException(event, skill);
+            assertSame(event, exception.getFailedEvent());
+        }
+
+        @Test
+        @DisplayName("getSkill returns constructor value")
+        void getSkill_returnsConstructorValue() {
+            Event event = mock(Event.class);
+            Skill skill = mock(Skill.class);
+            var exception = new EventNotRegisteredForLevelingException(event, skill);
+            assertSame(skill, exception.getSkill());
+        }
+    }
+
+    @Nested
+    @DisplayName("SkillNotRegisteredException")
+    class SkillNotRegisteredExceptionTests {
+
+        @Test
+        @DisplayName("getSkillKey returns constructor value")
+        void getSkillKey_returnsConstructorValue() {
+            NamespacedKey key = new NamespacedKey("mcrpg", "mining");
+            var exception = new SkillNotRegisteredException(key);
+            assertEquals(key, exception.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("default constructor has null message")
+        void defaultConstructor_hasNullMessage() {
+            NamespacedKey key = new NamespacedKey("mcrpg", "mining");
+            var exception = new SkillNotRegisteredException(key);
+            assertEquals(null, exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("message constructor passes message to super")
+        void messageConstructor_passesMessageToSuper() {
+            NamespacedKey key = new NamespacedKey("mcrpg", "mining");
+            var exception = new SkillNotRegisteredException(key, "not registered");
+            assertEquals("not registered", exception.getMessage());
+            assertEquals(key, exception.getSkillKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("WorldGuardFlagRegisterException")
+    class WorldGuardFlagRegisterExceptionTests {
+
+        @Test
+        @DisplayName("getStateFlagKey returns constructor value")
+        void getStateFlagKey_returnsConstructorValue() {
+            var exception = new WorldGuardFlagRegisterException("mcrpg-pvp");
+            assertEquals("mcrpg-pvp", exception.getStateFlagKey());
+        }
+
+        @Test
+        @DisplayName("default message contains flag key")
+        void defaultMessage_containsFlagKey() {
+            var exception = new WorldGuardFlagRegisterException("mcrpg-pvp");
+            assertNotNull(exception.getMessage());
+            assertTrue(exception.getMessage().contains("mcrpg-pvp"));
+        }
+
+        @Test
+        @DisplayName("custom message constructor")
+        void customMessage_passedToSuper() {
+            var exception = new WorldGuardFlagRegisterException("mcrpg-pvp", "custom conflict");
+            assertEquals("custom conflict", exception.getMessage());
+            assertEquals("mcrpg-pvp", exception.getStateFlagKey());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/PendingRewardCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/PendingRewardCoverageTest.java
@@ -1,0 +1,151 @@
+package us.eunoians.mcrpg.quest.reward;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PendingRewardCoverageTest extends McRPGBaseTest {
+
+    private static final UUID REWARD_ID = UUID.randomUUID();
+    private static final UUID PLAYER_UUID = UUID.randomUUID();
+    private static final NamespacedKey REWARD_TYPE_KEY = new NamespacedKey("mcrpg", "experience");
+    private static final NamespacedKey QUEST_KEY = new NamespacedKey("mcrpg", "test_quest");
+    private static final long CREATED_AT = 1_700_000_000_000L;
+    private static final long EXPIRES_AT = 1_700_086_400_000L;
+
+    private PendingReward createDefault() {
+        return new PendingReward(REWARD_ID, PLAYER_UUID, REWARD_TYPE_KEY,
+                Map.of("skill", "MINING", "amount", 500), QUEST_KEY, CREATED_AT, EXPIRES_AT);
+    }
+
+    @Nested
+    @DisplayName("Constructor and Getters")
+    class ConstructorAndGetterTests {
+
+        @Test
+        @DisplayName("getId returns constructor value")
+        void getId_returnsConstructorValue() {
+            PendingReward reward = createDefault();
+            assertEquals(REWARD_ID, reward.getId());
+        }
+
+        @Test
+        @DisplayName("getPlayerUUID returns constructor value")
+        void getPlayerUUID_returnsConstructorValue() {
+            PendingReward reward = createDefault();
+            assertEquals(PLAYER_UUID, reward.getPlayerUUID());
+        }
+
+        @Test
+        @DisplayName("getRewardTypeKey returns constructor value")
+        void getRewardTypeKey_returnsConstructorValue() {
+            PendingReward reward = createDefault();
+            assertEquals(REWARD_TYPE_KEY, reward.getRewardTypeKey());
+        }
+
+        @Test
+        @DisplayName("getQuestKey returns constructor value")
+        void getQuestKey_returnsConstructorValue() {
+            PendingReward reward = createDefault();
+            assertEquals(QUEST_KEY, reward.getQuestKey());
+        }
+
+        @Test
+        @DisplayName("getCreatedAt returns constructor value")
+        void getCreatedAt_returnsConstructorValue() {
+            PendingReward reward = createDefault();
+            assertEquals(CREATED_AT, reward.getCreatedAt());
+        }
+
+        @Test
+        @DisplayName("getExpiresAt returns constructor value")
+        void getExpiresAt_returnsConstructorValue() {
+            PendingReward reward = createDefault();
+            assertEquals(EXPIRES_AT, reward.getExpiresAt());
+        }
+    }
+
+    @Nested
+    @DisplayName("Serialized Config")
+    class SerializedConfigTests {
+
+        @Test
+        @DisplayName("getSerializedConfig returns expected entries")
+        void getSerializedConfig_returnsExpectedEntries() {
+            PendingReward reward = createDefault();
+            Map<String, Object> config = reward.getSerializedConfig();
+            assertEquals("MINING", config.get("skill"));
+            assertEquals(500, config.get("amount"));
+        }
+
+        @Test
+        @DisplayName("getSerializedConfig returns immutable copy")
+        void getSerializedConfig_returnsImmutableCopy() {
+            PendingReward reward = createDefault();
+            Map<String, Object> config = reward.getSerializedConfig();
+            assertThrows(UnsupportedOperationException.class, () -> config.put("extra", "value"));
+        }
+
+        @Test
+        @DisplayName("original map mutation does not affect pending reward")
+        void originalMapMutation_doesNotAffectReward() {
+            Map<String, Object> originalConfig = new HashMap<>();
+            originalConfig.put("skill", "MINING");
+            originalConfig.put("amount", 500);
+            PendingReward reward = new PendingReward(REWARD_ID, PLAYER_UUID, REWARD_TYPE_KEY,
+                    originalConfig, QUEST_KEY, CREATED_AT, EXPIRES_AT);
+            originalConfig.put("extra", "should not appear");
+            assertEquals(2, reward.getSerializedConfig().size());
+        }
+
+        @Test
+        @DisplayName("empty config is supported")
+        void emptyConfig_isSupported() {
+            PendingReward reward = new PendingReward(REWARD_ID, PLAYER_UUID, REWARD_TYPE_KEY,
+                    Map.of(), QUEST_KEY, CREATED_AT, EXPIRES_AT);
+            assertNotNull(reward.getSerializedConfig());
+            assertTrue(reward.getSerializedConfig().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Timestamp Semantics")
+    class TimestampSemanticsTests {
+
+        @Test
+        @DisplayName("expiresAt after createdAt represents valid window")
+        void expiresAfterCreated_isValidWindow() {
+            PendingReward reward = createDefault();
+            assertTrue(reward.getExpiresAt() > reward.getCreatedAt());
+        }
+
+        @Test
+        @DisplayName("zero timestamps are preserved")
+        void zeroTimestamps_arePreserved() {
+            PendingReward reward = new PendingReward(REWARD_ID, PLAYER_UUID, REWARD_TYPE_KEY,
+                    Map.of(), QUEST_KEY, 0L, 0L);
+            assertEquals(0L, reward.getCreatedAt());
+            assertEquals(0L, reward.getExpiresAt());
+        }
+
+        @Test
+        @DisplayName("negative timestamps are preserved")
+        void negativeTimestamps_arePreserved() {
+            PendingReward reward = new PendingReward(REWARD_ID, PLAYER_UUID, REWARD_TYPE_KEY,
+                    Map.of(), QUEST_KEY, -1L, -1L);
+            assertEquals(-1L, reward.getCreatedAt());
+            assertEquals(-1L, reward.getExpiresAt());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **ExceptionCoverageTest** (37 tests): Covers all 15 exception classes across 8 packages — `AbilityActivatedWithWrongEventException`, `AbilityNotRegisteredException`, `EventNotRegisteredForActivationException`, `AbilityDatabaseNameException`, `SkillHolderMissingSkillException`, `ContentPackFailedProcessingException`, `InvalidAbilityForLoadoutException`, `LoadoutMaxSizeExceededException`, `SelectedLoadoutAboveMaxException`, `LocaleParseException`, `NoLocalizationContainsMessageException`, `QuestScopeInvalidStateException`, `EventNotRegisteredForLevelingException`, `SkillNotRegisteredException`, `WorldGuardFlagRegisterException`. Tests constructor storage, getters, `getMessage()` formatting, custom message overloads, and defensive copy behavior.
- **PlayerEntityEventCoverageTest** (23 tests): Covers `PlayerAwardedRestedExperienceEvent` and `PlayerSafeZoneStateChangeEvent`. Tests constructor clamping (negative values to zero), setter clamping (between 0 and maxAccumulation), asymmetric constructor behavior (constructor does not clamp to max, only setter does), `Cancellable` contract (default false, settable, revertible), `SafeZoneStateChangeType` enum values, and handler list access.
- **PendingRewardCoverageTest** (13 tests): Covers `PendingReward` data class. Tests all 7 getters, serialized config immutability (`Map.copyOf`), defensive copy from original mutable map, empty config support, and timestamp edge cases (zero, negative).

### Packages covered (previously at 0% or low coverage)

| Package | Classes Tested | Tests Added |
|---------|---------------|-------------|
| `exception.ability` | 3 | 7 |
| `exception.database` | 1 | 2 |
| `exception.entity` | 1 | 3 |
| `exception.expansion` | 1 | 2 |
| `exception.loadout` | 3 | 7 |
| `exception.localization` | 2 | 6 |
| `exception.quest` | 1 | 2 |
| `exception.skill` | 2 | 5 |
| `exception.external.worldguard` | 1 | 3 |
| `event.entity.player` | 2 | 23 |
| `quest.reward` (PendingReward) | 1 | 13 |

**Total: 73 new test cases across 3 test files (project total: 2,370 tests, 0 failures)**

## Test plan

- [x] All 2,370 tests pass via `./gradlew verifiedShadowJar`
- [x] Zero regressions across the full test suite
- [x] Tests follow CLAUDE.md naming conventions (`@Test` before `@DisplayName`, short descriptive labels, `action_outcome_whenCondition` method names, `@Nested` grouping)
- [x] Testing audit persona run against all changes — fixed unused imports, added `assertNotSame` for defensive copy verification, added asymmetric constructor clamping test
- [x] `@ParameterizedTest` with `@EnumSource` used for `SafeZoneStateChangeType` enum coverage
- [x] `McRPGPlayerExtension` used correctly for player-dependent event tests

https://claude.ai/code/session_011ZJuVXW6VsLAv8SK83vgEh

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZJuVXW6VsLAv8SK83vgEh)_