### PR TITLE
[Unit Tests] BoardOffering templates, LoadoutResolution, loadout exceptions, quest definition coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/exception/LoadoutExceptionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/exception/LoadoutExceptionTest.java
@@ -1,0 +1,142 @@
+package us.eunoians.mcrpg.exception;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.entity.holder.LoadoutHolder;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.exception.entity.SkillHolderMissingSkillException;
+import us.eunoians.mcrpg.exception.loadout.LoadoutMaxSizeExceededException;
+import us.eunoians.mcrpg.exception.loadout.SelectedLoadoutAboveMaxException;
+import us.eunoians.mcrpg.loadout.Loadout;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Entity and Loadout Exceptions")
+class LoadoutExceptionTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("LoadoutMaxSizeExceededException")
+    class LoadoutMaxSizeExceededExceptionTests {
+
+        @Test
+        @DisplayName("no-message constructor preserves loadout")
+        void noMessageConstructor_preservesLoadout() {
+            Loadout loadout = new Loadout(UUID.randomUUID(), 0);
+            LoadoutMaxSizeExceededException ex = new LoadoutMaxSizeExceededException(loadout);
+
+            assertSame(loadout, ex.getLoadout());
+            assertNull(ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("message constructor preserves loadout and message")
+        void messageConstructor_preservesLoadoutAndMessage() {
+            Loadout loadout = new Loadout(UUID.randomUUID(), 1);
+            String message = "Loadout is full";
+            LoadoutMaxSizeExceededException ex = new LoadoutMaxSizeExceededException(loadout, message);
+
+            assertSame(loadout, ex.getLoadout());
+            assertEquals(message, ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("extends RuntimeException")
+        void extendsRuntimeException() {
+            Loadout loadout = new Loadout(UUID.randomUUID(), 0);
+            LoadoutMaxSizeExceededException ex = new LoadoutMaxSizeExceededException(loadout);
+            assertInstanceOf(RuntimeException.class, ex);
+        }
+    }
+
+    @Nested
+    @DisplayName("SelectedLoadoutAboveMaxException")
+    class SelectedLoadoutAboveMaxExceptionTests {
+
+        @Test
+        @DisplayName("preserves holder and slot")
+        void preservesHolderAndSlot() {
+            LoadoutHolder holder = mock(LoadoutHolder.class);
+            SelectedLoadoutAboveMaxException ex = new SelectedLoadoutAboveMaxException(holder, 5);
+
+            assertSame(holder, ex.getLoadoutHolder());
+            assertEquals(5, ex.getLoadoutSlot());
+        }
+
+        @Test
+        @DisplayName("zero slot is valid")
+        void zeroSlot_isValid() {
+            LoadoutHolder holder = mock(LoadoutHolder.class);
+            SelectedLoadoutAboveMaxException ex = new SelectedLoadoutAboveMaxException(holder, 0);
+
+            assertEquals(0, ex.getLoadoutSlot());
+        }
+
+        @Test
+        @DisplayName("negative slot is preserved")
+        void negativeSlot_isPreserved() {
+            LoadoutHolder holder = mock(LoadoutHolder.class);
+            SelectedLoadoutAboveMaxException ex = new SelectedLoadoutAboveMaxException(holder, -1);
+
+            assertEquals(-1, ex.getLoadoutSlot());
+        }
+
+        @Test
+        @DisplayName("extends RuntimeException")
+        void extendsRuntimeException() {
+            LoadoutHolder holder = mock(LoadoutHolder.class);
+            SelectedLoadoutAboveMaxException ex = new SelectedLoadoutAboveMaxException(holder, 0);
+            assertInstanceOf(RuntimeException.class, ex);
+        }
+    }
+
+    @Nested
+    @DisplayName("SkillHolderMissingSkillException")
+    class SkillHolderMissingSkillExceptionTests {
+
+        @Test
+        @DisplayName("no-message constructor preserves holder and key")
+        void noMessageConstructor_preservesHolderAndKey() {
+            SkillHolder holder = mock(SkillHolder.class);
+            NamespacedKey skillKey = new NamespacedKey("mcrpg", "swords");
+
+            SkillHolderMissingSkillException ex = new SkillHolderMissingSkillException(holder, skillKey);
+
+            assertSame(holder, ex.getSkillHolder());
+            assertEquals(skillKey, ex.getSkillKey());
+            assertNull(ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("message constructor preserves holder, key, and message")
+        void messageConstructor_preservesAll() {
+            SkillHolder holder = mock(SkillHolder.class);
+            NamespacedKey skillKey = new NamespacedKey("mcrpg", "mining");
+            String message = "Missing skill data for mining";
+
+            SkillHolderMissingSkillException ex =
+                    new SkillHolderMissingSkillException(holder, skillKey, message);
+
+            assertSame(holder, ex.getSkillHolder());
+            assertEquals(skillKey, ex.getSkillKey());
+            assertEquals(message, ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("extends RuntimeException")
+        void extendsRuntimeException() {
+            SkillHolder holder = mock(SkillHolder.class);
+            NamespacedKey key = new NamespacedKey("mcrpg", "swords");
+            SkillHolderMissingSkillException ex = new SkillHolderMissingSkillException(holder, key);
+            assertInstanceOf(RuntimeException.class, ex);
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/loadout/LoadoutResolutionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/loadout/LoadoutResolutionTest.java
@@ -1,0 +1,141 @@
+package us.eunoians.mcrpg.loadout;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("LoadoutResolution")
+class LoadoutResolutionTest extends McRPGBaseTest {
+
+    private Loadout createLoadout(int slot) {
+        return new Loadout(UUID.randomUUID(), slot);
+    }
+
+    @Nested
+    @DisplayName("Found")
+    class FoundTests {
+
+        @Test
+        @DisplayName("wraps single loadout")
+        void wrapsSingleLoadout() {
+            Loadout loadout = createLoadout(0);
+            LoadoutResolution resolution = new LoadoutResolution.Found(loadout);
+
+            assertInstanceOf(LoadoutResolution.Found.class, resolution);
+            assertEquals(loadout, ((LoadoutResolution.Found) resolution).loadout());
+        }
+
+        @Test
+        @DisplayName("equals matches same loadout")
+        void equals_sameLoadout() {
+            Loadout loadout = createLoadout(0);
+            LoadoutResolution.Found a = new LoadoutResolution.Found(loadout);
+            LoadoutResolution.Found b = new LoadoutResolution.Found(loadout);
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("hashCode matches for equal records")
+        void hashCode_matchesForEqualRecords() {
+            Loadout loadout = createLoadout(0);
+            LoadoutResolution.Found a = new LoadoutResolution.Found(loadout);
+            LoadoutResolution.Found b = new LoadoutResolution.Found(loadout);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+
+        @Test
+        @DisplayName("different loadouts produce different Found instances")
+        void differentLoadouts_notEqual() {
+            LoadoutResolution.Found a = new LoadoutResolution.Found(createLoadout(0));
+            LoadoutResolution.Found b = new LoadoutResolution.Found(createLoadout(1));
+            assertNotEquals(a, b);
+        }
+    }
+
+    @Nested
+    @DisplayName("Ambiguous")
+    class AmbiguousTests {
+
+        @Test
+        @DisplayName("wraps multiple loadouts")
+        void wrapsMultipleLoadouts() {
+            Loadout l1 = createLoadout(0);
+            Loadout l2 = createLoadout(1);
+            LoadoutResolution resolution = new LoadoutResolution.Ambiguous(List.of(l1, l2));
+
+            assertInstanceOf(LoadoutResolution.Ambiguous.class, resolution);
+            List<Loadout> matches = ((LoadoutResolution.Ambiguous) resolution).matches();
+            assertEquals(2, matches.size());
+            assertTrue(matches.contains(l1));
+            assertTrue(matches.contains(l2));
+        }
+
+        @Test
+        @DisplayName("equals matches same list content")
+        void equals_sameListContent() {
+            Loadout l1 = createLoadout(0);
+            List<Loadout> list = List.of(l1);
+            LoadoutResolution.Ambiguous a = new LoadoutResolution.Ambiguous(list);
+            LoadoutResolution.Ambiguous b = new LoadoutResolution.Ambiguous(list);
+            assertEquals(a, b);
+        }
+    }
+
+    @Nested
+    @DisplayName("NotFound")
+    class NotFoundTests {
+
+        @Test
+        @DisplayName("is a singleton-like record")
+        void isSingletonLikeRecord() {
+            LoadoutResolution resolution = new LoadoutResolution.NotFound();
+            assertInstanceOf(LoadoutResolution.NotFound.class, resolution);
+        }
+
+        @Test
+        @DisplayName("two NotFound instances are equal")
+        void twoInstances_areEqual() {
+            LoadoutResolution.NotFound a = new LoadoutResolution.NotFound();
+            LoadoutResolution.NotFound b = new LoadoutResolution.NotFound();
+            assertEquals(a, b);
+        }
+
+        @Test
+        @DisplayName("hashCode is consistent")
+        void hashCode_isConsistent() {
+            LoadoutResolution.NotFound a = new LoadoutResolution.NotFound();
+            LoadoutResolution.NotFound b = new LoadoutResolution.NotFound();
+            assertEquals(a.hashCode(), b.hashCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("Sealed interface type discrimination")
+    class TypeDiscrimination {
+
+        @Test
+        @DisplayName("Found is distinct from Ambiguous and NotFound")
+        void found_isDistinctFromOtherVariants() {
+            LoadoutResolution found = new LoadoutResolution.Found(createLoadout(0));
+            LoadoutResolution ambiguous = new LoadoutResolution.Ambiguous(List.of(createLoadout(0)));
+            LoadoutResolution notFound = new LoadoutResolution.NotFound();
+
+            assertInstanceOf(LoadoutResolution.Found.class, found);
+            assertInstanceOf(LoadoutResolution.Ambiguous.class, ambiguous);
+            assertInstanceOf(LoadoutResolution.NotFound.class, notFound);
+
+            assertNotEquals(found, ambiguous);
+            assertNotEquals(found, notFound);
+            assertNotEquals(ambiguous, notFound);
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/BoardOfferingTemplateTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/BoardOfferingTemplateTest.java
@@ -1,0 +1,239 @@
+package us.eunoians.mcrpg.quest.board;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("BoardOffering template constructors")
+class BoardOfferingTemplateTest extends McRPGBaseTest {
+
+    private static final NamespacedKey CATEGORY = new NamespacedKey("mcrpg", "shared_daily");
+    private static final NamespacedKey QUEST_DEF = new NamespacedKey("mcrpg", "test_quest");
+    private static final NamespacedKey RARITY = new NamespacedKey("mcrpg", "common");
+    private static final NamespacedKey TEMPLATE = new NamespacedKey("mcrpg", "gather_template");
+    private static final Duration COMPLETION_TIME = Duration.ofHours(24);
+    private static final String GENERATED_JSON = "{\"key\":\"mcrpg:generated_quest\"}";
+
+    private BoardOffering newTemplateOffering() {
+        return new BoardOffering(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                CATEGORY,
+                0,
+                QUEST_DEF,
+                RARITY,
+                null,
+                COMPLETION_TIME,
+                TEMPLATE,
+                GENERATED_JSON
+        );
+    }
+
+    private BoardOffering newNonTemplateOffering() {
+        return new BoardOffering(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                CATEGORY,
+                0,
+                QUEST_DEF,
+                RARITY,
+                null,
+                COMPLETION_TIME
+        );
+    }
+
+    @Nested
+    @DisplayName("Template VISIBLE constructor")
+    class TemplateVisibleConstructor {
+
+        @Test
+        @DisplayName("starts in VISIBLE state")
+        void startsInVisibleState() {
+            BoardOffering offering = newTemplateOffering();
+            assertEquals(BoardOffering.State.VISIBLE, offering.getState());
+        }
+
+        @Test
+        @DisplayName("getTemplateKey returns the template key")
+        void getTemplateKey_returnsTemplateKey() {
+            BoardOffering offering = newTemplateOffering();
+            assertTrue(offering.getTemplateKey().isPresent());
+            assertEquals(TEMPLATE, offering.getTemplateKey().get());
+        }
+
+        @Test
+        @DisplayName("getGeneratedDefinition returns the JSON")
+        void getGeneratedDefinition_returnsJson() {
+            BoardOffering offering = newTemplateOffering();
+            assertTrue(offering.getGeneratedDefinition().isPresent());
+            assertEquals(GENERATED_JSON, offering.getGeneratedDefinition().get());
+        }
+
+        @Test
+        @DisplayName("isTemplateGenerated returns true")
+        void isTemplateGenerated_returnsTrue() {
+            BoardOffering offering = newTemplateOffering();
+            assertTrue(offering.isTemplateGenerated());
+        }
+
+        @Test
+        @DisplayName("acceptedAt and questInstanceUUID are empty before acceptance")
+        void beforeAcceptance_optionalsEmpty() {
+            BoardOffering offering = newTemplateOffering();
+            assertTrue(offering.getAcceptedAt().isEmpty());
+            assertTrue(offering.getQuestInstanceUUID().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-template constructor")
+    class NonTemplateConstructor {
+
+        @Test
+        @DisplayName("getTemplateKey returns empty")
+        void getTemplateKey_returnsEmpty() {
+            BoardOffering offering = newNonTemplateOffering();
+            assertTrue(offering.getTemplateKey().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getGeneratedDefinition returns empty")
+        void getGeneratedDefinition_returnsEmpty() {
+            BoardOffering offering = newNonTemplateOffering();
+            assertTrue(offering.getGeneratedDefinition().isEmpty());
+        }
+
+        @Test
+        @DisplayName("isTemplateGenerated returns false")
+        void isTemplateGenerated_returnsFalse() {
+            BoardOffering offering = newNonTemplateOffering();
+            assertFalse(offering.isTemplateGenerated());
+        }
+    }
+
+    @Nested
+    @DisplayName("Database reconstruction with template metadata")
+    class DatabaseReconstructionWithTemplate {
+
+        @Test
+        @DisplayName("preserves template key and generated definition from persisted state")
+        void preservesTemplateMetadata() {
+            UUID offeringId = UUID.randomUUID();
+            UUID rotationId = UUID.randomUUID();
+            long acceptedAt = System.currentTimeMillis();
+            UUID questInstanceUUID = UUID.randomUUID();
+
+            BoardOffering offering = new BoardOffering(
+                    offeringId,
+                    rotationId,
+                    CATEGORY,
+                    1,
+                    QUEST_DEF,
+                    RARITY,
+                    "land-123",
+                    COMPLETION_TIME,
+                    BoardOffering.State.ACCEPTED,
+                    acceptedAt,
+                    questInstanceUUID,
+                    TEMPLATE,
+                    GENERATED_JSON
+            );
+
+            assertEquals(BoardOffering.State.ACCEPTED, offering.getState());
+            assertEquals(offeringId, offering.getOfferingId());
+            assertEquals(rotationId, offering.getRotationId());
+            assertEquals(1, offering.getSlotIndex());
+            assertTrue(offering.getScopeTargetId().isPresent());
+            assertEquals("land-123", offering.getScopeTargetId().get());
+            assertTrue(offering.getAcceptedAt().isPresent());
+            assertEquals(acceptedAt, offering.getAcceptedAt().get());
+            assertTrue(offering.getQuestInstanceUUID().isPresent());
+            assertEquals(questInstanceUUID, offering.getQuestInstanceUUID().get());
+            assertTrue(offering.isTemplateGenerated());
+            assertEquals(TEMPLATE, offering.getTemplateKey().get());
+            assertEquals(GENERATED_JSON, offering.getGeneratedDefinition().get());
+        }
+
+        @Test
+        @DisplayName("null template key means non-template in DB reconstruction")
+        void nullTemplateKey_isNonTemplate() {
+            BoardOffering offering = new BoardOffering(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    CATEGORY,
+                    0,
+                    QUEST_DEF,
+                    RARITY,
+                    null,
+                    COMPLETION_TIME,
+                    BoardOffering.State.VISIBLE,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            assertFalse(offering.isTemplateGenerated());
+            assertTrue(offering.getTemplateKey().isEmpty());
+            assertTrue(offering.getGeneratedDefinition().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Template offering state transitions")
+    class TemplateOfferingStateTransitions {
+
+        @Test
+        @DisplayName("template offering can be accepted")
+        void templateOffering_canBeAccepted() {
+            BoardOffering offering = newTemplateOffering();
+            UUID questUUID = UUID.randomUUID();
+            long now = System.currentTimeMillis();
+
+            offering.accept(now, questUUID);
+
+            assertEquals(BoardOffering.State.ACCEPTED, offering.getState());
+            assertTrue(offering.isTemplateGenerated());
+            assertEquals(TEMPLATE, offering.getTemplateKey().get());
+        }
+
+        @Test
+        @DisplayName("template offering can be expired")
+        void templateOffering_canBeExpired() {
+            BoardOffering offering = newTemplateOffering();
+            offering.transitionTo(BoardOffering.State.EXPIRED);
+
+            assertEquals(BoardOffering.State.EXPIRED, offering.getState());
+            assertTrue(offering.isTemplateGenerated());
+        }
+
+        @Test
+        @DisplayName("accepted template offering can be completed")
+        void acceptedTemplateOffering_canBeCompleted() {
+            BoardOffering offering = newTemplateOffering();
+            offering.accept(System.currentTimeMillis(), UUID.randomUUID());
+            offering.transitionTo(BoardOffering.State.COMPLETED);
+
+            assertEquals(BoardOffering.State.COMPLETED, offering.getState());
+        }
+
+        @Test
+        @DisplayName("accepted template offering can be abandoned")
+        void acceptedTemplateOffering_canBeAbandoned() {
+            BoardOffering offering = newTemplateOffering();
+            offering.accept(System.currentTimeMillis(), UUID.randomUUID());
+            offering.transitionTo(BoardOffering.State.ABANDONED);
+
+            assertEquals(BoardOffering.State.ABANDONED, offering.getState());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/definition/QuestDefinitionRewardDistributionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/definition/QuestDefinitionRewardDistributionTest.java
@@ -1,0 +1,183 @@
+package us.eunoians.mcrpg.quest.definition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.QuestTestHelper;
+import us.eunoians.mcrpg.quest.board.distribution.RewardDistributionConfig;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Quest definition reward distribution coverage")
+class QuestDefinitionRewardDistributionTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("QuestPhaseDefinition")
+    class PhaseDefinitionDistribution {
+
+        @Test
+        @DisplayName("getRewardDistribution returns empty when null")
+        void getRewardDistribution_returnsEmpty_whenNull() {
+            QuestStageDefinition stage = QuestTestHelper.singleStageDef("s", "o");
+            QuestPhaseDefinition phase = new QuestPhaseDefinition(
+                    0, PhaseCompletionMode.ALL, List.of(stage), List.of(), null);
+
+            assertTrue(phase.getRewardDistribution().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getRewardDistribution returns present when provided")
+        void getRewardDistribution_returnsPresent_whenProvided() {
+            QuestStageDefinition stage = QuestTestHelper.singleStageDef("s", "o");
+            RewardDistributionConfig config = new RewardDistributionConfig(List.of());
+            QuestPhaseDefinition phase = new QuestPhaseDefinition(
+                    0, PhaseCompletionMode.ALL, List.of(stage), List.of(), config);
+
+            assertTrue(phase.getRewardDistribution().isPresent());
+            assertSame(config, phase.getRewardDistribution().get());
+        }
+
+        @Test
+        @DisplayName("getRewards returns immutable list")
+        void getRewards_returnsImmutableList() {
+            QuestStageDefinition stage = QuestTestHelper.singleStageDef("s", "o");
+            QuestPhaseDefinition phase = new QuestPhaseDefinition(
+                    0, PhaseCompletionMode.ALL, List.of(stage), List.of(), null);
+
+            assertThrows(UnsupportedOperationException.class, () -> phase.getRewards().add(null));
+        }
+
+        @Test
+        @DisplayName("phaseIndex zero is valid")
+        void phaseIndex_zeroIsValid() {
+            QuestStageDefinition stage = QuestTestHelper.singleStageDef("s", "o");
+            QuestPhaseDefinition phase = new QuestPhaseDefinition(
+                    0, PhaseCompletionMode.ANY, List.of(stage), List.of(), null);
+
+            assertEquals(0, phase.getPhaseIndex());
+            assertEquals(PhaseCompletionMode.ANY, phase.getCompletionMode());
+        }
+
+        @Test
+        @DisplayName("multiple stages are preserved in order")
+        void multipleStages_preservedInOrder() {
+            QuestStageDefinition s1 = QuestTestHelper.singleStageDef("s1", "o1");
+            QuestStageDefinition s2 = QuestTestHelper.singleStageDef("s2", "o2");
+            QuestPhaseDefinition phase = new QuestPhaseDefinition(
+                    1, PhaseCompletionMode.ALL, List.of(s1, s2), List.of(), null);
+
+            assertEquals(2, phase.getStages().size());
+            assertEquals(new NamespacedKey("mcrpg", "s1"), phase.getStages().get(0).getStageKey());
+            assertEquals(new NamespacedKey("mcrpg", "s2"), phase.getStages().get(1).getStageKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("QuestStageDefinition")
+    class StageDefinitionDistribution {
+
+        @Test
+        @DisplayName("getRewardDistribution returns empty when null")
+        void getRewardDistribution_returnsEmpty_whenNull() {
+            QuestStageDefinition stage = QuestTestHelper.singleStageDef("s", "o");
+            assertTrue(stage.getRewardDistribution().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getRewardDistribution returns present when provided")
+        void getRewardDistribution_returnsPresent_whenProvided() {
+            RewardDistributionConfig config = new RewardDistributionConfig(List.of());
+            QuestObjectiveDefinition obj = QuestTestHelper.singleObjectiveDef("obj", 10);
+            QuestStageDefinition stage = new QuestStageDefinition(
+                    new NamespacedKey("mcrpg", "stage"),
+                    List.of(obj),
+                    List.of(),
+                    config
+            );
+
+            assertTrue(stage.getRewardDistribution().isPresent());
+            assertSame(config, stage.getRewardDistribution().get());
+        }
+
+        @Test
+        @DisplayName("multiple objectives are preserved")
+        void multipleObjectives_preserved() {
+            QuestObjectiveDefinition o1 = QuestTestHelper.singleObjectiveDef("o1", 10);
+            QuestObjectiveDefinition o2 = QuestTestHelper.singleObjectiveDef("o2", 20);
+            QuestStageDefinition stage = new QuestStageDefinition(
+                    new NamespacedKey("mcrpg", "multi_stage"),
+                    List.of(o1, o2),
+                    List.of(),
+                    null
+            );
+
+            assertEquals(2, stage.getObjectives().size());
+            assertEquals(new NamespacedKey("mcrpg", "o1"), stage.getObjectives().get(0).getObjectiveKey());
+            assertEquals(new NamespacedKey("mcrpg", "o2"), stage.getObjectives().get(1).getObjectiveKey());
+        }
+
+        @Test
+        @DisplayName("stageKey is preserved")
+        void stageKey_preserved() {
+            QuestObjectiveDefinition obj = QuestTestHelper.singleObjectiveDef("o", 5);
+            NamespacedKey key = new NamespacedKey("mcrpg", "custom_stage");
+            QuestStageDefinition stage = new QuestStageDefinition(key, List.of(obj), List.of(), null);
+
+            assertEquals(key, stage.getStageKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("QuestRepeatMode")
+    class RepeatModeTests {
+
+        @Test
+        @DisplayName("all five modes are defined")
+        void allFiveModes_areDefined() {
+            QuestRepeatMode[] modes = QuestRepeatMode.values();
+            assertEquals(5, modes.length);
+        }
+
+        @ParameterizedTest
+        @EnumSource(QuestRepeatMode.class)
+        @DisplayName("valueOf round-trips for each mode")
+        void valueOf_roundTrips(QuestRepeatMode mode) {
+            assertEquals(mode, QuestRepeatMode.valueOf(mode.name()));
+        }
+
+        @Test
+        @DisplayName("ONCE mode exists")
+        void once_exists() {
+            assertEquals(QuestRepeatMode.ONCE, QuestRepeatMode.valueOf("ONCE"));
+        }
+
+        @Test
+        @DisplayName("COOLDOWN_LIMITED mode exists")
+        void cooldownLimited_exists() {
+            assertEquals(QuestRepeatMode.COOLDOWN_LIMITED, QuestRepeatMode.valueOf("COOLDOWN_LIMITED"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PhaseCompletionMode")
+    class CompletionModeTests {
+
+        @Test
+        @DisplayName("ALL and ANY modes exist")
+        void allAndAny_exist() {
+            PhaseCompletionMode[] modes = PhaseCompletionMode.values();
+            assertEquals(2, modes.length);
+            assertEquals(PhaseCompletionMode.ALL, PhaseCompletionMode.valueOf("ALL"));
+            assertEquals(PhaseCompletionMode.ANY, PhaseCompletionMode.valueOf("ANY"));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/definition/QuestObjectiveDefinitionExpressionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/definition/QuestObjectiveDefinitionExpressionTest.java
@@ -1,0 +1,229 @@
+package us.eunoians.mcrpg.quest.definition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.QuestTestHelper;
+import us.eunoians.mcrpg.quest.board.distribution.RewardDistributionConfig;
+import us.eunoians.mcrpg.quest.objective.type.MockQuestObjectiveType;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("QuestObjectiveDefinition expression and distribution coverage")
+class QuestObjectiveDefinitionExpressionTest extends McRPGBaseTest {
+
+    private static final NamespacedKey OBJ_KEY = new NamespacedKey("mcrpg", "test_obj");
+
+    private MockQuestObjectiveType mockType() {
+        return QuestTestHelper.mockObjectiveType("test_type");
+    }
+
+    @Nested
+    @DisplayName("Expression-based constructor")
+    class ExpressionConstructor {
+
+        @Test
+        @DisplayName("blank expression throws IllegalArgumentException")
+        void blankExpression_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new QuestObjectiveDefinition(OBJ_KEY, mockType(), "   ", List.of(), null));
+        }
+
+        @Test
+        @DisplayName("empty expression throws IllegalArgumentException")
+        void emptyExpression_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new QuestObjectiveDefinition(OBJ_KEY, mockType(), "", List.of(), null));
+        }
+
+        @Test
+        @DisplayName("valid expression stores correctly")
+        void validExpression_storesCorrectly() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "10*tier", List.of(), null);
+
+            assertEquals(OBJ_KEY, def.getObjectiveKey());
+        }
+
+        @Test
+        @DisplayName("getRequiredProgress on expression-based throws IllegalStateException")
+        void getRequiredProgress_onExpressionBased_throwsIllegalStateException() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "10*tier", List.of(), null);
+
+            assertThrows(IllegalStateException.class, def::getRequiredProgress);
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveRequiredProgress")
+    class ResolveRequiredProgress {
+
+        @Test
+        @DisplayName("static progress returns value without variables")
+        void staticProgress_returnsValueWithoutVariables() {
+            QuestObjectiveDefinition def = QuestTestHelper.singleObjectiveDef("obj", 50);
+            assertEquals(50, def.resolveRequiredProgress(Map.of()));
+        }
+
+        @Test
+        @DisplayName("expression with tier variable resolves correctly")
+        void expressionWithTier_resolvesCorrectly() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "10*tier", List.of(), null);
+
+            assertEquals(30, def.resolveRequiredProgress(Map.of("tier", 3)));
+        }
+
+        @Test
+        @DisplayName("expression with missing tier variable throws IllegalArgumentException")
+        void expressionMissingTier_throwsIllegalArgumentException() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "10*tier", List.of(), null);
+
+            assertThrows(IllegalArgumentException.class, () -> def.resolveRequiredProgress(Map.of()));
+        }
+
+        @Test
+        @DisplayName("expression resolving to zero throws IllegalArgumentException")
+        void expressionResolvingToZero_throwsIllegalArgumentException() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "0*tier", List.of(), null);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> def.resolveRequiredProgress(Map.of("tier", 1)));
+        }
+
+        @Test
+        @DisplayName("expression resolving to negative throws IllegalArgumentException")
+        void expressionResolvingToNegative_throwsIllegalArgumentException() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "0-tier", List.of(), null);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> def.resolveRequiredProgress(Map.of("tier", 5)));
+        }
+
+        @Test
+        @DisplayName("expression without tier token resolves without requiring tier variable")
+        void expressionWithoutTier_resolvesWithoutTierVariable() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "100+50", List.of(), null);
+
+            assertEquals(150, def.resolveRequiredProgress(Map.of()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Static constructor validation")
+    class StaticConstructorValidation {
+
+        @Test
+        @DisplayName("zero requiredProgress throws IllegalArgumentException")
+        void zeroRequired_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new QuestObjectiveDefinition(OBJ_KEY, mockType(), 0, List.of(), null));
+        }
+
+        @Test
+        @DisplayName("negative requiredProgress throws IllegalArgumentException")
+        void negativeRequired_throwsIllegalArgumentException() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new QuestObjectiveDefinition(OBJ_KEY, mockType(), -5, List.of(), null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Reward distribution")
+    class RewardDistributionTests {
+
+        @Test
+        @DisplayName("getRewardDistribution returns empty when null")
+        void getRewardDistribution_returnsEmpty_whenNull() {
+            QuestObjectiveDefinition def = QuestTestHelper.singleObjectiveDef("obj", 10);
+            assertTrue(def.getRewardDistribution().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getRewardDistribution returns present when provided (static constructor)")
+        void getRewardDistribution_returnsPresent_staticConstructor() {
+            RewardDistributionConfig config = new RewardDistributionConfig(List.of());
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), 10, List.of(), config);
+
+            assertTrue(def.getRewardDistribution().isPresent());
+            assertSame(config, def.getRewardDistribution().get());
+        }
+
+        @Test
+        @DisplayName("getRewardDistribution returns present when provided (expression constructor)")
+        void getRewardDistribution_returnsPresent_expressionConstructor() {
+            RewardDistributionConfig config = new RewardDistributionConfig(List.of());
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "100", List.of(), config);
+
+            assertTrue(def.getRewardDistribution().isPresent());
+            assertSame(config, def.getRewardDistribution().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("Description route")
+    class DescriptionRouteTests {
+
+        @Test
+        @DisplayName("getDescriptionRoute returns non-null route")
+        void getDescriptionRoute_returnsNonNullRoute() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    new NamespacedKey("mcrpg", "gather_stone"),
+                    mockType(), 50, List.of(), null);
+
+            NamespacedKey questKey = new NamespacedKey("mcrpg", "daily_mining");
+            var route = def.getDescriptionRoute(questKey);
+            assertNotNull(route);
+        }
+
+        @Test
+        @DisplayName("getDescriptionRoute differs for different quest keys")
+        void getDescriptionRoute_differsForDifferentQuestKeys() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    new NamespacedKey("mcrpg", "gather_stone"),
+                    mockType(), 50, List.of(), null);
+
+            var route1 = def.getDescriptionRoute(new NamespacedKey("mcrpg", "quest_a"));
+            var route2 = def.getDescriptionRoute(new NamespacedKey("mcrpg", "quest_b"));
+            assertNotEquals(route1, route2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Rewards immutability")
+    class RewardsImmutability {
+
+        @Test
+        @DisplayName("getRewards returns immutable list (static constructor)")
+        void getRewards_immutable_staticConstructor() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), 10, List.of(), null);
+            assertThrows(UnsupportedOperationException.class, () -> def.getRewards().add(null));
+        }
+
+        @Test
+        @DisplayName("getRewards returns immutable list (expression constructor)")
+        void getRewards_immutable_expressionConstructor() {
+            QuestObjectiveDefinition def = new QuestObjectiveDefinition(
+                    OBJ_KEY, mockType(), "50", List.of(), null);
+            assertThrows(UnsupportedOperationException.class, () -> def.getRewards().add(null));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 new test classes covering previously untested code paths (all were at 0% coverage):

- **`BoardOfferingTemplateTest`** — Template-specific constructors, `isTemplateGenerated()`, `getTemplateKey()`, `getGeneratedDefinition()`, database reconstruction with template metadata, and template offering state transitions (accept, expire, complete, abandon)
- **`LoadoutResolutionTest`** — Sealed interface `LoadoutResolution` with all three record variants (`Found`, `Ambiguous`, `NotFound`): wrapping, equals/hashCode, type discrimination
- **`LoadoutExceptionTest`** — `LoadoutMaxSizeExceededException`, `SelectedLoadoutAboveMaxException`, `SkillHolderMissingSkillException`: both constructor variants, getter preservation, RuntimeException inheritance
- **`QuestObjectiveDefinitionExpressionTest`** — Expression-based constructor validation (blank/empty), `resolveRequiredProgress` with tier variables, zero/negative resolution guards, static constructor validation, reward distribution Optional behavior, description route, rewards immutability
- **`QuestDefinitionRewardDistributionTest`** — `QuestPhaseDefinition` and `QuestStageDefinition` reward distribution Optional behavior, stage ordering preservation, `QuestRepeatMode` enum (parameterized), `PhaseCompletionMode` enum

## Test plan

- [x] All 5 new test files pass individually
- [x] Full test suite passes (`./gradlew verifiedShadowJar` — BUILD SUCCESSFUL)
- [x] Testing audit persona (persona-testing.mdc) checklist applied — one finding fixed (converted `QuestRepeatMode` round-trip loop to `@ParameterizedTest`/`@EnumSource`)
- [x] No overlap with existing open test PRs (#238–#254)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HL54NfYMKTAsxFS2ndVUim