### PR TITLE
[Unit Tests] Pool, ResolvedPool, ConditionContext, scope provider coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/ConditionContextTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/condition/ConditionContextTest.java
@@ -1,0 +1,154 @@
+package us.eunoians.mcrpg.quest.board.template.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.board.rarity.QuestRarityRegistry;
+import us.eunoians.mcrpg.quest.board.template.ResolvedVariableContext;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+class ConditionContextTest extends McRPGBaseTest {
+
+    private static final NamespacedKey RARITY_KEY = new NamespacedKey("mcrpg", "common");
+
+    @Nested
+    @DisplayName("forTemplateGeneration")
+    class ForTemplateGeneration {
+
+        @DisplayName("Sets rarity, registry, random, and variables")
+        @Test
+        void setsGenerationFields() {
+            QuestRarityRegistry registry = new QuestRarityRegistry();
+            Random random = new Random(42);
+            ResolvedVariableContext vars = new ResolvedVariableContext(Map.of(), 1.0, 1.0, 1.0);
+
+            ConditionContext ctx = ConditionContext.forTemplateGeneration(RARITY_KEY, registry, random, vars);
+
+            assertEquals(RARITY_KEY, ctx.rolledRarity());
+            assertEquals(registry, ctx.rarityRegistry());
+            assertEquals(random, ctx.random());
+            assertEquals(vars, ctx.resolvedVariables());
+        }
+
+        @DisplayName("Leaves player fields null")
+        @Test
+        void leavesPlayerFieldsNull() {
+            QuestRarityRegistry registry = new QuestRarityRegistry();
+            Random random = new Random(42);
+            ResolvedVariableContext vars = new ResolvedVariableContext(Map.of(), 1.0, 1.0, 1.0);
+
+            ConditionContext ctx = ConditionContext.forTemplateGeneration(RARITY_KEY, registry, random, vars);
+
+            assertNull(ctx.playerUUID());
+            assertNull(ctx.completionHistory());
+        }
+    }
+
+    @Nested
+    @DisplayName("forPersonalGeneration")
+    class ForPersonalGeneration {
+
+        @DisplayName("Sets all fields including player data")
+        @Test
+        void setsAllFields() {
+            QuestRarityRegistry registry = new QuestRarityRegistry();
+            Random random = new Random(42);
+            ResolvedVariableContext vars = new ResolvedVariableContext(Map.of(), 1.0, 1.0, 1.0);
+            UUID playerUUID = UUID.randomUUID();
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+
+            ConditionContext ctx = ConditionContext.forPersonalGeneration(
+                    RARITY_KEY, registry, random, vars, playerUUID, history);
+
+            assertEquals(RARITY_KEY, ctx.rolledRarity());
+            assertEquals(registry, ctx.rarityRegistry());
+            assertEquals(random, ctx.random());
+            assertEquals(vars, ctx.resolvedVariables());
+            assertEquals(playerUUID, ctx.playerUUID());
+            assertEquals(history, ctx.completionHistory());
+        }
+    }
+
+    @Nested
+    @DisplayName("forPrerequisiteCheck")
+    class ForPrerequisiteCheck {
+
+        @DisplayName("Sets player UUID and completion history")
+        @Test
+        void setsPlayerFields() {
+            UUID playerUUID = UUID.randomUUID();
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+
+            ConditionContext ctx = ConditionContext.forPrerequisiteCheck(playerUUID, history);
+
+            assertEquals(playerUUID, ctx.playerUUID());
+            assertEquals(history, ctx.completionHistory());
+        }
+
+        @DisplayName("Leaves generation fields null")
+        @Test
+        void leavesGenerationFieldsNull() {
+            UUID playerUUID = UUID.randomUUID();
+            QuestCompletionHistory history = mock(QuestCompletionHistory.class);
+
+            ConditionContext ctx = ConditionContext.forPrerequisiteCheck(playerUUID, history);
+
+            assertNull(ctx.rolledRarity());
+            assertNull(ctx.rarityRegistry());
+            assertNull(ctx.random());
+            assertNull(ctx.resolvedVariables());
+        }
+    }
+
+    @Nested
+    @DisplayName("forRewardGrant")
+    class ForRewardGrant {
+
+        @DisplayName("Sets player UUID and optional rarity")
+        @Test
+        void setsPlayerAndRarity() {
+            UUID playerUUID = UUID.randomUUID();
+            QuestRarityRegistry registry = new QuestRarityRegistry();
+
+            ConditionContext ctx = ConditionContext.forRewardGrant(playerUUID, RARITY_KEY, registry);
+
+            assertEquals(playerUUID, ctx.playerUUID());
+            assertEquals(RARITY_KEY, ctx.rolledRarity());
+            assertEquals(registry, ctx.rarityRegistry());
+        }
+
+        @DisplayName("Leaves generation-only fields null")
+        @Test
+        void leavesGenerationOnlyFieldsNull() {
+            UUID playerUUID = UUID.randomUUID();
+
+            ConditionContext ctx = ConditionContext.forRewardGrant(playerUUID, RARITY_KEY, null);
+
+            assertNull(ctx.random());
+            assertNull(ctx.resolvedVariables());
+            assertNull(ctx.completionHistory());
+        }
+
+        @DisplayName("Allows null rarity and registry")
+        @Test
+        void allowsNullRarityAndRegistry() {
+            UUID playerUUID = UUID.randomUUID();
+
+            ConditionContext ctx = ConditionContext.forRewardGrant(playerUUID, null, null);
+
+            assertNotNull(ctx.playerUUID());
+            assertNull(ctx.rolledRarity());
+            assertNull(ctx.rarityRegistry());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/variable/PoolTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/variable/PoolTest.java
@@ -1,0 +1,97 @@
+package us.eunoians.mcrpg.quest.board.template.variable;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PoolTest extends McRPGBaseTest {
+
+    private static final NamespacedKey COMMON_KEY = new NamespacedKey("mcrpg", "common");
+    private static final NamespacedKey RARE_KEY = new NamespacedKey("mcrpg", "rare");
+
+    @DisplayName("Constructor stores name correctly")
+    @Test
+    void name_returnsConstructorValue() {
+        Pool pool = new Pool("ores", 1.0, Map.of(), List.of());
+        assertEquals("ores", pool.name());
+    }
+
+    @DisplayName("Constructor stores difficulty correctly")
+    @Test
+    void difficulty_returnsConstructorValue() {
+        Pool pool = new Pool("ores", 2.5, Map.of(), List.of());
+        assertEquals(2.5, pool.difficulty());
+    }
+
+    @DisplayName("weights() returns defensive copy")
+    @Test
+    void weights_returnsDefensiveCopy() {
+        Map<NamespacedKey, Integer> original = new HashMap<>();
+        original.put(COMMON_KEY, 10);
+
+        Pool pool = new Pool("ores", 1.0, original, List.of());
+        original.put(RARE_KEY, 5);
+
+        assertEquals(1, pool.weights().size());
+        assertEquals(10, pool.weights().get(COMMON_KEY));
+    }
+
+    @DisplayName("weights() is unmodifiable")
+    @Test
+    void weights_isUnmodifiable() {
+        Pool pool = new Pool("ores", 1.0, Map.of(COMMON_KEY, 10), List.of());
+        assertThrows(UnsupportedOperationException.class, () -> pool.weights().put(RARE_KEY, 5));
+    }
+
+    @DisplayName("values() returns defensive copy")
+    @Test
+    void values_returnsDefensiveCopy() {
+        List<String> original = new ArrayList<>(List.of("IRON_ORE"));
+
+        Pool pool = new Pool("ores", 1.0, Map.of(), original);
+        original.add("DIAMOND_ORE");
+
+        assertEquals(1, pool.values().size());
+        assertEquals("IRON_ORE", pool.values().get(0));
+    }
+
+    @DisplayName("values() is unmodifiable")
+    @Test
+    void values_isUnmodifiable() {
+        Pool pool = new Pool("ores", 1.0, Map.of(), List.of("IRON_ORE"));
+        assertThrows(UnsupportedOperationException.class, () -> pool.values().add("DIAMOND_ORE"));
+    }
+
+    @DisplayName("getWeightForRarity returns weight for known key")
+    @Test
+    void getWeightForRarity_returnsWeight_whenKeyPresent() {
+        Pool pool = new Pool("ores", 1.0, Map.of(COMMON_KEY, 10, RARE_KEY, 3), List.of());
+        assertEquals(10, pool.getWeightForRarity(COMMON_KEY));
+        assertEquals(3, pool.getWeightForRarity(RARE_KEY));
+    }
+
+    @DisplayName("getWeightForRarity returns 0 for unknown key")
+    @Test
+    void getWeightForRarity_returnsZero_whenKeyAbsent() {
+        Pool pool = new Pool("ores", 1.0, Map.of(COMMON_KEY, 10), List.of());
+        NamespacedKey unknownKey = new NamespacedKey("mcrpg", "legendary");
+        assertEquals(0, pool.getWeightForRarity(unknownKey));
+    }
+
+    @DisplayName("Pool preserves multiple values in order")
+    @Test
+    void values_preservesOrder() {
+        List<String> values = List.of("IRON_ORE", "COPPER_ORE", "DIAMOND_ORE");
+        Pool pool = new Pool("ores", 1.0, Map.of(), values);
+        assertEquals(values, pool.values());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/variable/ResolvedPoolTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/variable/ResolvedPoolTest.java
@@ -1,0 +1,69 @@
+package us.eunoians.mcrpg.quest.board.template.variable;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResolvedPoolTest {
+
+    @DisplayName("Constructor stores averageDifficulty correctly")
+    @Test
+    void averageDifficulty_returnsConstructorValue() {
+        ResolvedPool pool = new ResolvedPool(List.of("IRON_ORE"), 3.5);
+        assertEquals(3.5, pool.averageDifficulty());
+    }
+
+    @DisplayName("mergedValues() returns defensive copy")
+    @Test
+    void mergedValues_returnsDefensiveCopy() {
+        List<String> original = new ArrayList<>(List.of("IRON_ORE"));
+
+        ResolvedPool pool = new ResolvedPool(original, 1.0);
+        original.add("DIAMOND_ORE");
+
+        assertEquals(1, pool.mergedValues().size());
+        assertEquals("IRON_ORE", pool.mergedValues().get(0));
+    }
+
+    @DisplayName("mergedValues() is unmodifiable")
+    @Test
+    void mergedValues_isUnmodifiable() {
+        ResolvedPool pool = new ResolvedPool(List.of("IRON_ORE"), 1.0);
+        assertThrows(UnsupportedOperationException.class, () -> pool.mergedValues().add("DIAMOND_ORE"));
+    }
+
+    @DisplayName("Empty merged values list is valid")
+    @Test
+    void mergedValues_emptyList_isValid() {
+        ResolvedPool pool = new ResolvedPool(List.of(), 0.0);
+        assertTrue(pool.mergedValues().isEmpty());
+    }
+
+    @DisplayName("mergedValues preserves order")
+    @Test
+    void mergedValues_preservesOrder() {
+        List<String> values = List.of("IRON_ORE", "COPPER_ORE", "DIAMOND_ORE");
+        ResolvedPool pool = new ResolvedPool(values, 2.0);
+        assertEquals(values, pool.mergedValues());
+    }
+
+    @DisplayName("averageDifficulty can be zero")
+    @Test
+    void averageDifficulty_canBeZero() {
+        ResolvedPool pool = new ResolvedPool(List.of(), 0.0);
+        assertEquals(0.0, pool.averageDifficulty());
+    }
+
+    @DisplayName("averageDifficulty can be negative")
+    @Test
+    void averageDifficulty_canBeNegative() {
+        ResolvedPool pool = new ResolvedPool(List.of(), -1.5);
+        assertEquals(-1.5, pool.averageDifficulty());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/impl/scope/impl/PermissionQuestScopeProviderTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/impl/scope/impl/PermissionQuestScopeProviderTest.java
@@ -1,0 +1,87 @@
+package us.eunoians.mcrpg.quest.impl.scope.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PermissionQuestScopeProviderTest extends McRPGBaseTest {
+
+    @DisplayName("getKey returns permission_scope key")
+    @Test
+    void getKey_returnsPermissionScopeKey() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        assertEquals(PermissionQuestScope.PERMISSION_SCOPE_KEY, provider.getKey());
+        assertEquals("mcrpg:permission_scope", provider.getKey().toString());
+    }
+
+    @DisplayName("getExpansionKey returns McRPG expansion key")
+    @Test
+    void getExpansionKey_returnsMcRPGExpansionKey() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        assertTrue(provider.getExpansionKey().isPresent());
+        assertEquals(McRPGExpansion.EXPANSION_KEY, provider.getExpansionKey().orElseThrow());
+    }
+
+    @DisplayName("withPermissionNode returns this for chaining")
+    @Test
+    void withPermissionNode_returnsThisForChaining() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        PermissionQuestScopeProvider result = provider.withPermissionNode("mcrpg.quest.vip");
+        assertEquals(provider, result);
+    }
+
+    @DisplayName("createNewScope returns scope with correct quest UUID and permission")
+    @Test
+    void createNewScope_returnsScope_withCorrectFields() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        provider.withPermissionNode("mcrpg.quest.test");
+        UUID questUUID = UUID.randomUUID();
+
+        PermissionQuestScope scope = provider.createNewScope(questUUID);
+
+        assertNotNull(scope);
+        assertEquals(questUUID, scope.getQuestUUID());
+        assertEquals("mcrpg.quest.test", scope.getPermissionNode().orElseThrow());
+    }
+
+    @DisplayName("createNewScope throws when permission not set")
+    @Test
+    void createNewScope_throwsIllegalStateException_whenPermissionNotSet() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        assertThrows(IllegalStateException.class, () -> provider.createNewScope(UUID.randomUUID()));
+    }
+
+    @DisplayName("createNewScope returns valid scope")
+    @Test
+    void createNewScope_returnsValidScope() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        provider.withPermissionNode("mcrpg.quest.test");
+
+        PermissionQuestScope scope = provider.createNewScope(UUID.randomUUID());
+
+        assertTrue(scope.isScopeValid());
+    }
+
+    @DisplayName("Each createNewScope call returns a distinct scope")
+    @Test
+    void createNewScope_returnsDistinctScopes() {
+        PermissionQuestScopeProvider provider = new PermissionQuestScopeProvider();
+        provider.withPermissionNode("mcrpg.quest.test");
+        UUID questUUID1 = UUID.randomUUID();
+        UUID questUUID2 = UUID.randomUUID();
+
+        PermissionQuestScope scope1 = provider.createNewScope(questUUID1);
+        PermissionQuestScope scope2 = provider.createNewScope(questUUID2);
+
+        assertEquals(questUUID1, scope1.getQuestUUID());
+        assertEquals(questUUID2, scope2.getQuestUUID());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/impl/scope/impl/SinglePlayerQuestScopeProviderTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/impl/scope/impl/SinglePlayerQuestScopeProviderTest.java
@@ -1,0 +1,68 @@
+package us.eunoians.mcrpg.quest.impl.scope.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SinglePlayerQuestScopeProviderTest extends McRPGBaseTest {
+
+    @DisplayName("getKey returns single_player_scope key")
+    @Test
+    void getKey_returnsSinglePlayerScopeKey() {
+        SinglePlayerQuestScopeProvider provider = new SinglePlayerQuestScopeProvider();
+        assertEquals(SinglePlayerQuestScopeProvider.KEY, provider.getKey());
+        assertEquals("mcrpg:single_player_scope", provider.getKey().toString());
+    }
+
+    @DisplayName("getExpansionKey returns McRPG expansion key")
+    @Test
+    void getExpansionKey_returnsMcRPGExpansionKey() {
+        SinglePlayerQuestScopeProvider provider = new SinglePlayerQuestScopeProvider();
+        assertTrue(provider.getExpansionKey().isPresent());
+        assertEquals(McRPGExpansion.EXPANSION_KEY, provider.getExpansionKey().orElseThrow());
+    }
+
+    @DisplayName("createNewScope returns scope with correct quest UUID")
+    @Test
+    void createNewScope_returnsScope_withCorrectQuestUUID() {
+        SinglePlayerQuestScopeProvider provider = new SinglePlayerQuestScopeProvider();
+        UUID questUUID = UUID.randomUUID();
+
+        SinglePlayerQuestScope scope = provider.createNewScope(questUUID);
+
+        assertNotNull(scope);
+        assertEquals(questUUID, scope.getQuestUUID());
+    }
+
+    @DisplayName("createNewScope returns invalid scope (no player set)")
+    @Test
+    void createNewScope_returnsInvalidScope() {
+        SinglePlayerQuestScopeProvider provider = new SinglePlayerQuestScopeProvider();
+
+        SinglePlayerQuestScope scope = provider.createNewScope(UUID.randomUUID());
+
+        assertTrue(scope.getPlayerInScope().isEmpty());
+        assertTrue(scope.getCurrentPlayersInScope().isEmpty());
+    }
+
+    @DisplayName("Each createNewScope call returns a distinct scope")
+    @Test
+    void createNewScope_returnsDistinctScopes() {
+        SinglePlayerQuestScopeProvider provider = new SinglePlayerQuestScopeProvider();
+        UUID questUUID1 = UUID.randomUUID();
+        UUID questUUID2 = UUID.randomUUID();
+
+        SinglePlayerQuestScope scope1 = provider.createNewScope(questUUID1);
+        SinglePlayerQuestScope scope2 = provider.createNewScope(questUUID2);
+
+        assertEquals(questUUID1, scope1.getQuestUUID());
+        assertEquals(questUUID2, scope2.getQuestUUID());
+    }
+}


### PR DESCRIPTION
## Summary

- **PoolTest** (8 tests): Covers the `Pool` record's defensive copy semantics (`Map.copyOf`/`List.copyOf`), unmodifiability of `weights()` and `values()`, `getWeightForRarity()` for known/unknown keys, and value order preservation.
- **ResolvedPoolTest** (7 tests): Covers the `ResolvedPool` record's defensive copy of `mergedValues`, unmodifiability, empty list handling, order preservation, and edge-case difficulty values (zero, negative).
- **ConditionContextTest** (9 tests, 4 `@Nested` groups): Covers all 4 factory methods (`forTemplateGeneration`, `forPersonalGeneration`, `forPrerequisiteCheck`, `forRewardGrant`), verifying each sets the correct fields and leaves context-inappropriate fields null.
- **SinglePlayerQuestScopeProviderTest** (5 tests): Covers `getKey()`, `getExpansionKey()`, `createNewScope()` producing a scope with the correct quest UUID, initial invalid state, and distinct scope instances.
- **PermissionQuestScopeProviderTest** (7 tests): Covers `getKey()`, `getExpansionKey()`, `withPermissionNode()` chaining, `createNewScope()` with correct fields, the `IllegalStateException` when permission is not set, valid scope state, and distinct scope instances.

**Total: 36 new tests across 5 test classes for 5 previously untested source classes.**

## Test plan

- [x] All 36 new tests pass locally
- [x] Full test suite passes (`gradle test` — zero failures)
- [x] Testing audit persona (`persona-testing.mdc`) checklist reviewed — no concerns
- [x] No overlap with any of the 28 open `[Unit Tests]` PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtPbYZwcoJHRzxAZxiXjZB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtPbYZwcoJHRzxAZxiXjZB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for quest context creation, including correct field population and handling of optional values.
  * Added tests for pool behavior, confirming stored values, safe copying, immutability, and lookup results.
  * Added tests for resolved pool behavior, including ordering, empty values, and difficulty handling.
  * Added scope provider tests to verify keys, expansion integration, scope creation, validation, and unique quest data per scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->