### PR TITLE
[Unit Tests] OnAttackComponent, OnBlockBreakComponent, EventActivatableComponentAttribute, Loadout active abilities coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/ability/component/activatable/EventActivatableComponentAttributeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/component/activatable/EventActivatableComponentAttributeTest.java
@@ -1,0 +1,87 @@
+package us.eunoians.mcrpg.ability.component.activatable;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("EventActivatableComponentAttribute")
+public class EventActivatableComponentAttributeTest {
+
+    @Nested
+    @DisplayName("constructor and accessors")
+    class ConstructorAndAccessors {
+
+        @DisplayName("stores and returns the ability component")
+        @Test
+        public void abilityComponent_returnsStoredComponent() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attribute = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 0);
+            assertSame(component, attribute.abilityComponent());
+        }
+
+        @DisplayName("stores and returns the event class")
+        @Test
+        public void clazz_returnsStoredEventClass() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attribute = new EventActivatableComponentAttribute(component, BlockBreakEvent.class, 1);
+            assertEquals(BlockBreakEvent.class, attribute.clazz());
+        }
+
+        @DisplayName("stores and returns the priority")
+        @Test
+        public void priority_returnsStoredPriority() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attribute = new EventActivatableComponentAttribute(component, Event.class, 42);
+            assertEquals(42, attribute.priority());
+        }
+    }
+
+    @Nested
+    @DisplayName("equality")
+    class Equality {
+
+        @DisplayName("equals returns true for identical attributes")
+        @Test
+        public void equals_returnsTrue_whenIdentical() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attr1 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 5);
+            var attr2 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 5);
+            assertEquals(attr1, attr2);
+        }
+
+        @DisplayName("equals returns false when priority differs")
+        @Test
+        public void equals_returnsFalse_whenPriorityDiffers() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attr1 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 0);
+            var attr2 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 1);
+            assertNotEquals(attr1, attr2);
+        }
+
+        @DisplayName("equals returns false when event class differs")
+        @Test
+        public void equals_returnsFalse_whenEventClassDiffers() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attr1 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 0);
+            var attr2 = new EventActivatableComponentAttribute(component, BlockBreakEvent.class, 0);
+            assertNotEquals(attr1, attr2);
+        }
+
+        @DisplayName("hashCode is consistent for equal attributes")
+        @Test
+        public void hashCode_isConsistent_whenEqual() {
+            EventActivatableComponent component = mock(EventActivatableComponent.class);
+            var attr1 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 5);
+            var attr2 = new EventActivatableComponentAttribute(component, EntityDamageByEntityEvent.class, 5);
+            assertEquals(attr1.hashCode(), attr2.hashCode());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/component/activatable/OnAttackComponentTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/component/activatable/OnAttackComponentTest.java
@@ -1,0 +1,141 @@
+package us.eunoians.mcrpg.ability.component.activatable;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("OnAttackComponent")
+public class OnAttackComponentTest extends McRPGBaseTest {
+
+    private static final UUID HOLDER_UUID = UUID.randomUUID();
+    private AbilityHolder holder;
+
+    @BeforeEach
+    public void setup() {
+        holder = mock(AbilityHolder.class);
+        when(holder.getUUID()).thenReturn(HOLDER_UUID);
+    }
+
+    @Nested
+    @DisplayName("shouldActivate")
+    class ShouldActivate {
+
+        @DisplayName("returns true when damager matches holder and affectsEntity is true")
+        @Test
+        public void shouldActivate_returnsTrue_whenDamagerMatchesAndAffectsEntity() {
+            Entity damager = mock(Entity.class);
+            Entity damaged = mock(Entity.class);
+            when(damager.getUniqueId()).thenReturn(HOLDER_UUID);
+
+            EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+            when(event.getDamager()).thenReturn(damager);
+            when(event.getEntity()).thenReturn(damaged);
+
+            OnAttackComponent component = new OnAttackComponent() {
+                @Override
+                public boolean affectsEntity(@NotNull Entity entity) {
+                    return true;
+                }
+            };
+
+            assertTrue(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false when damager UUID does not match holder UUID")
+        @Test
+        public void shouldActivate_returnsFalse_whenDamagerDoesNotMatchHolder() {
+            Entity damager = mock(Entity.class);
+            Entity damaged = mock(Entity.class);
+            when(damager.getUniqueId()).thenReturn(UUID.randomUUID());
+
+            EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+            when(event.getDamager()).thenReturn(damager);
+            when(event.getEntity()).thenReturn(damaged);
+
+            OnAttackComponent component = new OnAttackComponent() {
+                @Override
+                public boolean affectsEntity(@NotNull Entity entity) {
+                    return true;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false when affectsEntity returns false")
+        @Test
+        public void shouldActivate_returnsFalse_whenAffectsEntityReturnsFalse() {
+            Entity damager = mock(Entity.class);
+            Entity damaged = mock(Entity.class);
+            when(damager.getUniqueId()).thenReturn(HOLDER_UUID);
+
+            EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+            when(event.getDamager()).thenReturn(damager);
+            when(event.getEntity()).thenReturn(damaged);
+
+            OnAttackComponent component = new OnAttackComponent() {
+                @Override
+                public boolean affectsEntity(@NotNull Entity entity) {
+                    return false;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false for non-EntityDamageByEntityEvent")
+        @Test
+        public void shouldActivate_returnsFalse_whenEventIsNotEntityDamageByEntityEvent() {
+            BlockBreakEvent event = mock(BlockBreakEvent.class);
+
+            OnAttackComponent component = new OnAttackComponent() {
+                @Override
+                public boolean affectsEntity(@NotNull Entity entity) {
+                    return true;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("passes the damaged entity to affectsEntity")
+        @Test
+        public void shouldActivate_passesDamagedEntityToAffectsEntity() {
+            Entity damager = mock(Entity.class);
+            Entity damaged = mock(Entity.class);
+            UUID damagedUuid = UUID.randomUUID();
+            when(damager.getUniqueId()).thenReturn(HOLDER_UUID);
+            when(damaged.getUniqueId()).thenReturn(damagedUuid);
+
+            EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+            when(event.getDamager()).thenReturn(damager);
+            when(event.getEntity()).thenReturn(damaged);
+
+            final Entity[] receivedEntity = new Entity[1];
+            OnAttackComponent component = new OnAttackComponent() {
+                @Override
+                public boolean affectsEntity(@NotNull Entity entity) {
+                    receivedEntity[0] = entity;
+                    return true;
+                }
+            };
+
+            component.shouldActivate(holder, event);
+            assertTrue(receivedEntity[0] != null && receivedEntity[0].getUniqueId().equals(damagedUuid));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/component/activatable/OnBlockBreakComponentTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/component/activatable/OnBlockBreakComponentTest.java
@@ -1,0 +1,218 @@
+package us.eunoians.mcrpg.ability.component.activatable;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@DisplayName("OnBlockBreakComponent")
+public class OnBlockBreakComponentTest extends McRPGBaseTest {
+
+    private static final UUID HOLDER_UUID = UUID.randomUUID();
+    private AbilityHolder holder;
+
+    @BeforeEach
+    public void setup() {
+        holder = mock(AbilityHolder.class);
+        when(holder.getUUID()).thenReturn(HOLDER_UUID);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+
+        YamlDocument mainConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+    }
+
+    @Nested
+    @DisplayName("shouldActivate")
+    class ShouldActivate {
+
+        @DisplayName("returns true when player matches holder, affectsBlock is true, and block is natural")
+        @Test
+        public void shouldActivate_returnsTrue_whenAllConditionsMet() {
+            Player player = mock(Player.class);
+            when(player.getUniqueId()).thenReturn(HOLDER_UUID);
+
+            Block block = mock(Block.class);
+
+            BlockBreakEvent event = mock(BlockBreakEvent.class);
+            when(event.getPlayer()).thenReturn(player);
+            when(event.getBlock()).thenReturn(block);
+
+            WorldManager worldManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.WORLD);
+            doReturn(true).when(worldManager).isBlockNatural(block);
+
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return true;
+                }
+            };
+
+            assertTrue(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false when player UUID does not match holder UUID")
+        @Test
+        public void shouldActivate_returnsFalse_whenPlayerDoesNotMatchHolder() {
+            Player player = mock(Player.class);
+            when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+
+            Block block = mock(Block.class);
+
+            BlockBreakEvent event = mock(BlockBreakEvent.class);
+            when(event.getPlayer()).thenReturn(player);
+            when(event.getBlock()).thenReturn(block);
+
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return true;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false when affectsBlock returns false")
+        @Test
+        public void shouldActivate_returnsFalse_whenAffectsBlockReturnsFalse() {
+            Player player = mock(Player.class);
+            when(player.getUniqueId()).thenReturn(HOLDER_UUID);
+
+            Block block = mock(Block.class);
+
+            BlockBreakEvent event = mock(BlockBreakEvent.class);
+            when(event.getPlayer()).thenReturn(player);
+            when(event.getBlock()).thenReturn(block);
+
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return false;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false for non-BlockBreakEvent")
+        @Test
+        public void shouldActivate_returnsFalse_whenEventIsNotBlockBreakEvent() {
+            EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return true;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns false when block is unnatural and affectsUnnaturalBlocks is false")
+        @Test
+        public void shouldActivate_returnsFalse_whenBlockUnnaturalAndDoesNotAffectUnnatural() {
+            Player player = mock(Player.class);
+            when(player.getUniqueId()).thenReturn(HOLDER_UUID);
+
+            Block block = mock(Block.class);
+
+            BlockBreakEvent event = mock(BlockBreakEvent.class);
+            when(event.getPlayer()).thenReturn(player);
+            when(event.getBlock()).thenReturn(block);
+
+            WorldManager worldManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.WORLD);
+            doReturn(false).when(worldManager).isBlockNatural(block);
+
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return true;
+                }
+            };
+
+            assertFalse(component.shouldActivate(holder, event));
+        }
+
+        @DisplayName("returns true when block is unnatural and affectsUnnaturalBlocks is true")
+        @Test
+        public void shouldActivate_returnsTrue_whenBlockUnnaturalAndAffectsUnnatural() {
+            Player player = mock(Player.class);
+            when(player.getUniqueId()).thenReturn(HOLDER_UUID);
+
+            Block block = mock(Block.class);
+
+            BlockBreakEvent event = mock(BlockBreakEvent.class);
+            when(event.getPlayer()).thenReturn(player);
+            when(event.getBlock()).thenReturn(block);
+
+            WorldManager worldManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.WORLD);
+            doReturn(false).when(worldManager).isBlockNatural(block);
+
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return true;
+                }
+
+                @Override
+                public boolean affectsUnnaturalBlocks() {
+                    return true;
+                }
+            };
+
+            assertTrue(component.shouldActivate(holder, event));
+        }
+    }
+
+    @Nested
+    @DisplayName("affectsUnnaturalBlocks")
+    class AffectsUnnaturalBlocks {
+
+        @DisplayName("default returns false")
+        @Test
+        public void affectsUnnaturalBlocks_defaultReturnsFalse() {
+            OnBlockBreakComponent component = new OnBlockBreakComponent() {
+                @Override
+                public boolean affectsBlock(@NotNull Block b) {
+                    return true;
+                }
+            };
+
+            assertFalse(component.affectsUnnaturalBlocks());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/loadout/LoadoutActiveAbilityTest.java
+++ b/src/test/java/us/eunoians/mcrpg/loadout/LoadoutActiveAbilityTest.java
@@ -1,0 +1,243 @@
+package us.eunoians.mcrpg.loadout;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.attribute.AbilityAttributeRegistry;
+import us.eunoians.mcrpg.ability.impl.herbalism.InstantIrrigation;
+import us.eunoians.mcrpg.ability.impl.herbalism.MassHarvest;
+import us.eunoians.mcrpg.ability.impl.herbalism.VerdantSurge;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.MainConfigFile;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.EntityManager;
+import us.eunoians.mcrpg.entity.player.McRPGPlayer;
+import us.eunoians.mcrpg.entity.player.McRPGPlayerExtension;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.SkillRegistry;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+import us.eunoians.mcrpg.world.WorldManager;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@DisplayName("Loadout active ability operations")
+@ExtendWith(McRPGPlayerExtension.class)
+public class LoadoutActiveAbilityTest extends McRPGBaseTest {
+
+    private MassHarvest massHarvest;
+    private VerdantSurge verdantSurge;
+    private InstantIrrigation instantIrrigation;
+    private YamlDocument mainConfig;
+
+    @BeforeEach
+    public void setup() {
+        server.getPluginManager().clearEvents();
+        SkillRegistry skillRegistry = new SkillRegistry();
+        RegistryAccess.registryAccess().register(skillRegistry);
+        Herbalism herbalism = new Herbalism(mcRPG);
+        skillRegistry.register(herbalism);
+
+        ReloadableContentManager reloadableContentManager = new ReloadableContentManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(reloadableContentManager);
+        YamlDocument herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+        when(herbalismConfig.getString(HerbalismConfigFile.LEVEL_UP_EQUATION)).thenReturn("5");
+
+        mainConfig = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MAIN_CONFIG)).thenReturn(mainConfig);
+        when(mainConfig.getInt(MainConfigFile.MAX_LOADOUT_AMOUNT)).thenReturn(5);
+        when(mainConfig.getInt(MainConfigFile.MAX_PASSIVE_LOADOUT_SIZE)).thenReturn(2);
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+        massHarvest = new MassHarvest(mcRPG);
+        abilityRegistry.register(massHarvest);
+        verdantSurge = new VerdantSurge(mcRPG);
+        abilityRegistry.register(verdantSurge);
+        instantIrrigation = new InstantIrrigation(mcRPG);
+        abilityRegistry.register(instantIrrigation);
+
+        EntityManager entityManager = new EntityManager(mcRPG);
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(entityManager);
+        AbilityAttributeRegistry abilityAttributeRegistry = new AbilityAttributeRegistry();
+        RegistryAccess.registryAccess().register(abilityAttributeRegistry);
+        when(mainConfig.getStringList(MainConfigFile.DISABLED_WORLDS)).thenReturn(List.of(""));
+        WorldManager worldManager = spy(new WorldManager(mcRPG));
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(worldManager);
+    }
+
+    private Loadout createLoadoutWithAbilities(@NotNull McRPGPlayer mcRPGPlayer, NamespacedKey... keys) {
+        LinkedHashSet<NamespacedKey> abilities = new LinkedHashSet<>();
+        for (NamespacedKey key : keys) {
+            abilities.add(key);
+        }
+        return new Loadout(mcRPGPlayer.getUUID(), 1, abilities);
+    }
+
+    @Nested
+    @DisplayName("getOrderedActiveAbilities")
+    class GetOrderedActiveAbilities {
+
+        @DisplayName("returns only ComboActivatable abilities")
+        @Test
+        public void getOrderedActiveAbilities_returnsOnlyActive(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = createLoadoutWithAbilities(mcRPGPlayer,
+                    massHarvest.getAbilityKey(), instantIrrigation.getAbilityKey(), verdantSurge.getAbilityKey());
+
+            List<NamespacedKey> activeAbilities = loadout.getOrderedActiveAbilities();
+
+            assertEquals(2, activeAbilities.size());
+            assertTrue(activeAbilities.contains(massHarvest.getAbilityKey()));
+            assertTrue(activeAbilities.contains(verdantSurge.getAbilityKey()));
+        }
+
+        @DisplayName("preserves insertion order among active abilities")
+        @Test
+        public void getOrderedActiveAbilities_preservesInsertionOrder(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = createLoadoutWithAbilities(mcRPGPlayer,
+                    verdantSurge.getAbilityKey(), instantIrrigation.getAbilityKey(), massHarvest.getAbilityKey());
+
+            List<NamespacedKey> activeAbilities = loadout.getOrderedActiveAbilities();
+
+            assertEquals(List.of(verdantSurge.getAbilityKey(), massHarvest.getAbilityKey()), activeAbilities);
+        }
+
+        @DisplayName("returns empty list when no active abilities present")
+        @Test
+        public void getOrderedActiveAbilities_returnsEmpty_whenNoActiveAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = createLoadoutWithAbilities(mcRPGPlayer, instantIrrigation.getAbilityKey());
+
+            assertTrue(loadout.getOrderedActiveAbilities().isEmpty());
+        }
+
+        @DisplayName("returns empty list when loadout is empty")
+        @Test
+        public void getOrderedActiveAbilities_returnsEmpty_whenLoadoutEmpty(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+
+            assertTrue(loadout.getOrderedActiveAbilities().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("swapActivePositions")
+    class SwapActivePositions {
+
+        @DisplayName("swaps two active abilities")
+        @Test
+        public void swapActivePositions_swapsTwoActiveAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(massHarvest.getAbilityKey());
+            loadout.addAbility(verdantSurge.getAbilityKey());
+
+            assertEquals(List.of(massHarvest.getAbilityKey(), verdantSurge.getAbilityKey()), loadout.getOrderedActiveAbilities());
+
+            loadout.swapActivePositions(1, 2);
+
+            assertEquals(List.of(verdantSurge.getAbilityKey(), massHarvest.getAbilityKey()), loadout.getOrderedActiveAbilities());
+        }
+
+        @DisplayName("no-op when from and to slots are the same")
+        @Test
+        public void swapActivePositions_noOp_whenSameSlot(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(massHarvest.getAbilityKey());
+            loadout.addAbility(verdantSurge.getAbilityKey());
+
+            loadout.swapActivePositions(1, 1);
+
+            assertEquals(List.of(massHarvest.getAbilityKey(), verdantSurge.getAbilityKey()), loadout.getOrderedActiveAbilities());
+        }
+
+        @DisplayName("no-op when fromComboSlot is out of range")
+        @Test
+        public void swapActivePositions_noOp_whenFromSlotOutOfRange(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(massHarvest.getAbilityKey());
+            loadout.addAbility(verdantSurge.getAbilityKey());
+
+            loadout.swapActivePositions(3, 1);
+
+            assertEquals(List.of(massHarvest.getAbilityKey(), verdantSurge.getAbilityKey()), loadout.getOrderedActiveAbilities());
+        }
+
+        @DisplayName("no-op when toComboSlot is out of range")
+        @Test
+        public void swapActivePositions_noOp_whenToSlotOutOfRange(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(massHarvest.getAbilityKey());
+            loadout.addAbility(verdantSurge.getAbilityKey());
+
+            loadout.swapActivePositions(1, 3);
+
+            assertEquals(List.of(massHarvest.getAbilityKey(), verdantSurge.getAbilityKey()), loadout.getOrderedActiveAbilities());
+        }
+
+        @DisplayName("no-op when fromComboSlot is zero")
+        @Test
+        public void swapActivePositions_noOp_whenFromSlotZero(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(massHarvest.getAbilityKey());
+            loadout.addAbility(verdantSurge.getAbilityKey());
+
+            loadout.swapActivePositions(0, 1);
+
+            assertEquals(List.of(massHarvest.getAbilityKey(), verdantSurge.getAbilityKey()), loadout.getOrderedActiveAbilities());
+        }
+
+        @DisplayName("no-op when toComboSlot is negative")
+        @Test
+        public void swapActivePositions_noOp_whenToSlotNegative(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = mcRPGPlayer.asSkillHolder().getLoadout(1);
+            loadout.addAbility(massHarvest.getAbilityKey());
+            loadout.addAbility(verdantSurge.getAbilityKey());
+
+            loadout.swapActivePositions(1, -1);
+
+            assertEquals(List.of(massHarvest.getAbilityKey(), verdantSurge.getAbilityKey()), loadout.getOrderedActiveAbilities());
+        }
+
+        @DisplayName("preserves passive ability positions when swapping active abilities")
+        @Test
+        public void swapActivePositions_preservesPassivePositions(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = createLoadoutWithAbilities(mcRPGPlayer,
+                    massHarvest.getAbilityKey(), instantIrrigation.getAbilityKey(), verdantSurge.getAbilityKey());
+
+            loadout.swapActivePositions(1, 2);
+
+            List<NamespacedKey> ordered = loadout.getOrderedAbilities();
+            assertEquals(verdantSurge.getAbilityKey(), ordered.get(0));
+            assertEquals(instantIrrigation.getAbilityKey(), ordered.get(1));
+            assertEquals(massHarvest.getAbilityKey(), ordered.get(2));
+        }
+
+        @DisplayName("no-op when loadout has no active abilities")
+        @Test
+        public void swapActivePositions_noOp_whenNoActiveAbilities(@NotNull McRPGPlayer mcRPGPlayer) {
+            Loadout loadout = createLoadoutWithAbilities(mcRPGPlayer, instantIrrigation.getAbilityKey());
+
+            loadout.swapActivePositions(1, 2);
+
+            assertEquals(List.of(instantIrrigation.getAbilityKey()), loadout.getOrderedAbilities());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **OnAttackComponentTest** (5 tests): Covers all branches of `shouldActivate()` — damager match/mismatch, `affectsEntity` true/false, wrong event type, and verifies the damaged entity is passed to `affectsEntity`
- **OnBlockBreakComponentTest** (7 tests): Covers `shouldActivate()` branches — player match/mismatch, `affectsBlock` true/false, wrong event type, natural/unnatural block handling, `affectsUnnaturalBlocks` override, and default `affectsUnnaturalBlocks` returns false
- **EventActivatableComponentAttributeTest** (7 tests): Covers record constructor/accessors and equality/hashCode behavior (identical, differing priority, differing event class)
- **LoadoutActiveAbilityTest** (12 tests): Covers `getOrderedActiveAbilities()` filtering (only ComboActivatable, insertion order, empty cases) and `swapActivePositions()` (valid swap, same-slot no-op, out-of-range/zero/negative no-ops, passive position preservation, empty loadout)

All 4 classes had 0% test coverage prior to this PR. Total: 31 new tests, all passing.

## Test plan
- [x] `./gradlew verifiedShadowJar` passes with zero failures
- [x] Testing audit persona checklist reviewed — no concerns found
- [x] Tests follow project naming conventions (`action_outcome_whenCondition`, `@DisplayName`, `@Nested` grouping)
- [x] Tests extend `McRPGBaseTest` where MockBukkit/registry access is needed; `EventActivatableComponentAttributeTest` is plain JUnit (no Bukkit dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sV3cWGigLqPvqDMeu2jNx

---
_Generated by [Claude Code](https://claude.ai/code/session_018sV3cWGigLqPvqDMeu2jNx)_