### PR TITLE
Add validation for EntryLimiterParser expression format

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/util/worldguard/EntryLimiterParser.java
+++ b/src/main/java/us/eunoians/mcrpg/util/worldguard/EntryLimiterParser.java
@@ -1,11 +1,16 @@
 package us.eunoians.mcrpg.util.worldguard;
 
+import org.bukkit.Bukkit;
 import us.eunoians.mcrpg.players.McRPGPlayer;
 
 public class EntryLimiterParser extends McRPGParser {
 
   public boolean evaluateExpression(McRPGPlayer player, String expression) {
     String[] info = expression.split(" ");
+    if (info.length < 3) {
+      Bukkit.getLogger().warning("[McRPG] Invalid BanEntry expression: '" + expression + "' - expected format: '<condition> <operator> <value>'");
+      return false;
+    }
     int var = Integer.parseInt(info[2]);
     boolean result = false;
     if(info[0].equalsIgnoreCase("power_level")){


### PR DESCRIPTION
## Summary
Added input validation to `EntryLimiterParser.evaluateExpression()` to handle malformed BanEntry expressions gracefully instead of throwing an exception.

## Changes
- Added length check for parsed expression components before accessing array indices
- Log a warning with the invalid expression and expected format when validation fails
- Return `false` early if the expression doesn't match the required format: `<condition> <operator> <value>`
- Prevents `ArrayIndexOutOfBoundsException` when evaluating incomplete or malformed expressions

## Implementation Details
The parser now validates that the expression splits into at least 3 components before attempting to parse the third element as an integer. This defensive programming approach ensures the plugin logs helpful diagnostic information rather than crashing when encountering invalid WorldGuard BanEntry configurations.

https://claude.ai/code/session_011LFhpmw49MjbLp4KYqTtTE