### PR TITLE
Isolate reward granting and add scope guards for quest board

### DIFF
--- a/src/main/java/us/eunoians/mcrpg/database/table/board/BoardOfferingDAO.java
+++ b/src/main/java/us/eunoians/mcrpg/database/table/board/BoardOfferingDAO.java
@@ -5,6 +5,7 @@ import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import us.eunoians.mcrpg.McRPG;
 import us.eunoians.mcrpg.quest.board.BoardOffering;
 
 import java.sql.Connection;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Level;
 
 /**
  * DAO for the {@code mcrpg_board_offering} table.
@@ -125,6 +127,35 @@ public class BoardOfferingDAO {
             }
         } catch (SQLException e) {
             e.printStackTrace();
+        }
+        return offerings;
+    }
+
+    /**
+     * Loads only the shared (unscoped) offerings for a rotation — rows whose
+     * {@code scope_target_id} is {@code NULL}. Scoped (group) and personal offerings
+     * are excluded so they can never leak into the shared board cache on restart.
+     *
+     * @param connection the database connection
+     * @param rotationId the rotation UUID
+     * @return the list of shared offerings for the rotation
+     */
+    @NotNull
+    public static List<BoardOffering> loadSharedOfferingsForRotation(@NotNull Connection connection,
+                                                                     @NotNull UUID rotationId) {
+        List<BoardOffering> offerings = new ArrayList<>();
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT * FROM " + TABLE_NAME
+                        + " WHERE rotation_id = ? AND scope_target_id IS NULL ORDER BY slot_index")) {
+            ps.setString(1, rotationId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    offerings.add(buildOffering(rs));
+                }
+            }
+        } catch (SQLException e) {
+            McRPG.getInstance().getLogger().log(Level.WARNING,
+                    "[BoardOfferingDAO] Failed to load shared offerings for rotation " + rotationId, e);
         }
         return offerings;
     }

--- a/src/main/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAO.java
+++ b/src/main/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAO.java
@@ -15,6 +15,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -140,19 +141,29 @@ public class PendingRewardDAO {
         }
 
         try (PreparedStatement select = connection.prepareStatement(
-                "SELECT * FROM " + TABLE_NAME + " WHERE player_uuid = ?")) {
+                "SELECT * FROM " + TABLE_NAME + " WHERE player_uuid = ? AND expires_at > ?")) {
             select.setString(1, playerUUID.toString());
+            select.setLong(2, now);
             try (ResultSet rs = select.executeQuery()) {
                 while (rs.next()) {
-                    Map<String, Object> config = GSON.fromJson(rs.getString("serialized_config"), CONFIG_MAP_TYPE);
+                    String rowId = rs.getString("id");
                     String rewardTypeKeyStr = rs.getString("reward_type_key");
                     String questKeyStr = rs.getString("quest_key");
+                    NamespacedKey rewardTypeKey = NamespacedKey.fromString(rewardTypeKeyStr);
+                    NamespacedKey questKey = NamespacedKey.fromString(questKeyStr);
+                    if (rewardTypeKey == null || questKey == null) {
+                        McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Skipping pending reward row " + rowId
+                                + " for player " + playerUUID + " — unparseable key(s): reward_type_key='" + rewardTypeKeyStr
+                                + "', quest_key='" + questKeyStr + "'. Row retained for manual inspection.");
+                        continue;
+                    }
+                    Map<String, Object> config = GSON.fromJson(rs.getString("serialized_config"), CONFIG_MAP_TYPE);
                     rewards.add(new PendingReward(
-                            UUID.fromString(rs.getString("id")),
+                            UUID.fromString(rowId),
                             playerUUID,
-                            NamespacedKey.fromString(rewardTypeKeyStr),
+                            rewardTypeKey,
                             config,
-                            NamespacedKey.fromString(questKeyStr),
+                            questKey,
                             rs.getLong("created_at"),
                             rs.getLong("expires_at")
                     ));
@@ -231,5 +242,31 @@ public class PendingRewardDAO {
         } catch (SQLException e) {
             McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Failed to delete pending reward " + rewardId, e);
         }
+    }
+
+    /**
+     * Generates the prepared statements to delete a set of pending rewards by ID.
+     * The returned statements are not executed — callers run them inside a single
+     * transaction (e.g. {@code FailSafeTransaction}) so that deletion of granted
+     * rewards is atomic and cannot partially fail.
+     *
+     * @param connection the database connection
+     * @param rewardIds  the pending reward IDs to delete
+     * @return the list of prepared delete statements (one per ID); empty if {@code rewardIds} is empty
+     */
+    @NotNull
+    public static List<PreparedStatement> deletePendingRewards(@NotNull Connection connection, @NotNull Collection<UUID> rewardIds) {
+        List<PreparedStatement> statements = new ArrayList<>();
+        for (UUID rewardId : rewardIds) {
+            try {
+                PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM " + TABLE_NAME + " WHERE id = ?");
+                statement.setString(1, rewardId.toString());
+                statements.add(statement);
+            } catch (SQLException e) {
+                McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Failed to prepare delete statement for pending reward " + rewardId, e);
+            }
+        }
+        return statements;
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAO.java
+++ b/src/main/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAO.java
@@ -147,26 +147,32 @@ public class PendingRewardDAO {
             try (ResultSet rs = select.executeQuery()) {
                 while (rs.next()) {
                     String rowId = rs.getString("id");
-                    String rewardTypeKeyStr = rs.getString("reward_type_key");
-                    String questKeyStr = rs.getString("quest_key");
-                    NamespacedKey rewardTypeKey = NamespacedKey.fromString(rewardTypeKeyStr);
-                    NamespacedKey questKey = NamespacedKey.fromString(questKeyStr);
-                    if (rewardTypeKey == null || questKey == null) {
-                        McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Skipping pending reward row " + rowId
-                                + " for player " + playerUUID + " — unparseable key(s): reward_type_key='" + rewardTypeKeyStr
-                                + "', quest_key='" + questKeyStr + "'. Row retained for manual inspection.");
-                        continue;
+                    try {
+                        String rewardTypeKeyStr = rs.getString("reward_type_key");
+                        String questKeyStr = rs.getString("quest_key");
+                        NamespacedKey rewardTypeKey = NamespacedKey.fromString(rewardTypeKeyStr);
+                        NamespacedKey questKey = NamespacedKey.fromString(questKeyStr);
+                        if (rewardTypeKey == null || questKey == null) {
+                            McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Skipping pending reward row " + rowId
+                                    + " for player " + playerUUID + " — unparseable key(s): reward_type_key='" + rewardTypeKeyStr
+                                    + "', quest_key='" + questKeyStr + "'. Row retained for manual inspection.");
+                            continue;
+                        }
+                        Map<String, Object> config = GSON.fromJson(rs.getString("serialized_config"), CONFIG_MAP_TYPE);
+                        rewards.add(new PendingReward(
+                                UUID.fromString(rowId),
+                                playerUUID,
+                                rewardTypeKey,
+                                config,
+                                questKey,
+                                rs.getLong("created_at"),
+                                rs.getLong("expires_at")
+                        ));
+                    } catch (RuntimeException e) {
+                        // A single corrupt row (bad JSON, malformed UUID) must not abort the whole load.
+                        McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Skipping unparseable pending reward row "
+                                + rowId + " for player " + playerUUID + "; row retained for manual inspection.", e);
                     }
-                    Map<String, Object> config = GSON.fromJson(rs.getString("serialized_config"), CONFIG_MAP_TYPE);
-                    rewards.add(new PendingReward(
-                            UUID.fromString(rowId),
-                            playerUUID,
-                            rewardTypeKey,
-                            config,
-                            questKey,
-                            rs.getLong("created_at"),
-                            rs.getLong("expires_at")
-                    ));
                 }
             }
         } catch (SQLException e) {
@@ -192,16 +198,29 @@ public class PendingRewardDAO {
             select.setLong(2, now);
             try (ResultSet rs = select.executeQuery()) {
                 while (rs.next()) {
-                    Map<String, Object> config = GSON.fromJson(rs.getString("serialized_config"), CONFIG_MAP_TYPE);
-                    rewards.add(new PendingReward(
-                            UUID.fromString(rs.getString("id")),
-                            playerUUID,
-                            NamespacedKey.fromString(rs.getString("reward_type_key")),
-                            config,
-                            NamespacedKey.fromString(rs.getString("quest_key")),
-                            rs.getLong("created_at"),
-                            rs.getLong("expires_at")
-                    ));
+                    String rowId = rs.getString("id");
+                    try {
+                        NamespacedKey rewardTypeKey = NamespacedKey.fromString(rs.getString("reward_type_key"));
+                        NamespacedKey questKey = NamespacedKey.fromString(rs.getString("quest_key"));
+                        if (rewardTypeKey == null || questKey == null) {
+                            McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Skipping pending reward row "
+                                    + rowId + " for player " + playerUUID + " — unparseable key(s).");
+                            continue;
+                        }
+                        Map<String, Object> config = GSON.fromJson(rs.getString("serialized_config"), CONFIG_MAP_TYPE);
+                        rewards.add(new PendingReward(
+                                UUID.fromString(rowId),
+                                playerUUID,
+                                rewardTypeKey,
+                                config,
+                                questKey,
+                                rs.getLong("created_at"),
+                                rs.getLong("expires_at")
+                        ));
+                    } catch (RuntimeException e) {
+                        McRPG.getInstance().getLogger().log(Level.WARNING, "[PendingRewardDAO] Skipping unparseable pending reward row "
+                                + rowId + " for player " + playerUUID + ".", e);
+                    }
                 }
             }
         } catch (SQLException e) {

--- a/src/main/java/us/eunoians/mcrpg/listener/entity/player/PlayerJoinListener.java
+++ b/src/main/java/us/eunoians/mcrpg/listener/entity/player/PlayerJoinListener.java
@@ -1,6 +1,7 @@
 package us.eunoians.mcrpg.listener.entity.player;
 
 import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.transaction.FailSafeTransaction;
 import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.task.core.CoreTask;
@@ -23,8 +24,12 @@ import us.eunoians.mcrpg.task.player.McRPGPlayerLoadTask;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
 
 /**
  * Starts the {@link McRPGPlayerLoadTask} to load in the player and grants any
@@ -70,7 +75,7 @@ public class PlayerJoinListener implements Listener {
             try (Connection connection = database.getConnection()) {
                 pendingRewards = PendingRewardDAO.loadAndCleanPendingRewards(connection, player.getUniqueId());
             } catch (SQLException e) {
-                e.printStackTrace();
+                mcRPG.getLogger().log(Level.SEVERE, "Failed to load pending rewards for player " + player.getUniqueId(), e);
                 return;
             }
 
@@ -87,26 +92,76 @@ public class PlayerJoinListener implements Listener {
                     QuestRewardTypeRegistry rewardTypeRegistry = RegistryAccess.registryAccess()
                             .registry(McRPGRegistryKey.QUEST_REWARD_TYPE);
 
-                    for (PendingReward pending : pendingRewards) {
-                        Optional<QuestRewardType> baseType = rewardTypeRegistry.get(pending.getRewardTypeKey());
-                        if (baseType.isEmpty()) {
-                            continue;
-                        }
-                        QuestRewardType configured = baseType.get().fromSerializedConfig(pending.getSerializedConfig());
-                        configured.grant(player);
+                    Set<UUID> grantedRewardIds = grantRewards(mcRPG, player, pendingRewards, rewardTypeRegistry);
+
+                    if (grantedRewardIds.isEmpty()) {
+                        return;
                     }
 
-                    database.getDatabaseExecutorService().submit(() -> {
-                        try (Connection connection = database.getConnection()) {
-                            for (PendingReward pending : pendingRewards) {
-                                PendingRewardDAO.deletePendingReward(connection, pending.getId());
-                            }
-                        } catch (SQLException e) {
-                            e.printStackTrace();
-                        }
-                    });
+                    deleteGrantedRewards(mcRPG, database, player.getUniqueId(), grantedRewardIds);
                 }
             }.runTask();
+        });
+    }
+
+    /**
+     * Grants each loaded pending reward in isolation and reports which rows were actually granted.
+     * <p>
+     * A reward whose type key is not registered is retained (never granted, never marked for deletion)
+     * so it survives until the owning expansion returns or the row expires. A reward whose
+     * {@code fromSerializedConfig}/{@code grant} throws is logged and skipped without aborting the loop,
+     * and is left in the database so it is not silently lost.
+     *
+     * @param mcRPG              the plugin instance
+     * @param player            the player to grant rewards to
+     * @param pendingRewards    the loaded pending rewards
+     * @param rewardTypeRegistry the reward type registry used to resolve reward keys
+     * @return the IDs of the rewards that were successfully granted and may now be deleted
+     */
+    @NotNull
+    private Set<UUID> grantRewards(@NotNull McRPG mcRPG, @NotNull Player player,
+                                   @NotNull List<PendingReward> pendingRewards,
+                                   @NotNull QuestRewardTypeRegistry rewardTypeRegistry) {
+        Set<UUID> grantedRewardIds = new HashSet<>();
+        for (PendingReward pending : pendingRewards) {
+            Optional<QuestRewardType> baseType = rewardTypeRegistry.get(pending.getRewardTypeKey());
+            if (baseType.isEmpty()) {
+                mcRPG.getLogger().log(Level.WARNING, "Retaining pending reward " + pending.getId() + " for player "
+                        + player.getUniqueId() + ": reward type '" + pending.getRewardTypeKey()
+                        + "' is not registered (expansion not enabled?). The reward will be granted once the type is available.");
+                continue;
+            }
+            try {
+                QuestRewardType configured = baseType.get().fromSerializedConfig(pending.getSerializedConfig());
+                configured.grant(player);
+                grantedRewardIds.add(pending.getId());
+            } catch (RuntimeException e) {
+                mcRPG.getLogger().log(Level.SEVERE, "Failed to grant pending reward " + pending.getId() + " (type '"
+                        + pending.getRewardTypeKey() + "') for player " + player.getUniqueId()
+                        + ". The reward is retained and will be retried on next login.", e);
+            }
+        }
+        return grantedRewardIds;
+    }
+
+    /**
+     * Deletes exactly the rows that were granted, atomically, on the database executor thread.
+     *
+     * @param mcRPG            the plugin instance
+     * @param database         the database instance
+     * @param playerUUID       the player whose rewards were granted
+     * @param grantedRewardIds the IDs of the rewards to delete
+     */
+    private void deleteGrantedRewards(@NotNull McRPG mcRPG, @NotNull Database database,
+                                      @NotNull UUID playerUUID, @NotNull Set<UUID> grantedRewardIds) {
+        database.getDatabaseExecutorService().submit(() -> {
+            try (Connection connection = database.getConnection()) {
+                new FailSafeTransaction(connection,
+                        PendingRewardDAO.deletePendingRewards(connection, grantedRewardIds)).executeTransaction();
+            } catch (SQLException e) {
+                mcRPG.getLogger().log(Level.SEVERE, "Failed to delete granted pending rewards for player " + playerUUID
+                        + "; they may be re-granted on next login.", e);
+            }
         });
     }
 }

--- a/src/main/java/us/eunoians/mcrpg/listener/entity/player/PlayerJoinListener.java
+++ b/src/main/java/us/eunoians/mcrpg/listener/entity/player/PlayerJoinListener.java
@@ -119,9 +119,9 @@ public class PlayerJoinListener implements Listener {
      * @return the IDs of the rewards that were successfully granted and may now be deleted
      */
     @NotNull
-    private Set<UUID> grantRewards(@NotNull McRPG mcRPG, @NotNull Player player,
-                                   @NotNull List<PendingReward> pendingRewards,
-                                   @NotNull QuestRewardTypeRegistry rewardTypeRegistry) {
+    Set<UUID> grantRewards(@NotNull McRPG mcRPG, @NotNull Player player,
+                           @NotNull List<PendingReward> pendingRewards,
+                           @NotNull QuestRewardTypeRegistry rewardTypeRegistry) {
         Set<UUID> grantedRewardIds = new HashSet<>();
         for (PendingReward pending : pendingRewards) {
             Optional<QuestRewardType> baseType = rewardTypeRegistry.get(pending.getRewardTypeKey());

--- a/src/main/java/us/eunoians/mcrpg/listener/quest/QuestCompleteListener.java
+++ b/src/main/java/us/eunoians/mcrpg/listener/quest/QuestCompleteListener.java
@@ -53,16 +53,12 @@ public class QuestCompleteListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onQuestComplete(@NotNull QuestCompleteEvent event) {
         QuestInstance questInstance = event.getQuestInstance();
-        questInstance.grantRewards(event.getQuestDefinition().getRewards());
 
-        event.getQuestDefinition().getRewardDistribution().ifPresent(config -> {
-            Map<UUID, Long> contributions = contributionAggregator.fromQuest(questInstance);
-            Set<UUID> groupMembers = questInstance.getQuestScope()
-                    .map(scope -> scope.getCurrentPlayersInScope())
-                    .orElse(Set.of());
-            distributionService.resolveAndGrant(config, contributions, groupMembers, questInstance);
-        });
-
+        // State-critical lifecycle first: completion logging (enforces ONCE/LIMITED repeat modes),
+        // board-slot release, retirement, and ephemeral-definition cleanup must all run even if a
+        // reward grant later throws. Otherwise a single throwing reward type would leave a ONCE quest
+        // unlogged (infinitely repeatable), un-retired (a zombie in the active map), and its board slot
+        // held forever.
         logCompletionForAllScopePlayers(questInstance);
         terminator.releaseBoardSlot(questInstance, "COMPLETED");
         terminator.decrementBoardCount(questInstance);
@@ -72,6 +68,52 @@ public class QuestCompleteListener implements Listener {
         questManager.retireQuest(questInstance);
 
         terminator.deregisterEphemeralDefinition(questInstance.getQuestKey());
+
+        // Reward granting last, isolated. retireQuest only relocates the instance between tiers, so the
+        // scope and contribution data read here are still live. Each grant path already isolates
+        // individual reward failures; these guards ensure an unexpected throw cannot undo the lifecycle
+        // steps above.
+        grantQuestRewards(questInstance, event);
+        grantDistributionRewards(questInstance, event);
+    }
+
+    /**
+     * Grants the quest-level rewards, isolating any failure so it cannot abort completion handling.
+     *
+     * @param questInstance the completed quest instance
+     * @param event         the completion event carrying the quest definition
+     */
+    private void grantQuestRewards(@NotNull QuestInstance questInstance, @NotNull QuestCompleteEvent event) {
+        try {
+            questInstance.grantRewards(event.getQuestDefinition().getRewards());
+        } catch (RuntimeException e) {
+            McRPG.getInstance().getLogger().log(Level.SEVERE,
+                    "Failed to grant quest rewards for " + questInstance.getQuestUUID()
+                            + "; the quest completion has already been finalized.", e);
+        }
+    }
+
+    /**
+     * Resolves and grants distribution rewards for a scoped quest, isolating any failure so it cannot
+     * abort completion handling.
+     *
+     * @param questInstance the completed quest instance
+     * @param event         the completion event carrying the quest definition
+     */
+    private void grantDistributionRewards(@NotNull QuestInstance questInstance, @NotNull QuestCompleteEvent event) {
+        event.getQuestDefinition().getRewardDistribution().ifPresent(config -> {
+            try {
+                Map<UUID, Long> contributions = contributionAggregator.fromQuest(questInstance);
+                Set<UUID> groupMembers = questInstance.getQuestScope()
+                        .map(scope -> scope.getCurrentPlayersInScope())
+                        .orElse(Set.of());
+                distributionService.resolveAndGrant(config, contributions, groupMembers, questInstance);
+            } catch (RuntimeException e) {
+                McRPG.getInstance().getLogger().log(Level.SEVERE,
+                        "Failed to grant distribution rewards for " + questInstance.getQuestUUID()
+                                + "; the quest completion has already been finalized.", e);
+            }
+        });
     }
 
     private void logCompletionForAllScopePlayers(@NotNull QuestInstance questInstance) {

--- a/src/main/java/us/eunoians/mcrpg/quest/board/OfferingAcceptResult.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/board/OfferingAcceptResult.java
@@ -40,7 +40,14 @@ public enum OfferingAcceptResult {
      * scope-validation failure inside the manager).
      * This is an internal error state and should not normally be presented to players.
      */
-    QUEST_START_FAILED;
+    QUEST_START_FAILED,
+
+    /**
+     * The offering is scope-targeted (a group/scoped offering, or another player's personal offering)
+     * and cannot be accepted through the shared-board path by the requesting player. Scoped offerings
+     * are accepted via their dedicated scoped-acceptance path instead.
+     */
+    WRONG_SCOPE;
 
     /**
      * Returns {@code true} if this result represents a successful acceptance.

--- a/src/main/java/us/eunoians/mcrpg/quest/board/QuestBoardManager.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/board/QuestBoardManager.java
@@ -509,6 +509,21 @@ public class QuestBoardManager extends Manager<McRPG> {
     }
 
     /**
+     * Returns every cached offering for a board regardless of scope, including scoped (group)
+     * offerings. Intended only for internal consumers that must see scope-targeted entries (e.g.
+     * {@link #getScopedOfferingsForPlayer}); shared-board-facing views must use
+     * {@link #getSharedOfferingsForBoard}, which strips scoped/personal offerings.
+     *
+     * @param boardKey the board key
+     * @return an immutable list of all cached offerings, or empty if the cache is not warmed
+     */
+    @NotNull
+    private List<BoardOffering> getAllCachedOfferings(@NotNull NamespacedKey boardKey) {
+        Map<UUID, BoardOffering> cached = offeringCache.get(boardKey);
+        return cached != null ? List.copyOf(cached.values()) : List.of();
+    }
+
+    /**
      * Filters a collection of offerings down to the shared (unscoped) ones — those whose
      * {@code scopeTargetId} is empty. Scoped (group) and personal offerings are excluded so
      * they never render on the shared board.
@@ -1161,7 +1176,9 @@ public class QuestBoardManager extends Manager<McRPG> {
         ScopedBoardAdapterRegistry adapterRegistry = plugin().registryAccess()
                 .registry(McRPGRegistryKey.SCOPED_BOARD_ADAPTER);
         QuestBoard board = getDefaultBoard();
-        List<BoardOffering> allOfferings = getSharedOfferingsForBoard(board.getBoardKey());
+        // Scoped offerings are stripped from the shared view, so read the full cache here and filter by
+        // the caller's entity scope below.
+        List<BoardOffering> allOfferings = getAllCachedOfferings(board.getBoardKey());
 
         Map<String, List<BoardOffering>> result = new HashMap<>();
 

--- a/src/main/java/us/eunoians/mcrpg/quest/board/QuestBoardManager.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/board/QuestBoardManager.java
@@ -69,6 +69,7 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -227,10 +228,12 @@ public class QuestBoardManager extends Manager<McRPG> {
                 }
                 // Warm the offering cache so getSharedOfferingsForBoard() never hits DB on main thread
                 List<BoardOffering> warmOfferings = new ArrayList<>();
+                // Load only shared (unscoped) offerings — scoped/personal rows must never enter the
+                // shared cache, or they would render on every player's board and be acceptable cross-scope.
                 dailyRotation.ifPresent(daily ->
-                        warmOfferings.addAll(BoardOfferingDAO.loadOfferingsForRotation(connection, daily.getRotationId())));
+                        warmOfferings.addAll(BoardOfferingDAO.loadSharedOfferingsForRotation(connection, daily.getRotationId())));
                 weeklyRotation.ifPresent(weekly ->
-                        warmOfferings.addAll(BoardOfferingDAO.loadOfferingsForRotation(connection, weekly.getRotationId())));
+                        warmOfferings.addAll(BoardOfferingDAO.loadSharedOfferingsForRotation(connection, weekly.getRotationId())));
                 validateOfferingStates(connection, warmOfferings);
                 offeringCache.put(DEFAULT_BOARD_KEY, toOfferingMap(warmOfferings));
 
@@ -496,11 +499,43 @@ public class QuestBoardManager extends Manager<McRPG> {
     public List<BoardOffering> getSharedOfferingsForBoard(@NotNull NamespacedKey boardKey) {
         Map<UUID, BoardOffering> cached = offeringCache.get(boardKey);
         if (cached != null) {
-            return List.copyOf(cached.values());
+            // Only unscoped offerings belong on the shared board. Filtering here (rather than in the GUI)
+            // guarantees every consumer of the shared view inherits the scope guarantee.
+            return filterSharedOfferings(cached.values());
         }
         plugin().getLogger().warning("[QuestBoard] Offering cache miss for " + boardKey
                 + " — cache should have been warmed during initialization or rotation");
         return List.of();
+    }
+
+    /**
+     * Filters a collection of offerings down to the shared (unscoped) ones — those whose
+     * {@code scopeTargetId} is empty. Scoped (group) and personal offerings are excluded so
+     * they never render on the shared board.
+     *
+     * @param offerings the offerings to filter
+     * @return an immutable list containing only the unscoped offerings
+     */
+    @NotNull
+    static List<BoardOffering> filterSharedOfferings(@NotNull Collection<BoardOffering> offerings) {
+        return offerings.stream()
+                .filter(offering -> offering.getScopeTargetId().isEmpty())
+                .toList();
+    }
+
+    /**
+     * Determines whether an offering may be accepted through the shared-board acceptance path by the
+     * given player. Unscoped offerings are always acceptable; a scope-targeted offering is only
+     * acceptable if its target is the clicking player (a personal offering). Scoped (group) offerings —
+     * whose target is a group entity id — are rejected here and handled by the scoped-acceptance path.
+     *
+     * @param offering   the offering being accepted
+     * @param playerUUID the UUID of the accepting player
+     * @return {@code true} if acceptance through the shared-board path is permitted
+     */
+    static boolean canAcceptThroughSharedBoard(@NotNull BoardOffering offering, @NotNull UUID playerUUID) {
+        Optional<String> scopeTargetId = offering.getScopeTargetId();
+        return scopeTargetId.isEmpty() || scopeTargetId.get().equals(playerUUID.toString());
     }
 
     /**
@@ -522,6 +557,13 @@ public class QuestBoardManager extends Manager<McRPG> {
 
             if (offering == null || !offering.canTransitionTo(BoardOffering.State.ACCEPTED)) {
                 return OfferingAcceptResult.NOT_AVAILABLE;
+            }
+
+            // Guard against cross-scope acceptance: this shared-board path may only accept unscoped
+            // offerings (or, defensively, a personal offering belonging to the clicking player). Scoped
+            // (group) offerings are accepted through acceptScopedOffering, never here.
+            if (!canAcceptThroughSharedBoard(offering, player.getUniqueId())) {
+                return OfferingAcceptResult.WRONG_SCOPE;
             }
 
             int activeCount = getActiveBoardQuestCount(player.getUniqueId());

--- a/src/main/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolver.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolver.java
@@ -184,10 +184,7 @@ public final class QuestRewardDistributionResolver {
                 }
             }
             case SCALE -> {
-                QuestRewardType scaled = entry.reward().withAmountMultiplier(baseMultiplier);
-                boolean isScalable = scaled != entry.reward();
-
-                if (!isScalable) {
+                if (!entry.reward().isScalable()) {
                     logger.warning("Non-scalable reward '" + entry.reward().getKey()
                             + "' used with SCALE pot-behavior; granting unscaled to all qualifying players");
                     for (UUID playerUUID : qualifyingPlayers) {
@@ -197,6 +194,7 @@ public final class QuestRewardDistributionResolver {
                     return;
                 }
 
+                QuestRewardType scaled = entry.reward().withAmountMultiplier(baseMultiplier);
                 OptionalLong scaledAmount = scaled.getNumericAmount();
                 if (scaledAmount.isPresent() && scaledAmount.getAsLong() < entry.minScaledAmount()) {
                     return;
@@ -206,8 +204,11 @@ public final class QuestRewardDistributionResolver {
                     result.computeIfAbsent(playerUUID, k -> new ArrayList<>()).add(scaled);
                 }
 
-                if (entry.remainderStrategy() != RemainderStrategy.DISCARD) {
-                    distributeRemainder(entry, baseMultiplier, qualifyingPlayers,
+                // Distribute the leftover between the pot total and what was actually granted. Passing the
+                // real per-player amount (rather than re-deriving it from the multiplier) keeps the remainder
+                // consistent with the reward type's own rounding, so granted + remainder == pot.
+                if (entry.remainderStrategy() != RemainderStrategy.DISCARD && scaledAmount.isPresent()) {
+                    distributeRemainder(entry, scaledAmount.getAsLong(), qualifyingPlayers,
                             snapshot, result, random);
                 }
             }
@@ -250,10 +251,7 @@ public final class QuestRewardDistributionResolver {
                 for (UUID playerUUID : qualifyingPlayers) {
                     long playerContribution = snapshot.contributions().getOrDefault(playerUUID, 0L);
                     double multiplier = (double) playerContribution / totalContribution;
-                    QuestRewardType scaled = entry.reward().withAmountMultiplier(multiplier);
-                    boolean isScalable = scaled != entry.reward();
-
-                    if (!isScalable) {
+                    if (!entry.reward().isScalable()) {
                         logger.warning("Non-scalable reward '" + entry.reward().getKey()
                                 + "' used with SCALE pot-behavior; granting unscaled to all");
                         for (UUID uuid : qualifyingPlayers) {
@@ -263,6 +261,7 @@ public final class QuestRewardDistributionResolver {
                         return;
                     }
 
+                    QuestRewardType scaled = entry.reward().withAmountMultiplier(multiplier);
                     OptionalLong scaledAmount = scaled.getNumericAmount();
                     if (scaledAmount.isPresent() && scaledAmount.getAsLong() < entry.minScaledAmount()) {
                         continue;
@@ -276,9 +275,14 @@ public final class QuestRewardDistributionResolver {
 
     /**
      * Distributes any remainder reward to one or more players based on the configured strategy.
+     * <p>
+     * {@code perPlayerAmount} is the amount each qualifying player actually received, so the
+     * remainder ({@code total - perPlayerAmount * players}) reflects the reward type's real rounding
+     * rather than a re-derived estimate. Remainder shares are granted with
+     * {@link QuestRewardType#withExactAmount(long)} so no rounding drift is introduced.
      *
      * @param entry             the reward entry with remainder configuration
-     * @param baseMultiplier    the base multiplier used for per-player calculation
+     * @param perPlayerAmount   the exact numeric amount each qualifying player was granted
      * @param qualifyingPlayers the set of qualifying players
      * @param snapshot          the contribution snapshot
      * @param result            the reward map to populate
@@ -286,7 +290,7 @@ public final class QuestRewardDistributionResolver {
      */
     private void distributeRemainder(
             @NotNull DistributionRewardEntry entry,
-            double baseMultiplier,
+            long perPlayerAmount,
             @NotNull Set<UUID> qualifyingPlayers,
             @NotNull ContributionSnapshot snapshot,
             @NotNull Map<UUID, List<QuestRewardType>> result,
@@ -298,9 +302,7 @@ public final class QuestRewardDistributionResolver {
         }
 
         long total = originalAmount.getAsLong();
-        long perPlayer = Math.max(entry.minScaledAmount(),
-                Math.round(total * baseMultiplier));
-        long distributed = perPlayer * qualifyingPlayers.size();
+        long distributed = perPlayerAmount * qualifyingPlayers.size();
         long remainder = total - distributed;
 
         if (remainder <= 0) {
@@ -309,15 +311,14 @@ public final class QuestRewardDistributionResolver {
 
         switch (entry.remainderStrategy()) {
             case TOP_CONTRIBUTOR -> findTopContributor(qualifyingPlayers, snapshot).ifPresent(top -> {
-                QuestRewardType extra = entry.reward().withAmountMultiplier(
-                        (double) remainder / total);
+                QuestRewardType extra = entry.reward().withExactAmount(remainder);
                 result.computeIfAbsent(top, k -> new ArrayList<>()).add(extra);
             });
             case RANDOM -> {
                 List<UUID> shuffled = new ArrayList<>(qualifyingPlayers);
                 Collections.shuffle(shuffled, random);
                 for (int i = 0; i < remainder && i < shuffled.size(); i++) {
-                    QuestRewardType extra = entry.reward().withAmountMultiplier(1.0 / total);
+                    QuestRewardType extra = entry.reward().withExactAmount(1);
                     result.computeIfAbsent(shuffled.get(i), k -> new ArrayList<>()).add(extra);
                 }
             }

--- a/src/main/java/us/eunoians/mcrpg/quest/board/distribution/RewardDistributionGranter.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/board/distribution/RewardDistributionGranter.java
@@ -1,6 +1,7 @@
 package us.eunoians.mcrpg.quest.board.distribution;
 
 import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.transaction.FailSafeTransaction;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -17,6 +18,7 @@ import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -97,23 +99,28 @@ public final class RewardDistributionGranter {
                 .getDatabase();
         database.getDatabaseExecutorService().submit(() -> {
             try (Connection connection = database.getConnection()) {
+                List<PreparedStatement> statements = new ArrayList<>();
                 for (QuestRewardType reward : rewards) {
-                    PendingReward pending = new PendingReward(
-                            UUID.randomUUID(),
-                            playerUUID,
-                            reward.getKey(),
-                            reward.serializeConfig(),
-                            questKey,
-                            now,
-                            expiresAt
-                    );
-                    for (PreparedStatement stmt : PendingRewardDAO.savePendingReward(connection, pending)) {
-                        stmt.executeUpdate();
+                    try {
+                        PendingReward pending = new PendingReward(
+                                UUID.randomUUID(),
+                                playerUUID,
+                                reward.getKey(),
+                                reward.serializeConfig(),
+                                questKey,
+                                now,
+                                expiresAt
+                        );
+                        statements.addAll(PendingRewardDAO.savePendingReward(connection, pending));
+                    } catch (RuntimeException e) {
+                        plugin.getLogger().log(Level.SEVERE, "Failed to build pending distribution reward '" + reward.getKey()
+                                + "' for offline player " + playerUUID + " (quest: " + questKey + "); skipping this reward.", e);
                     }
                 }
+                new FailSafeTransaction(connection, statements).executeTransaction();
             } catch (SQLException e) {
                 plugin.getLogger().log(Level.SEVERE,
-                        "Failed to persist pending reward for offline player (quest: " + questKey + ")", e);
+                        "Failed to persist pending rewards for offline player (quest: " + questKey + ")", e);
             }
         });
     }

--- a/src/main/java/us/eunoians/mcrpg/quest/board/distribution/RewardDistributionGranter.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/board/distribution/RewardDistributionGranter.java
@@ -57,7 +57,13 @@ public final class RewardDistributionGranter {
             Player player = Bukkit.getPlayer(playerUUID);
             if (player != null && player.isOnline()) {
                 for (QuestRewardType reward : rewards) {
-                    reward.grant(player);
+                    try {
+                        reward.grant(player);
+                    } catch (RuntimeException e) {
+                        plugin.getLogger().log(Level.SEVERE, "Failed to grant distribution reward '" + reward.getKey()
+                                + "' for quest " + questKey + " to player " + playerUUID
+                                + "; other rewards are unaffected.", e);
+                    }
                 }
             } else {
                 queueForOffline(playerUUID, rewards, questKey);

--- a/src/main/java/us/eunoians/mcrpg/quest/impl/QuestInstance.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/impl/QuestInstance.java
@@ -615,16 +615,21 @@ public class QuestInstance {
             try (Connection connection = database.getConnection()) {
                 List<PreparedStatement> statements = new ArrayList<>();
                 for (QuestRewardType reward : rewards) {
-                    PendingReward pending = new PendingReward(
-                            UUID.randomUUID(),
-                            playerUUID,
-                            reward.getKey(),
-                            reward.serializeConfig(),
-                            questKey,
-                            nowMillis,
-                            expiresAt
-                    );
-                    statements.addAll(PendingRewardDAO.savePendingReward(connection, pending));
+                    try {
+                        PendingReward pending = new PendingReward(
+                                UUID.randomUUID(),
+                                playerUUID,
+                                reward.getKey(),
+                                reward.serializeConfig(),
+                                questKey,
+                                nowMillis,
+                                expiresAt
+                        );
+                        statements.addAll(PendingRewardDAO.savePendingReward(connection, pending));
+                    } catch (RuntimeException e) {
+                        McRPG.getInstance().getLogger().log(Level.SEVERE, "Failed to build pending reward '" + reward.getKey()
+                                + "' for offline player " + playerUUID + " (quest: " + questKey + "); skipping this reward.", e);
+                    }
                 }
                 new FailSafeTransaction(connection, statements).executeTransaction();
             } catch (SQLException e) {

--- a/src/main/java/us/eunoians/mcrpg/quest/impl/QuestInstance.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/impl/QuestInstance.java
@@ -1,6 +1,7 @@
 package us.eunoians.mcrpg.quest.impl;
 
 import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.transaction.FailSafeTransaction;
 import com.diamonddagger590.mccore.registry.RegistryAccess;
 import com.diamonddagger590.mccore.registry.RegistryKey;
 import com.diamonddagger590.mccore.util.Methods;
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.UUID;
+import java.util.logging.Level;
 
 /**
  * Mutable runtime instance of a quest, tracking state, timestamps, scope, and child stage instances.
@@ -605,6 +607,7 @@ public class QuestInstance {
                 .registry(RegistryKey.MANAGER).manager(McRPGManagerKey.DATABASE).getDatabase();
         database.getDatabaseExecutorService().submit(() -> {
             try (Connection connection = database.getConnection()) {
+                List<PreparedStatement> statements = new ArrayList<>();
                 for (QuestRewardType reward : rewards) {
                     PendingReward pending = new PendingReward(
                             UUID.randomUUID(),
@@ -615,12 +618,12 @@ public class QuestInstance {
                             nowMillis,
                             expiresAt
                     );
-                    for (PreparedStatement stmt : PendingRewardDAO.savePendingReward(connection, pending)) {
-                        stmt.executeUpdate();
-                    }
+                    statements.addAll(PendingRewardDAO.savePendingReward(connection, pending));
                 }
+                new FailSafeTransaction(connection, statements).executeTransaction();
             } catch (SQLException e) {
-                e.printStackTrace();
+                McRPG.getInstance().getLogger().log(Level.SEVERE,
+                        "Failed to persist pending rewards for offline player " + playerUUID + " (quest: " + questKey + ")", e);
             }
         });
     }

--- a/src/main/java/us/eunoians/mcrpg/quest/impl/QuestInstance.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/impl/QuestInstance.java
@@ -578,7 +578,13 @@ public class QuestInstance {
                 Player player = Bukkit.getPlayer(playerUUID);
                 if (player != null && player.isOnline()) {
                     for (QuestRewardType reward : rewards) {
-                        reward.grant(player);
+                        try {
+                            reward.grant(player);
+                        } catch (RuntimeException e) {
+                            McRPG.getInstance().getLogger().log(Level.SEVERE, "Failed to grant reward '" + reward.getKey()
+                                    + "' for quest " + questKey + " to player " + playerUUID
+                                    + "; other rewards are unaffected.", e);
+                        }
                     }
                 } else {
                     queueRewardsForOfflinePlayer(playerUUID, rewards);

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/QuestRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/QuestRewardType.java
@@ -98,6 +98,38 @@ public interface QuestRewardType extends McRPGContent {
     }
 
     /**
+     * Indicates whether this reward type carries a numeric amount that the distribution
+     * resolver can scale via {@link #withAmountMultiplier} / {@link #withExactAmount}.
+     * <p>
+     * The default is {@code false}. Reward types with numeric amounts (experience, items,
+     * currency) must override this to return {@code true}. The resolver uses this explicit
+     * signal — rather than probing object identity — to decide whether a {@code SCALE}
+     * pot-behavior tier can split the reward.
+     *
+     * @return {@code true} if the reward can be scaled to a specific amount
+     */
+    default boolean isScalable() {
+        return false;
+    }
+
+    /**
+     * Returns a new reward instance with its numeric amount set to exactly {@code amount}.
+     * Used by the distribution resolver to grant computed remainder shares without the
+     * rounding drift that a multiplier round-trip would introduce.
+     * <p>
+     * The default returns {@code this} unchanged. Scalable reward types (those returning
+     * {@code true} from {@link #isScalable()}) must override this to build a copy carrying
+     * the exact amount.
+     *
+     * @param amount the exact numeric amount the returned reward should grant
+     * @return a copy carrying the exact amount, or {@code this} if the type is not scalable
+     */
+    @NotNull
+    default QuestRewardType withExactAmount(long amount) {
+        return this;
+    }
+
+    /**
      * Returns the numeric amount of this reward, if applicable. Used by the
      * distribution resolver for remainder calculations in split-mode tiers.
      * Reward types without a numeric amount (e.g., ability upgrades) return empty.

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/BoostedExperienceRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/BoostedExperienceRewardType.java
@@ -115,10 +115,21 @@ public class BoostedExperienceRewardType implements QuestRewardType {
         return new BoostedExperienceRewardType(amt, route, label);
     }
 
+    @Override
+    public boolean isScalable() {
+        return true;
+    }
+
     @NotNull
     @Override
     public BoostedExperienceRewardType withAmountMultiplier(double multiplier) {
         return new BoostedExperienceRewardType(Math.max(1, (int) (amount * multiplier)), localizationRoute, displayLabel);
+    }
+
+    @NotNull
+    @Override
+    public BoostedExperienceRewardType withExactAmount(long exactAmount) {
+        return new BoostedExperienceRewardType((int) exactAmount, localizationRoute, displayLabel);
     }
 
     @NotNull

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/ExperienceRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/ExperienceRewardType.java
@@ -141,11 +141,22 @@ public class ExperienceRewardType implements QuestRewardType {
         return OptionalLong.of(amount);
     }
 
+    @Override
+    public boolean isScalable() {
+        return true;
+    }
+
     @NotNull
     @Override
     public ExperienceRewardType withAmountMultiplier(double multiplier) {
         long scaled = Math.max(1, (long) (amount * multiplier));
         return new ExperienceRewardType(skillName, scaled, localizationRoute, displayLabel);
+    }
+
+    @NotNull
+    @Override
+    public ExperienceRewardType withExactAmount(long exactAmount) {
+        return new ExperienceRewardType(skillName, exactAmount, localizationRoute, displayLabel);
     }
 
     @NotNull

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/ItemRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/ItemRewardType.java
@@ -188,11 +188,22 @@ public class ItemRewardType implements QuestRewardType {
         return OptionalLong.of(amount);
     }
 
+    @Override
+    public boolean isScalable() {
+        return true;
+    }
+
     @NotNull
     @Override
     public QuestRewardType withAmountMultiplier(double multiplier) {
         int scaled = Math.max(1, (int) Math.round(amount * multiplier));
         return new ItemRewardType(itemConfig, scaled, localizationRoute, displayLabel);
+    }
+
+    @NotNull
+    @Override
+    public QuestRewardType withExactAmount(long exactAmount) {
+        return new ItemRewardType(itemConfig, (int) exactAmount, localizationRoute, displayLabel);
     }
 
     @NotNull

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableExperienceRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableExperienceRewardType.java
@@ -116,10 +116,21 @@ public class RedeemableExperienceRewardType implements QuestRewardType {
         return new RedeemableExperienceRewardType(amt, route, label);
     }
 
+    @Override
+    public boolean isScalable() {
+        return true;
+    }
+
     @NotNull
     @Override
     public RedeemableExperienceRewardType withAmountMultiplier(double multiplier) {
         return new RedeemableExperienceRewardType(Math.max(1, (int) (amount * multiplier)), localizationRoute, displayLabel);
+    }
+
+    @NotNull
+    @Override
+    public RedeemableExperienceRewardType withExactAmount(long exactAmount) {
+        return new RedeemableExperienceRewardType((int) exactAmount, localizationRoute, displayLabel);
     }
 
     @NotNull

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableLevelsRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableLevelsRewardType.java
@@ -116,10 +116,21 @@ public class RedeemableLevelsRewardType implements QuestRewardType {
         return new RedeemableLevelsRewardType(amt, route, label);
     }
 
+    @Override
+    public boolean isScalable() {
+        return true;
+    }
+
     @NotNull
     @Override
     public RedeemableLevelsRewardType withAmountMultiplier(double multiplier) {
         return new RedeemableLevelsRewardType(Math.max(1, (int) (amount * multiplier)), localizationRoute, displayLabel);
+    }
+
+    @NotNull
+    @Override
+    public RedeemableLevelsRewardType withExactAmount(long exactAmount) {
+        return new RedeemableLevelsRewardType((int) exactAmount, localizationRoute, displayLabel);
     }
 
     @NotNull

--- a/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/ScalableCommandRewardType.java
+++ b/src/main/java/us/eunoians/mcrpg/quest/reward/builtin/ScalableCommandRewardType.java
@@ -140,11 +140,22 @@ public final class ScalableCommandRewardType implements QuestRewardType {
         }
     }
 
+    @Override
+    public boolean isScalable() {
+        return true;
+    }
+
     @NotNull
     @Override
     public QuestRewardType withAmountMultiplier(double multiplier) {
         long scaled = Math.max(1, Math.round(baseAmount * multiplier));
         return new ScalableCommandRewardType(commandTemplate, scaled, displayLabel, localizationRoute);
+    }
+
+    @NotNull
+    @Override
+    public QuestRewardType withExactAmount(long exactAmount) {
+        return new ScalableCommandRewardType(commandTemplate, exactAmount, displayLabel, localizationRoute);
     }
 
     @NotNull

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/BoardOfferingDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/BoardOfferingDAOTest.java
@@ -230,6 +230,41 @@ public class BoardOfferingDAOTest extends McRPGBaseTest {
         verify(mockConnection).prepareStatement(contains("scope_target_id IS NULL"));
     }
 
+    @DisplayName("loadSharedOfferingsForRotation returns built offerings when rows are present")
+    @Test
+    void loadSharedOfferingsForRotation_returnsOfferings_whenPresent() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+        UUID offeringId = UUID.randomUUID();
+        UUID rotId = UUID.randomUUID();
+
+        when(mockResultSet.next()).thenReturn(true, false);
+        when(mockResultSet.getString("offering_id")).thenReturn(offeringId.toString());
+        when(mockResultSet.getString("rotation_id")).thenReturn(rotId.toString());
+        when(mockResultSet.getString("category_key")).thenReturn("mcrpg:daily_shared");
+        when(mockResultSet.getInt("slot_index")).thenReturn(0);
+        when(mockResultSet.getString("quest_definition_key")).thenReturn("mcrpg:mine_stone");
+        when(mockResultSet.getString("rarity_key")).thenReturn("mcrpg:common");
+        when(mockResultSet.getString("scope_target_id")).thenReturn(null);
+        when(mockResultSet.getString("state")).thenReturn("VISIBLE");
+        when(mockResultSet.getLong("accepted_at")).thenReturn(0L);
+        when(mockResultSet.wasNull()).thenReturn(true);
+        when(mockResultSet.getString("quest_instance_uuid")).thenReturn(null);
+        when(mockResultSet.getLong("completion_time_ms")).thenReturn(86400000L);
+        when(mockResultSet.getString("generated_definition")).thenReturn(null);
+        when(mockResultSet.getString("template_key")).thenReturn(null);
+
+        List<BoardOffering> result = BoardOfferingDAO.loadSharedOfferingsForRotation(mockConnection, rotId);
+
+        assertEquals(1, result.size());
+        assertEquals(offeringId, result.get(0).getOfferingId());
+        assertTrue(result.get(0).getScopeTargetId().isEmpty());
+    }
+
     @DisplayName("loadPersonalOfferingsForRotation returns empty when no results")
     @Test
     void loadPersonalOfferingsForRotation_returnsEmpty() throws SQLException {

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/BoardOfferingDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/BoardOfferingDAOTest.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.*;
 
 public class BoardOfferingDAOTest extends McRPGBaseTest {
@@ -210,6 +211,23 @@ public class BoardOfferingDAOTest extends McRPGBaseTest {
         assertTrue(offering.isTemplateGenerated());
         assertEquals(new NamespacedKey("mcrpg", "daily_mining"), offering.getTemplateKey().orElseThrow());
         assertEquals(generatedDef, offering.getGeneratedDefinition().orElseThrow());
+    }
+
+    @DisplayName("loadSharedOfferingsForRotation filters on scope_target_id IS NULL")
+    @Test
+    void loadSharedOfferingsForRotation_filtersOnNullScope() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        List<BoardOffering> result = BoardOfferingDAO.loadSharedOfferingsForRotation(mockConnection, UUID.randomUUID());
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(mockConnection).prepareStatement(contains("scope_target_id IS NULL"));
     }
 
     @DisplayName("loadPersonalOfferingsForRotation returns empty when no results")

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAOTest.java
@@ -105,6 +105,45 @@ public class PendingRewardDAOTest extends McRPGBaseTest {
     }
 
     @Test
+    @DisplayName("loadAndCleanPendingRewards skips a row with corrupt serialized_config JSON")
+    public void loadAndCleanPendingRewards_skipsRow_whenJsonCorrupt() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement deleteStatement = mock(PreparedStatement.class);
+        PreparedStatement selectStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(mockConnection.prepareStatement(contains("DELETE"))).thenReturn(deleteStatement);
+        when(mockConnection.prepareStatement(contains("SELECT"))).thenReturn(selectStatement);
+        when(selectStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("id")).thenReturn(UUID.randomUUID().toString());
+        when(resultSet.getString("reward_type_key")).thenReturn("mcrpg:test_reward");
+        when(resultSet.getString("quest_key")).thenReturn("mcrpg:test_quest");
+        when(resultSet.getString("serialized_config")).thenReturn("this is not json");
+
+        List<PendingReward> rewards = PendingRewardDAO.loadAndCleanPendingRewards(mockConnection, UUID.randomUUID());
+
+        // The GSON parse failure is caught per-row: the corrupt row is skipped, not propagated.
+        assertTrue(rewards.isEmpty());
+    }
+
+    @Test
+    @DisplayName("deletePendingRewards skips an id whose statement fails to prepare and keeps the rest")
+    public void deletePendingRewards_skipsFailedId_whenPrepareThrows() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement okStatement = mock(PreparedStatement.class);
+        // First id's prepare throws; the second succeeds.
+        when(mockConnection.prepareStatement(anyString()))
+                .thenThrow(new SQLException("boom"))
+                .thenReturn(okStatement);
+
+        List<PreparedStatement> statements = PendingRewardDAO.deletePendingRewards(
+                mockConnection, new java.util.LinkedHashSet<>(List.of(UUID.randomUUID(), UUID.randomUUID())));
+
+        // One prepare failed and was isolated; the other id still produced a statement.
+        assertEquals(1, statements.size());
+    }
+
+    @Test
     @DisplayName("deletePendingRewards prepares one statement per id")
     public void deletePendingRewards_returnsStatementPerId() throws SQLException {
         Connection mockConnection = mock(Connection.class);

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/PendingRewardDAOTest.java
@@ -8,13 +8,20 @@ import us.eunoians.mcrpg.quest.reward.PendingReward;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,5 +58,72 @@ public class PendingRewardDAOTest extends McRPGBaseTest {
 
         PendingRewardDAO.deletePendingReward(mockConnection, UUID.randomUUID());
         verify(mockStatement).executeUpdate();
+    }
+
+    @Test
+    @DisplayName("loadAndCleanPendingRewards binds the expires_at filter on the select")
+    public void loadAndCleanPendingRewards_bindsExpiresAtFilter_whenSelecting() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement deleteStatement = mock(PreparedStatement.class);
+        PreparedStatement selectStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(mockConnection.prepareStatement(contains("DELETE"))).thenReturn(deleteStatement);
+        when(mockConnection.prepareStatement(contains("SELECT"))).thenReturn(selectStatement);
+        when(selectStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("id")).thenReturn(UUID.randomUUID().toString());
+        when(resultSet.getString("reward_type_key")).thenReturn("mcrpg:test_reward");
+        when(resultSet.getString("quest_key")).thenReturn("mcrpg:test_quest");
+        when(resultSet.getString("serialized_config")).thenReturn("{}");
+
+        List<PendingReward> rewards = PendingRewardDAO.loadAndCleanPendingRewards(mockConnection, UUID.randomUUID());
+
+        assertEquals(1, rewards.size());
+        // Second bind param on the SELECT is the expires_at floor — proves expiry is filtered independently of the DELETE.
+        verify(selectStatement).setLong(eq(2), anyLong());
+    }
+
+    @Test
+    @DisplayName("loadAndCleanPendingRewards retains rows with an unparseable key")
+    public void loadAndCleanPendingRewards_skipsRow_whenKeyUnparseable() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement deleteStatement = mock(PreparedStatement.class);
+        PreparedStatement selectStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(mockConnection.prepareStatement(contains("DELETE"))).thenReturn(deleteStatement);
+        when(mockConnection.prepareStatement(contains("SELECT"))).thenReturn(selectStatement);
+        when(selectStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("id")).thenReturn(UUID.randomUUID().toString());
+        when(resultSet.getString("reward_type_key")).thenReturn("INVALID KEY");
+        when(resultSet.getString("quest_key")).thenReturn("mcrpg:test_quest");
+
+        List<PendingReward> rewards = PendingRewardDAO.loadAndCleanPendingRewards(mockConnection, UUID.randomUUID());
+
+        // Row is not returned (skipped) and is never handed to the delete set — it survives for inspection.
+        assertTrue(rewards.isEmpty());
+    }
+
+    @Test
+    @DisplayName("deletePendingRewards prepares one statement per id")
+    public void deletePendingRewards_returnsStatementPerId() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+        Set<UUID> ids = Set.of(UUID.randomUUID(), UUID.randomUUID());
+        List<PreparedStatement> statements = PendingRewardDAO.deletePendingRewards(mockConnection, ids);
+
+        assertEquals(2, statements.size());
+    }
+
+    @Test
+    @DisplayName("deletePendingRewards returns empty for no ids")
+    public void deletePendingRewards_returnsEmpty_whenNoIds() {
+        Connection mockConnection = mock(Connection.class);
+
+        List<PreparedStatement> statements = PendingRewardDAO.deletePendingRewards(mockConnection, Set.of());
+
+        assertTrue(statements.isEmpty());
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/listener/entity/player/PlayerJoinListenerTest.java
+++ b/src/test/java/us/eunoians/mcrpg/listener/entity/player/PlayerJoinListenerTest.java
@@ -1,0 +1,146 @@
+package us.eunoians.mcrpg.listener.entity.player;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.reward.PendingReward;
+import us.eunoians.mcrpg.quest.reward.QuestRewardType;
+import us.eunoians.mcrpg.quest.reward.QuestRewardTypeRegistry;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests the login grant loop's failure isolation: a reward whose type is unregistered or whose
+ * grant throws must be retained (never added to the delete set), while successful grants are reported.
+ */
+public class PlayerJoinListenerTest extends McRPGBaseTest {
+
+    private PlayerJoinListener listener;
+    private Player player;
+    private QuestRewardTypeRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PlayerJoinListener();
+        player = mock(Player.class);
+        registry = new QuestRewardTypeRegistry();
+    }
+
+    private PendingReward pending(@NotNull NamespacedKey rewardTypeKey) {
+        return new PendingReward(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                rewardTypeKey,
+                Map.of(),
+                new NamespacedKey("mcrpg", "test_quest"),
+                0L,
+                Long.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("grantRewards returns only successfully granted ids")
+    void grantRewards_returnsGrantedId_whenGrantSucceeds() {
+        NamespacedKey key = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "ok_reward");
+        registry.register(new RecordingRewardType(key));
+        PendingReward reward = pending(key);
+
+        Set<UUID> granted = listener.grantRewards(McRPG.getInstance(), player, List.of(reward), registry);
+
+        assertEquals(Set.of(reward.getId()), granted);
+    }
+
+    @Test
+    @DisplayName("grantRewards retains a reward whose type is not registered")
+    void grantRewards_retainsReward_whenTypeUnregistered() {
+        PendingReward reward = pending(new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "missing_reward"));
+
+        Set<UUID> granted = listener.grantRewards(McRPG.getInstance(), player, List.of(reward), registry);
+
+        // Unregistered type -> not granted, so its row id is never returned for deletion.
+        assertTrue(granted.isEmpty());
+    }
+
+    @Test
+    @DisplayName("grantRewards isolates a throwing reward and still grants the others")
+    void grantRewards_isolatesFailure_whenGrantThrows() {
+        NamespacedKey throwingKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "throwing_reward");
+        NamespacedKey okKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "ok_reward");
+        registry.register(new ThrowingRewardType(throwingKey));
+        registry.register(new RecordingRewardType(okKey));
+
+        PendingReward throwing = pending(throwingKey);
+        PendingReward ok = pending(okKey);
+
+        Set<UUID> granted = listener.grantRewards(McRPG.getInstance(), player, List.of(throwing, ok), registry);
+
+        // The throwing reward is retained; the good reward is still granted.
+        assertFalse(granted.contains(throwing.getId()));
+        assertTrue(granted.contains(ok.getId()));
+    }
+
+    /** Reward type that grants without side effects. */
+    private static class RecordingRewardType implements QuestRewardType {
+        private final NamespacedKey key;
+
+        RecordingRewardType(@NotNull NamespacedKey key) {
+            this.key = key;
+        }
+
+        @Override
+        public @NotNull NamespacedKey getKey() {
+            return key;
+        }
+
+        @Override
+        public @NotNull QuestRewardType parseConfig(@NotNull Section section) {
+            return this;
+        }
+
+        @Override
+        public void grant(@NotNull Player player) {
+        }
+
+        @Override
+        public @NotNull Map<String, Object> serializeConfig() {
+            return Map.of();
+        }
+
+        @Override
+        public @NotNull QuestRewardType fromSerializedConfig(@NotNull Map<String, Object> config) {
+            return this;
+        }
+
+        @Override
+        public @NotNull Optional<NamespacedKey> getExpansionKey() {
+            return Optional.empty();
+        }
+    }
+
+    /** Reward type whose grant always throws, simulating faulty third-party reward code. */
+    private static class ThrowingRewardType extends RecordingRewardType {
+        ThrowingRewardType(@NotNull NamespacedKey key) {
+            super(key);
+        }
+
+        @Override
+        public void grant(@NotNull Player player) {
+            throw new IllegalStateException("boom");
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/QuestBoardManagerScopeGuardTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/QuestBoardManagerScopeGuardTest.java
@@ -2,9 +2,9 @@ package us.eunoians.mcrpg.quest.board;
 
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import us.eunoians.mcrpg.McRPGBaseTest;
 
 import java.time.Duration;
 import java.util.List;
@@ -16,11 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the scope guards that keep scoped/personal offerings off the shared board and out of the
- * shared-board acceptance path.
+ * shared-board acceptance path. These are pure-Java static helpers, so no MockBukkit bootstrap is needed.
  */
-public class QuestBoardManagerScopeGuardTest extends McRPGBaseTest {
+public class QuestBoardManagerScopeGuardTest {
 
-    private BoardOffering offering(@org.jetbrains.annotations.Nullable String scopeTargetId, int slot) {
+    private BoardOffering offering(@Nullable String scopeTargetId, int slot) {
         return new BoardOffering(
                 UUID.randomUUID(),
                 UUID.randomUUID(),

--- a/src/test/java/us/eunoians/mcrpg/quest/board/QuestBoardManagerScopeGuardTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/QuestBoardManagerScopeGuardTest.java
@@ -1,0 +1,80 @@
+package us.eunoians.mcrpg.quest.board;
+
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the scope guards that keep scoped/personal offerings off the shared board and out of the
+ * shared-board acceptance path.
+ */
+public class QuestBoardManagerScopeGuardTest extends McRPGBaseTest {
+
+    private BoardOffering offering(@org.jetbrains.annotations.Nullable String scopeTargetId, int slot) {
+        return new BoardOffering(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                new NamespacedKey("mcrpg", "daily_shared"),
+                slot,
+                new NamespacedKey("mcrpg", "mine_stone"),
+                new NamespacedKey("mcrpg", "common"),
+                scopeTargetId,
+                Duration.ofDays(1));
+    }
+
+    @Test
+    @DisplayName("filterSharedOfferings drops scoped and personal offerings")
+    void filterSharedOfferings_dropsScopedAndPersonal() {
+        BoardOffering shared = offering(null, 0);
+        BoardOffering scoped = offering("lands-entity-42", 1);
+        BoardOffering personal = offering(UUID.randomUUID().toString(), 2);
+
+        List<BoardOffering> result = QuestBoardManager.filterSharedOfferings(List.of(shared, scoped, personal));
+
+        assertEquals(1, result.size());
+        assertEquals(shared.getOfferingId(), result.get(0).getOfferingId());
+    }
+
+    @Test
+    @DisplayName("canAcceptThroughSharedBoard allows an unscoped offering")
+    void canAcceptThroughSharedBoard_allowsUnscoped() {
+        assertTrue(QuestBoardManager.canAcceptThroughSharedBoard(offering(null, 0), UUID.randomUUID()));
+    }
+
+    @Test
+    @DisplayName("canAcceptThroughSharedBoard rejects a scoped offering")
+    void canAcceptThroughSharedBoard_rejectsScoped() {
+        assertFalse(QuestBoardManager.canAcceptThroughSharedBoard(offering("lands-entity-42", 0), UUID.randomUUID()));
+    }
+
+    @Test
+    @DisplayName("canAcceptThroughSharedBoard rejects another player's personal offering")
+    void canAcceptThroughSharedBoard_rejectsOtherPlayersPersonal() {
+        UUID owner = UUID.randomUUID();
+        UUID clicker = UUID.randomUUID();
+        assertFalse(QuestBoardManager.canAcceptThroughSharedBoard(offering(owner.toString(), 0), clicker));
+    }
+
+    @Test
+    @DisplayName("canAcceptThroughSharedBoard allows the player's own personal offering")
+    void canAcceptThroughSharedBoard_allowsOwnPersonal() {
+        UUID player = UUID.randomUUID();
+        assertTrue(QuestBoardManager.canAcceptThroughSharedBoard(offering(player.toString(), 0), player));
+    }
+
+    @Test
+    @DisplayName("WRONG_SCOPE is not an accepted result")
+    void wrongScope_isNotAccepted() {
+        assertFalse(OfferingAcceptResult.WRONG_SCOPE.isAccepted());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/distribution/MinScaledAmountDistributionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/distribution/MinScaledAmountDistributionTest.java
@@ -69,8 +69,18 @@ public class MinScaledAmountDistributionTest extends McRPGBaseTest {
         public @org.jetbrains.annotations.NotNull Optional<NamespacedKey> getExpansionKey() { return Optional.empty(); }
 
         @Override
+        public boolean isScalable() {
+            return true;
+        }
+
+        @Override
         public @org.jetbrains.annotations.NotNull QuestRewardType withAmountMultiplier(double multiplier) {
             return new ScalableReward(Math.round(amount * multiplier));
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull QuestRewardType withExactAmount(long exactAmount) {
+            return new ScalableReward(exactAmount);
         }
 
         @Override

--- a/src/test/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolverTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolverTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.jetbrains.annotations.NotNull;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.board.distribution.builtin.ParticipatedDistributionType;
 import us.eunoians.mcrpg.quest.board.distribution.builtin.TopPlayersDistributionType;
@@ -84,8 +85,23 @@ public class QuestRewardDistributionResolverTest extends McRPGBaseTest {
         }
 
         @Override
+        public boolean isScalable() {
+            return true;
+        }
+
+        @Override
         public @org.jetbrains.annotations.NotNull QuestRewardType withAmountMultiplier(double multiplier) {
             return new TestRewardType(Math.max(1, (long) (amount * multiplier)));
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull QuestRewardType withExactAmount(long exactAmount) {
+            return new TestRewardType(exactAmount);
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull java.util.OptionalLong getNumericAmount() {
+            return java.util.OptionalLong.of(amount);
         }
     }
 
@@ -240,5 +256,68 @@ public class QuestRewardDistributionResolverTest extends McRPGBaseTest {
 
         var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry);
         assertTrue(result.isEmpty());
+    }
+
+    @Nested
+    @DisplayName("Remainder distribution")
+    class RemainderDistribution {
+
+        private RewardDistributionConfig configWith(@NotNull RemainderStrategy strategy) {
+            var entry = new DistributionRewardEntry(new TestRewardType(10), PotBehavior.SCALE, strategy, 1, 1, null);
+            var tier = new DistributionTierConfig("t1", ParticipatedDistributionType.KEY,
+                    RewardSplitMode.SPLIT_EVEN, List.of(entry), Map.of(), null, null);
+            return new RewardDistributionConfig(List.of(tier));
+        }
+
+        private long grantedTotal(@NotNull Map<UUID, List<QuestRewardType>> result) {
+            return result.values().stream()
+                    .flatMap(List::stream)
+                    .mapToLong(reward -> ((TestRewardType) reward).getAmount())
+                    .sum();
+        }
+
+        @Test
+        @DisplayName("TOP_CONTRIBUTOR routes the truncation remainder so granted total equals the pot")
+        void topContributor_grantsFullPot_whenSplitTruncates() {
+            UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID(), p3 = UUID.randomUUID(), p4 = UUID.randomUUID();
+            var config = configWith(RemainderStrategy.TOP_CONTRIBUTOR);
+            var snapshot = new ContributionSnapshot(
+                    Map.of(p1, 40L, p2, 30L, p3, 20L, p4, 10L), 100, Set.of(p1, p2, p3, p4), null);
+
+            var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry);
+
+            // 10 XP / 4 players truncates to 2 each (8 granted); the leftover 2 goes to the top contributor.
+            assertEquals(10, grantedTotal(result));
+            assertEquals(2, result.get(p1).size());
+            assertEquals(1, result.get(p2).size());
+        }
+
+        @Test
+        @DisplayName("DISCARD drops the truncation remainder")
+        void discard_dropsRemainder() {
+            UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID(), p3 = UUID.randomUUID(), p4 = UUID.randomUUID();
+            var config = configWith(RemainderStrategy.DISCARD);
+            var snapshot = new ContributionSnapshot(
+                    Map.of(p1, 40L, p2, 30L, p3, 20L, p4, 10L), 100, Set.of(p1, p2, p3, p4), null);
+
+            var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry);
+
+            // 2 each, remainder 2 discarded.
+            assertEquals(8, grantedTotal(result));
+        }
+
+        @Test
+        @DisplayName("RANDOM distributes the whole pot as single-unit remainder shares")
+        void random_grantsFullPot() {
+            UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID(), p3 = UUID.randomUUID(), p4 = UUID.randomUUID();
+            var config = configWith(RemainderStrategy.RANDOM);
+            var snapshot = new ContributionSnapshot(
+                    Map.of(p1, 40L, p2, 30L, p3, 20L, p4, 10L), 100, Set.of(p1, p2, p3, p4), null);
+
+            var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry, new java.util.Random(0));
+
+            // 2 each (8) plus two 1-unit remainder shares == 10.
+            assertEquals(10, grantedTotal(result));
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolverTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolverTest.java
@@ -371,6 +371,27 @@ public class QuestRewardDistributionResolverTest extends McRPGBaseTest {
         }
 
         @Test
+        @DisplayName("TOP_CONTRIBUTOR extra reward carries the exact remainder amount")
+        void topContributor_extraRewardCarriesExactRemainder() {
+            UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID(), p3 = UUID.randomUUID(), p4 = UUID.randomUUID();
+            // Pot 11 / 4 players truncates to a 2 share each (8 granted); the exact leftover 3 goes to the top.
+            var entry = new DistributionRewardEntry(new TestRewardType(11), PotBehavior.SCALE,
+                    RemainderStrategy.TOP_CONTRIBUTOR, 1, 1, null);
+            var tier = new DistributionTierConfig("t1", ParticipatedDistributionType.KEY,
+                    RewardSplitMode.SPLIT_EVEN, List.of(entry), Map.of(), null, null);
+            var config = new RewardDistributionConfig(List.of(tier));
+            var snapshot = new ContributionSnapshot(
+                    Map.of(p1, 40L, p2, 30L, p3, 20L, p4, 10L), 100, Set.of(p1, p2, p3, p4), null);
+
+            var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry);
+
+            assertEquals(11, grantedTotal(result));
+            // The extra reward must carry the exact remainder (3), not a rounded/multiplier value.
+            assertTrue(result.get(p1).stream().anyMatch(reward -> ((TestRewardType) reward).getAmount() == 3),
+                    "Top contributor must receive an extra reward of exactly the remainder (3)");
+        }
+
+        @Test
         @DisplayName("DISCARD drops the truncation remainder")
         void discard_dropsRemainder() {
             UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID(), p3 = UUID.randomUUID(), p4 = UUID.randomUUID();

--- a/src/test/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolverTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/distribution/QuestRewardDistributionResolverTest.java
@@ -258,6 +258,84 @@ public class QuestRewardDistributionResolverTest extends McRPGBaseTest {
         assertTrue(result.isEmpty());
     }
 
+    /**
+     * Reward double that does not opt into scaling — {@code isScalable()} keeps the interface default
+     * of {@code false}. Used to exercise the resolver's non-scalable guard.
+     */
+    static class NonScalableReward implements QuestRewardType {
+
+        static final NamespacedKey KEY = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "non_scalable_reward");
+
+        @Override
+        public @org.jetbrains.annotations.NotNull NamespacedKey getKey() {
+            return KEY;
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull QuestRewardType parseConfig(@org.jetbrains.annotations.NotNull Section section) {
+            return this;
+        }
+
+        @Override
+        public void grant(@org.jetbrains.annotations.NotNull Player player) {
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull Map<String, Object> serializeConfig() {
+            return Map.of();
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull QuestRewardType fromSerializedConfig(@org.jetbrains.annotations.NotNull Map<String, Object> config) {
+            return this;
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull Optional<NamespacedKey> getExpansionKey() {
+            return Optional.empty();
+        }
+    }
+
+    @Nested
+    @DisplayName("SPLIT_PROPORTIONAL scalability guard")
+    class ProportionalScalabilityGuard {
+
+        @Test
+        @DisplayName("a non-scalable reward is granted unscaled to every qualifying player")
+        void nonScalableReward_grantedUnscaledToAll() {
+            UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID();
+            var entry = new DistributionRewardEntry(new NonScalableReward(), PotBehavior.SCALE,
+                    RemainderStrategy.DISCARD, 1, 1, null);
+            var tier = new DistributionTierConfig("t1", ParticipatedDistributionType.KEY,
+                    RewardSplitMode.SPLIT_PROPORTIONAL, List.of(entry), Map.of(), null, null);
+            var config = new RewardDistributionConfig(List.of(tier));
+            var snapshot = new ContributionSnapshot(Map.of(p1, 75L, p2, 25L), 100, Set.of(p1, p2), null);
+
+            var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry);
+
+            assertEquals(2, result.size());
+            assertTrue(result.get(p1).get(0) instanceof NonScalableReward);
+            assertTrue(result.get(p2).get(0) instanceof NonScalableReward);
+        }
+
+        @Test
+        @DisplayName("a scalable reward is split proportionally by contribution")
+        void scalableReward_splitProportionally() {
+            UUID p1 = UUID.randomUUID(), p2 = UUID.randomUUID();
+            var entry = new DistributionRewardEntry(new TestRewardType(1000), PotBehavior.SCALE,
+                    RemainderStrategy.DISCARD, 1, 1, null);
+            var tier = new DistributionTierConfig("t1", ParticipatedDistributionType.KEY,
+                    RewardSplitMode.SPLIT_PROPORTIONAL, List.of(entry), Map.of(), null, null);
+            var config = new RewardDistributionConfig(List.of(tier));
+            var snapshot = new ContributionSnapshot(Map.of(p1, 75L, p2, 25L), 100, Set.of(p1, p2), null);
+
+            var result = resolver.resolve(config, snapshot, null, rarityRegistry, typeRegistry);
+
+            assertEquals(750, ((TestRewardType) result.get(p1).get(0)).getAmount());
+            assertEquals(250, ((TestRewardType) result.get(p2).get(0)).getAmount());
+        }
+    }
+
     @Nested
     @DisplayName("Remainder distribution")
     class RemainderDistribution {

--- a/src/test/java/us/eunoians/mcrpg/quest/board/distribution/RemainderStrategyDistributionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/distribution/RemainderStrategyDistributionTest.java
@@ -70,8 +70,18 @@ public class RemainderStrategyDistributionTest extends McRPGBaseTest {
         public @org.jetbrains.annotations.NotNull Optional<NamespacedKey> getExpansionKey() { return Optional.empty(); }
 
         @Override
+        public boolean isScalable() {
+            return true;
+        }
+
+        @Override
         public @org.jetbrains.annotations.NotNull QuestRewardType withAmountMultiplier(double multiplier) {
             return new CountingReward(Math.max(1, Math.round(amount * multiplier)));
+        }
+
+        @Override
+        public @org.jetbrains.annotations.NotNull QuestRewardType withExactAmount(long exactAmount) {
+            return new CountingReward(exactAmount);
         }
 
         @Override

--- a/src/test/java/us/eunoians/mcrpg/quest/board/distribution/RewardDistributionGranterFaultIsolationTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/distribution/RewardDistributionGranterFaultIsolationTest.java
@@ -1,0 +1,99 @@
+package us.eunoians.mcrpg.quest.board.distribution;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPG;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.reward.QuestRewardType;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link RewardDistributionGranter} isolates a throwing reward so the remaining rewards for
+ * the same online player are still granted.
+ */
+public class RewardDistributionGranterFaultIsolationTest extends McRPGBaseTest {
+
+    @Test
+    @DisplayName("a throwing reward does not abort the remaining rewards for an online player")
+    void grant_isolatesThrowingReward_forOnlinePlayer() {
+        Player player = server.addPlayer();
+        RewardDistributionGranter granter = new RewardDistributionGranter(McRPG.getInstance());
+
+        RecordingReward good = new RecordingReward(new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "good"));
+        ThrowingReward bad = new ThrowingReward(new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "bad"));
+
+        // The throwing reward is granted first so that, without isolation, the good reward would be skipped.
+        Map<UUID, List<QuestRewardType>> resolved = Map.of(player.getUniqueId(), List.of(bad, good));
+
+        granter.grant(resolved, new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "test_quest"));
+
+        assertTrue(good.wasGranted(), "The reward after the throwing one must still be granted");
+    }
+
+    /** Reward that records whether its grant ran. */
+    private static class RecordingReward implements QuestRewardType {
+        private final NamespacedKey key;
+        private boolean granted;
+
+        RecordingReward(@NotNull NamespacedKey key) {
+            this.key = key;
+        }
+
+        boolean wasGranted() {
+            return granted;
+        }
+
+        @Override
+        public @NotNull NamespacedKey getKey() {
+            return key;
+        }
+
+        @Override
+        public @NotNull QuestRewardType parseConfig(@NotNull Section section) {
+            return this;
+        }
+
+        @Override
+        public void grant(@NotNull Player player) {
+            granted = true;
+        }
+
+        @Override
+        public @NotNull Map<String, Object> serializeConfig() {
+            return Map.of();
+        }
+
+        @Override
+        public @NotNull QuestRewardType fromSerializedConfig(@NotNull Map<String, Object> config) {
+            return this;
+        }
+
+        @Override
+        public @NotNull Optional<NamespacedKey> getExpansionKey() {
+            return Optional.empty();
+        }
+    }
+
+    /** Reward whose grant always throws. */
+    private static class ThrowingReward extends RecordingReward {
+        ThrowingReward(@NotNull NamespacedKey key) {
+            super(key);
+        }
+
+        @Override
+        public void grant(@NotNull Player player) {
+            throw new IllegalStateException("boom");
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/QuestRewardTypeDefaultMethodsTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/QuestRewardTypeDefaultMethodsTest.java
@@ -11,6 +11,7 @@ import us.eunoians.mcrpg.McRPGBaseTest;
 import java.util.OptionalLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,6 +47,28 @@ class QuestRewardTypeDefaultMethodsTest extends McRPGBaseTest {
         void returnsEmpty_byDefault() {
             OptionalLong result = rewardType.getNumericAmount();
             assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("isScalable")
+    class IsScalable {
+
+        @Test
+        @DisplayName("returns false by default")
+        void returnsFalse_byDefault() {
+            assertFalse(rewardType.isScalable());
+        }
+    }
+
+    @Nested
+    @DisplayName("withExactAmount")
+    class WithExactAmount {
+
+        @Test
+        @DisplayName("returns this by default")
+        void returnsThis_byDefault() {
+            assertSame(rewardType, rewardType.withExactAmount(5));
         }
     }
 

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RewardTypeScalabilityTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RewardTypeScalabilityTest.java
@@ -1,0 +1,56 @@
+package us.eunoians.mcrpg.quest.reward.builtin;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.reward.QuestRewardType;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies every built-in scalable reward type honours the {@link QuestRewardType#isScalable()} /
+ * {@link QuestRewardType#withExactAmount(long)} contract the distribution resolver relies on. If a
+ * type accidentally inherited the {@code isScalable() == false} default, the resolver would silently
+ * fall back to granting unscaled rewards.
+ */
+public class RewardTypeScalabilityTest extends McRPGBaseTest {
+
+    static Stream<Arguments> scalableRewardTypes() {
+        return Stream.of(
+                Arguments.of("experience", (Supplier<QuestRewardType>) ExperienceRewardType::new),
+                Arguments.of("item", (Supplier<QuestRewardType>) ItemRewardType::new),
+                Arguments.of("boosted_experience", (Supplier<QuestRewardType>) BoostedExperienceRewardType::new),
+                Arguments.of("redeemable_experience", (Supplier<QuestRewardType>) RedeemableExperienceRewardType::new),
+                Arguments.of("redeemable_levels", (Supplier<QuestRewardType>) RedeemableLevelsRewardType::new),
+                Arguments.of("scalable_command", (Supplier<QuestRewardType>) ScalableCommandRewardType::new));
+    }
+
+    @ParameterizedTest(name = "{0} is scalable")
+    @MethodSource("scalableRewardTypes")
+    @DisplayName("built-in scalable reward types report isScalable() == true")
+    void isScalable_returnsTrue(String name, Supplier<QuestRewardType> factory) {
+        assertTrue(factory.get().isScalable(), name + " must be scalable");
+    }
+
+    @ParameterizedTest(name = "{0} withExactAmount sets the exact amount")
+    @MethodSource("scalableRewardTypes")
+    @DisplayName("withExactAmount produces a reward carrying the exact numeric amount")
+    void withExactAmount_setsExactNumericAmount(String name, Supplier<QuestRewardType> factory) {
+        QuestRewardType scaled = factory.get().withExactAmount(7);
+        assertTrue(scaled.getNumericAmount().isPresent(), name + " must expose a numeric amount");
+        assertEquals(7L, scaled.getNumericAmount().getAsLong(), name + " must carry the exact amount");
+    }
+
+    @ParameterizedTest(name = "{0} withExactAmount(1) yields amount 1")
+    @MethodSource("scalableRewardTypes")
+    @DisplayName("withExactAmount(1) — the single-unit remainder share — yields amount 1")
+    void withExactAmount_singleUnit_yieldsOne(String name, Supplier<QuestRewardType> factory) {
+        assertEquals(1L, factory.get().withExactAmount(1).getNumericAmount().getAsLong(), name);
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RewardTypeScalabilityTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RewardTypeScalabilityTest.java
@@ -53,4 +53,11 @@ public class RewardTypeScalabilityTest extends McRPGBaseTest {
     void withExactAmount_singleUnit_yieldsOne(String name, Supplier<QuestRewardType> factory) {
         assertEquals(1L, factory.get().withExactAmount(1).getNumericAmount().getAsLong(), name);
     }
+
+    @ParameterizedTest(name = "{0} withExactAmount(0) yields amount 0")
+    @MethodSource("scalableRewardTypes")
+    @DisplayName("withExactAmount(0) — boundary — carries exactly 0 without clamping to 1")
+    void withExactAmount_zero_yieldsZero(String name, Supplier<QuestRewardType> factory) {
+        assertEquals(0L, factory.get().withExactAmount(0).getNumericAmount().getAsLong(), name);
+    }
 }


### PR DESCRIPTION
## Summary
This PR hardens reward granting and quest board offering acceptance by isolating failures, adding explicit scope validation, and improving error handling and logging throughout the reward pipeline.

## Key Changes

### Reward Granting Isolation
- **PlayerJoinListener**: Refactored pending reward granting to isolate individual reward failures. Rewards whose type is not registered are retained (logged as WARNING) and retried on next login. Rewards that throw during grant are logged (SEVERE) and left in the database rather than silently lost. Granted rewards are deleted atomically via `FailSafeTransaction`.
- **QuestCompleteListener**: Moved reward granting to the end of completion handling, after all state-critical lifecycle steps (logging, board-slot release, retirement, ephemeral cleanup). Wrapped quest-level and distribution reward granting in try-catch blocks so a throwing reward cannot undo completion finalization.
- **QuestInstance.grantRewards()**: Added try-catch around individual reward grants so one failing reward doesn't abort the loop.
- **RewardDistributionGranter**: Added try-catch around individual reward grants during distribution.

### Quest Board Scope Guards
- **QuestBoardManager**: 
  - Added `filterSharedOfferings()` static method to exclude scoped and personal offerings from the shared board view.
  - Added `canAcceptThroughSharedBoard()` static method to validate that an offering can be accepted by a player through the shared-board path (unscoped offerings always allowed; personal offerings only by owner; scoped offerings rejected).
  - Updated `getSharedOfferingsForBoard()` to filter cached offerings before returning.
  - Updated initialization to load only shared offerings into the cache via new `loadSharedOfferingsForRotation()` DAO method.
- **BoardOfferingDAO**: Added `loadSharedOfferingsForRotation()` to load only offerings with `scope_target_id IS NULL`, preventing scoped/personal rows from entering the shared cache on restart.
- **OfferingAcceptResult**: Added `WRONG_SCOPE` result type for scope validation failures.

### Pending Reward Loading & Deletion
- **PendingRewardDAO**:
  - Updated `loadAndCleanPendingRewards()` to filter on `expires_at > ?` (independent of deletion), skip rows with unparseable keys (logged as WARNING, retained for inspection), and validate keys before parsing.
  - Added `deletePendingRewards()` to generate prepared statements for atomic deletion of a set of reward IDs (used with `FailSafeTransaction`).

### Reward Type Scalability
- **QuestRewardType**: Added `isScalable()` default method (returns false) and `withExactAmount(long)` default method to support remainder distribution without rounding drift.
- **Scalable reward implementations** (ExperienceRewardType, ItemRewardType, BoostedExperienceRewardType, RedeemableExperienceRewardType, RedeemableLevelsRewardType, ScalableCommandRewardType): Overridden `isScalable()` to return true and implemented `withExactAmount()` to build copies with exact amounts.
- **QuestRewardDistributionResolver**: Updated SCALE pot-behavior to check `isScalable()` explicitly (rather than object identity) and pass the actual scaled amount to remainder distribution (not the multiplier) to keep remainder consistent with the reward type's own rounding.

### Error Logging Improvements
- Replaced `e.printStackTrace()` calls with proper `Logger.log(Level.SEVERE, ...)` throughout.
- Added detailed context to all reward-granting failures (player UUID, reward ID, quest UUID, reward type key).
- Added WARNING logs for retained rewards (unregistered types, unparseable keys).

### Tests
- **QuestBoardManagerScopeGuardTest** (new): Tests for `filterSharedOfferings()` and `canAcceptThroughSharedBoard()` scope validation.
- **PendingRewardDAOTest**: Added tests for expires_at filtering, unparseable key handling, and `deletePendingRewards()` statement generation.
- **BoardOfferingDAOTest**: Added test

https://claude.ai/code/session_01LBGaJvAnCFf7EuRcLwPYqY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared quest boards now display and accept only eligible unscoped offerings.
  * Added clearer handling when an offering belongs to a different scope.
  * Reward distribution now supports accurate scaling and remainder allocation.

* **Bug Fixes**
  * Failed or invalid rewards no longer prevent other rewards from being granted.
  * Pending rewards are removed only after successful delivery.
  * Quest completion proceeds safely even when reward processing encounters errors.
  * Expired or malformed pending rewards are handled more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->