### PR TITLE
[Unit Tests] Add tests for quest chain events and LocaleSetting

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainAbandonEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainAbandonEventTest.java
@@ -1,0 +1,77 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainAbandonEvent}.
+ */
+public class QuestChainAbandonEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(new NamespacedKey("mcrpg", "quest_one")));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("getters return constructor values")
+    void event_getters_returnConstructorValues() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainAbandonEvent event = new QuestChainAbandonEvent(definition, player, player.getUniqueId());
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("getPlayer returns null when player is offline")
+    void getPlayer_returnsNull_whenPlayerOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainAbandonEvent event = new QuestChainAbandonEvent(definition, null, offlineUUID);
+
+        assertNull(event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("getHandlers returns static HandlerList")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainAbandonEvent event = new QuestChainAbandonEvent(definition, player, player.getUniqueId());
+
+        assertEquals(QuestChainAbandonEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("getChainDefinition returns provided definition when player is null")
+    void getChainDefinition_returnsDefinition_whenPlayerNull() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID uuid = UUID.randomUUID();
+
+        QuestChainAbandonEvent event = new QuestChainAbandonEvent(definition, null, uuid);
+
+        assertSame(definition, event.getChainDefinition());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainExpireEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainExpireEventTest.java
@@ -1,0 +1,95 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link QuestChainExpireEvent}.
+ */
+public class QuestChainExpireEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(new NamespacedKey("mcrpg", "quest_one")));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("getters return constructor values")
+    void event_getters_returnConstructorValues() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(definition, player.getUniqueId(), player);
+
+        assertSame(definition, event.getChainDefinition());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+        assertTrue(event.getPlayer().isPresent());
+        assertSame(player, event.getPlayer().get());
+    }
+
+    @Test
+    @DisplayName("getPlayer returns empty Optional when player is offline")
+    void getPlayer_returnsEmpty_whenPlayerOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(definition, offlineUUID, null);
+
+        assertEquals(Optional.empty(), event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("event is not cancelled by default")
+    void isCancelled_returnsFalse_byDefault() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(definition, player.getUniqueId(), player);
+
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled changes cancelled state")
+    void setCancelled_updatesCancelledState() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(definition, player.getUniqueId(), player);
+
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+
+        event.setCancelled(false);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("getHandlers returns static HandlerList")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(definition, player.getUniqueId(), player);
+
+        assertEquals(QuestChainExpireEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainFailEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainFailEventTest.java
@@ -1,0 +1,77 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainFailEvent}.
+ */
+public class QuestChainFailEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(new NamespacedKey("mcrpg", "quest_one")));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("getters return constructor values")
+    void event_getters_returnConstructorValues() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainFailEvent event = new QuestChainFailEvent(definition, player, player.getUniqueId());
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("getPlayer returns null when player is offline")
+    void getPlayer_returnsNull_whenPlayerOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainFailEvent event = new QuestChainFailEvent(definition, null, offlineUUID);
+
+        assertNull(event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("getHandlers returns static HandlerList")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainFailEvent event = new QuestChainFailEvent(definition, player, player.getUniqueId());
+
+        assertEquals(QuestChainFailEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Test
+    @DisplayName("getChainDefinition returns provided definition")
+    void getChainDefinition_returnsProvidedDefinition() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID uuid = UUID.randomUUID();
+
+        QuestChainFailEvent event = new QuestChainFailEvent(definition, null, uuid);
+
+        assertSame(definition, event.getChainDefinition());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainRestartEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainRestartEventTest.java
@@ -1,0 +1,104 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainRestartEvent}.
+ */
+public class QuestChainRestartEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(new NamespacedKey("mcrpg", "quest_one")));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("getters return constructor values with REPEAT_MODE reason")
+    void event_getters_returnConstructorValues_whenRepeatMode() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, player, player.getUniqueId(), QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+        assertEquals(QuestChainRestartEvent.RestartReason.REPEAT_MODE, event.getReason());
+    }
+
+    @Test
+    @DisplayName("getters return constructor values with QUEST_EXPIRE_RESTART_CHAIN reason")
+    void event_getters_returnConstructorValues_whenQuestExpireRestartChain() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, player, player.getUniqueId(),
+                QuestChainRestartEvent.RestartReason.QUEST_EXPIRE_RESTART_CHAIN);
+
+        assertEquals(QuestChainRestartEvent.RestartReason.QUEST_EXPIRE_RESTART_CHAIN, event.getReason());
+    }
+
+    @Test
+    @DisplayName("getPlayer returns null when player is offline")
+    void getPlayer_returnsNull_whenPlayerOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, null, offlineUUID, QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+        assertNull(event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("getHandlers returns static HandlerList")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, player, player.getUniqueId(), QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+        assertEquals(QuestChainRestartEvent.getHandlerList(), event.getHandlers());
+    }
+
+    @Nested
+    @DisplayName("RestartReason")
+    class RestartReasonTest {
+
+        @ParameterizedTest
+        @EnumSource(QuestChainRestartEvent.RestartReason.class)
+        @DisplayName("all RestartReason values are preserved through event construction")
+        void allReasons_arePreserved(QuestChainRestartEvent.RestartReason reason) {
+            QuestChainDefinition definition = buildDefinition();
+            PlayerMock player = server.addPlayer();
+
+            QuestChainRestartEvent event = new QuestChainRestartEvent(
+                    definition, player, player.getUniqueId(), reason);
+
+            assertEquals(reason, event.getReason());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
@@ -1,0 +1,101 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainStepRetryEvent}.
+ */
+public class QuestChainStepRetryEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(new NamespacedKey("mcrpg", "quest_one")));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("getters return constructor values")
+    void event_getters_returnConstructorValues() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().getFirst();
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 2, 5);
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+        assertSame(step, event.getStep());
+        assertEquals(2, event.getRetryNumber());
+        assertEquals(5, event.getMaxRetries());
+    }
+
+    @Test
+    @DisplayName("getPlayer returns null when player is offline")
+    void getPlayer_returnsNull_whenPlayerOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+        QuestChainStep step = definition.getSteps().getFirst();
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, null, offlineUUID, step, 1, 3);
+
+        assertNull(event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("maxRetries returns -1 for unlimited retries")
+    void getMaxRetries_returnsNegativeOne_whenUnlimited() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().getFirst();
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 1, -1);
+
+        assertEquals(-1, event.getMaxRetries());
+    }
+
+    @Test
+    @DisplayName("retryNumber reflects first retry attempt")
+    void getRetryNumber_returnsOne_whenFirstRetry() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().getFirst();
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 1, 5);
+
+        assertEquals(1, event.getRetryNumber());
+    }
+
+    @Test
+    @DisplayName("getHandlers returns static HandlerList")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().getFirst();
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 1, 3);
+
+        assertEquals(QuestChainStepRetryEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/setting/impl/LocaleSettingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/setting/impl/LocaleSettingTest.java
@@ -1,0 +1,143 @@
+package us.eunoians.mcrpg.setting.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link LocaleSetting}.
+ */
+public class LocaleSettingTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("fromString")
+    class FromStringTest {
+
+        @Test
+        @DisplayName("fromString matches CLIENT_LOCALE exactly")
+        void fromString_matchesClientLocale_whenExact() {
+            Optional<?> result = LocaleSetting.CLIENT_LOCALE.fromString("CLIENT_LOCALE");
+
+            assertTrue(result.isPresent());
+            assertEquals(LocaleSetting.CLIENT_LOCALE, result.get());
+        }
+
+        @Test
+        @DisplayName("fromString matches SERVER_LOCALE exactly")
+        void fromString_matchesServerLocale_whenExact() {
+            Optional<?> result = LocaleSetting.CLIENT_LOCALE.fromString("SERVER_LOCALE");
+
+            assertTrue(result.isPresent());
+            assertEquals(LocaleSetting.SERVER_LOCALE, result.get());
+        }
+
+        @Test
+        @DisplayName("fromString is case-insensitive for CLIENT_LOCALE")
+        void fromString_isCaseInsensitive_whenClientLocale() {
+            Optional<?> result = LocaleSetting.CLIENT_LOCALE.fromString("client_locale");
+
+            assertTrue(result.isPresent());
+            assertEquals(LocaleSetting.CLIENT_LOCALE, result.get());
+        }
+
+        @Test
+        @DisplayName("fromString is case-insensitive for SERVER_LOCALE")
+        void fromString_isCaseInsensitive_whenServerLocale() {
+            Optional<?> result = LocaleSetting.SERVER_LOCALE.fromString("server_locale");
+
+            assertTrue(result.isPresent());
+            assertEquals(LocaleSetting.SERVER_LOCALE, result.get());
+        }
+
+        @Test
+        @DisplayName("fromString returns empty for unknown string")
+        void fromString_returnsEmpty_whenUnknownString() {
+            Optional<?> result = LocaleSetting.CLIENT_LOCALE.fromString("NONEXISTENT_SETTING");
+
+            assertFalse(result.isPresent());
+        }
+
+        @Test
+        @DisplayName("fromString returns empty for empty string")
+        void fromString_returnsEmpty_whenEmptyString() {
+            Optional<?> result = LocaleSetting.CLIENT_LOCALE.fromString("");
+
+            assertFalse(result.isPresent());
+        }
+
+        @ParameterizedTest
+        @EnumSource(LocaleSetting.class)
+        @DisplayName("fromString matches each enum value by name")
+        void fromString_matchesEachValue_byName(LocaleSetting setting) {
+            Optional<?> result = setting.fromString(setting.name());
+
+            assertTrue(result.isPresent());
+            assertEquals(setting, result.get());
+        }
+
+        @ParameterizedTest
+        @EnumSource(LocaleSetting.class)
+        @DisplayName("fromString matches each enum value case-insensitively")
+        void fromString_matchesEachValue_caseInsensitively(LocaleSetting setting) {
+            Optional<?> result = setting.fromString(setting.name().toLowerCase());
+
+            assertTrue(result.isPresent());
+            assertEquals(setting, result.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("getSettingKey")
+    class SettingKeyTest {
+
+        @Test
+        @DisplayName("getSettingKey returns locale-setting NamespacedKey")
+        void getSettingKey_returnsLocaleSettingKey() {
+            assertEquals(LocalePlayerSetting.SETTING_KEY, LocaleSetting.CLIENT_LOCALE.getSettingKey());
+        }
+
+        @Test
+        @DisplayName("getSettingKey is consistent across enum values")
+        void getSettingKey_isConsistent_acrossEnumValues() {
+            assertEquals(
+                    LocaleSetting.CLIENT_LOCALE.getSettingKey(),
+                    LocaleSetting.SERVER_LOCALE.getSettingKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("enum values")
+    class EnumValuesTest {
+
+        @Test
+        @DisplayName("CLIENT_LOCALE and SERVER_LOCALE are the only values")
+        void enumValues_containsExpectedValues() {
+            LocaleSetting[] values = LocaleSetting.values();
+
+            assertEquals(2, values.length);
+            assertEquals(LocaleSetting.CLIENT_LOCALE, values[0]);
+            assertEquals(LocaleSetting.SERVER_LOCALE, values[1]);
+        }
+
+        @Test
+        @DisplayName("valueOf returns correct value for CLIENT_LOCALE")
+        void valueOf_returnsCorrectValue_whenClientLocale() {
+            assertEquals(LocaleSetting.CLIENT_LOCALE, LocaleSetting.valueOf("CLIENT_LOCALE"));
+        }
+
+        @Test
+        @DisplayName("valueOf returns correct value for SERVER_LOCALE")
+        void valueOf_returnsCorrectValue_whenServerLocale() {
+            assertEquals(LocaleSetting.SERVER_LOCALE, LocaleSetting.valueOf("SERVER_LOCALE"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for 5 previously untested quest chain event classes: `QuestChainFailEvent`, `QuestChainExpireEvent`, `QuestChainRestartEvent`, `QuestChainStepRetryEvent`, `QuestChainAbandonEvent`
- Add unit tests for `LocaleSetting` enum (previously at 13% coverage with no direct test class)
- ~37 test executions across 6 new test files

## Classes Covered

| Class | Key coverage |
|-------|-------------|
| `QuestChainFailEvent` | Constructor getters, null player (offline), HandlerList |
| `QuestChainExpireEvent` | Constructor getters, empty Optional when offline, cancellation toggle, HandlerList |
| `QuestChainRestartEvent` | Constructor getters, null player, HandlerList, parameterized RestartReason enum |
| `QuestChainStepRetryEvent` | Constructor getters (step, retryNumber, maxRetries), null player, unlimited retries (-1), HandlerList |
| `QuestChainAbandonEvent` | Constructor getters, null player (offline), HandlerList |
| `LocaleSetting` | fromString exact/case-insensitive/unknown/empty, parameterized enum matching, getSettingKey consistency, enum values/valueOf |

## Test plan

- [x] All 6 new test files pass individually
- [x] Full test suite passes with no regressions (only pre-existing failures in `QuestRewardDistributionResolverPotBehaviorTest`)
- [x] Testing audit persona applied — no concerns found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8PV45naRjtoHhr7ecZKVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8PV45naRjtoHhr7ecZKVW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for quest chain abandonment, expiration, failure, restart, and step retry events.
  * Verified event data, offline-player handling, cancellation behavior, restart reasons, retry details, and handler registration.
  * Added coverage for locale setting parsing, case handling, valid values, and setting keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->