### PR TITLE
[Unit Tests] Add coverage for BucketEmpty/Fill objectives and Sound/Title rewards

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BucketEmptyObjectiveTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BucketEmptyObjectiveTypeCoverageTest.java
@@ -1,0 +1,267 @@
+package us.eunoians.mcrpg.quest.objective.type.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.Material;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("BucketEmptyObjectiveType — extended coverage")
+public class BucketEmptyObjectiveTypeCoverageTest extends McRPGBaseTest {
+
+    private BucketEmptyObjectiveType baseType;
+
+    @BeforeEach
+    public void setup() {
+        baseType = new BucketEmptyObjectiveType();
+    }
+
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for BucketEmptyQuestContext")
+        public void canProcess_returnsTrue_forBucketEmptyContext() {
+            PlayerBucketEmptyEvent mockEvent = mock(PlayerBucketEmptyEvent.class);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(mockEvent);
+            assertTrue(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic mock context")
+        public void canProcess_returnsFalse_forGenericContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for BucketFillQuestContext")
+        public void canProcess_returnsFalse_forBucketFillContext() {
+            BucketFillQuestContext context = mock(BucketFillQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — empty bucket filter (base type)")
+    class ProcessProgressEmptyFilter {
+
+        @Test
+        @DisplayName("returns 1 for any bucket when no filter is set")
+        public void processProgress_returnsOne_forWaterBucket_whenNoFilter() {
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.WATER_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+
+        @Test
+        @DisplayName("returns 1 for lava bucket when no filter is set")
+        public void processProgress_returnsOne_forLavaBucket_whenNoFilter() {
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.LAVA_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — with bucket filter via parseConfig")
+    class ProcessProgressWithFilter {
+
+        private BucketEmptyObjectiveType filteredType;
+
+        @BeforeEach
+        public void setupFilteredType() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "LAVA_BUCKET"));
+            filteredType = baseType.parseConfig(section);
+        }
+
+        @Test
+        @DisplayName("returns 1 for matching bucket")
+        public void processProgress_returnsOne_forMatchingBucket() {
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.WATER_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = filteredType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+
+        @Test
+        @DisplayName("returns 0 for non-matching bucket")
+        public void processProgress_returnsZero_forNonMatchingBucket() {
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.MILK_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = filteredType.processProgress(instance, context);
+            assertEquals(0, progress);
+        }
+
+        @Test
+        @DisplayName("returns 1 for second matching bucket in filter")
+        public void processProgress_returnsOne_forSecondMatchingBucket() {
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.LAVA_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = filteredType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — wrong context type")
+    class ProcessProgressWrongContext {
+
+        @Test
+        @DisplayName("returns 0 for non-BucketEmpty context")
+        public void processProgress_returnsZero_forWrongContextType() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(0, progress);
+        }
+
+        @Test
+        @DisplayName("returns 0 for BucketFillQuestContext")
+        public void processProgress_returnsZero_forBucketFillContext() {
+            BucketFillQuestContext context = mock(BucketFillQuestContext.class);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(0, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("key namespace is mcrpg")
+        public void getKey_namespaceIsMcrpg() {
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+        }
+
+        @Test
+        @DisplayName("key value is bucket_empty")
+        public void getKey_valueIsBucketEmpty() {
+            assertEquals("bucket_empty", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("expansion key is present")
+        public void getExpansionKey_isPresent() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("returns new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+
+            BucketEmptyObjectiveType parsed = baseType.parseConfig(section);
+            assertNotSame(baseType, parsed);
+        }
+
+        @Test
+        @DisplayName("no buckets key produces empty filter that accepts any bucket")
+        public void parseConfig_noBucketsKey_producesEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+
+            BucketEmptyObjectiveType parsed = baseType.parseConfig(section);
+
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.POWDER_SNOW_BUCKET);
+            BucketEmptyQuestContext context = new BucketEmptyQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            assertEquals(1, parsed.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("buckets key with entries produces filtering type")
+        public void parseConfig_withBuckets_producesFilteringType() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET"));
+
+            BucketEmptyObjectiveType parsed = baseType.parseConfig(section);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            PlayerBucketEmptyEvent matchEvent = createMockBucketEmptyEvent(Material.WATER_BUCKET);
+            assertEquals(1, parsed.processProgress(instance, new BucketEmptyQuestContext(matchEvent)));
+
+            PlayerBucketEmptyEvent noMatchEvent = createMockBucketEmptyEvent(Material.LAVA_BUCKET);
+            assertEquals(0, parsed.processProgress(instance, new BucketEmptyQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("buckets key with empty list produces empty filter")
+        public void parseConfig_emptyBucketsList_producesEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of());
+
+            BucketEmptyObjectiveType parsed = baseType.parseConfig(section);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            PlayerBucketEmptyEvent event = createMockBucketEmptyEvent(Material.WATER_BUCKET);
+            assertEquals(1, parsed.processProgress(instance, new BucketEmptyQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("invalid material names are filtered out")
+        public void parseConfig_invalidMaterialNames_areFilteredOut() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "NOT_A_REAL_MATERIAL"));
+
+            BucketEmptyObjectiveType parsed = baseType.parseConfig(section);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            PlayerBucketEmptyEvent waterEvent = createMockBucketEmptyEvent(Material.WATER_BUCKET);
+            assertEquals(1, parsed.processProgress(instance, new BucketEmptyQuestContext(waterEvent)));
+        }
+    }
+
+    /**
+     * @param bucketMaterial the material of the bucket being emptied
+     * @return a mock event returning the given material from {@code getBucket()}
+     */
+    private PlayerBucketEmptyEvent createMockBucketEmptyEvent(Material bucketMaterial) {
+        PlayerBucketEmptyEvent event = mock(PlayerBucketEmptyEvent.class);
+        when(event.getBucket()).thenReturn(bucketMaterial);
+        return event;
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BucketFillObjectiveTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BucketFillObjectiveTypeCoverageTest.java
@@ -1,0 +1,270 @@
+package us.eunoians.mcrpg.quest.objective.type.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.Material;
+import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("BucketFillObjectiveType — extended coverage")
+public class BucketFillObjectiveTypeCoverageTest extends McRPGBaseTest {
+
+    private BucketFillObjectiveType baseType;
+
+    @BeforeEach
+    public void setup() {
+        baseType = new BucketFillObjectiveType();
+    }
+
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for BucketFillQuestContext")
+        public void canProcess_returnsTrue_forBucketFillContext() {
+            PlayerBucketFillEvent mockEvent = mock(PlayerBucketFillEvent.class);
+            BucketFillQuestContext context = new BucketFillQuestContext(mockEvent);
+            assertTrue(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic mock context")
+        public void canProcess_returnsFalse_forGenericContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for BucketEmptyQuestContext")
+        public void canProcess_returnsFalse_forBucketEmptyContext() {
+            BucketEmptyQuestContext context = mock(BucketEmptyQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — empty bucket filter (base type)")
+    class ProcessProgressEmptyFilter {
+
+        @Test
+        @DisplayName("returns 1 for any bucket when no filter is set")
+        public void processProgress_returnsOne_forWaterBucket_whenNoFilter() {
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.WATER_BUCKET);
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+
+        @Test
+        @DisplayName("returns 1 for lava bucket when no filter is set")
+        public void processProgress_returnsOne_forLavaBucket_whenNoFilter() {
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.LAVA_BUCKET);
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — with bucket filter via parseConfig")
+    class ProcessProgressWithFilter {
+
+        private BucketFillObjectiveType filteredType;
+
+        @BeforeEach
+        public void setupFilteredType() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "LAVA_BUCKET"));
+            filteredType = baseType.parseConfig(section);
+        }
+
+        @Test
+        @DisplayName("returns 1 for matching bucket")
+        public void processProgress_returnsOne_forMatchingBucket() {
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.WATER_BUCKET);
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = filteredType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+
+        @Test
+        @DisplayName("returns 0 for non-matching bucket")
+        public void processProgress_returnsZero_forNonMatchingBucket() {
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.MILK_BUCKET);
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = filteredType.processProgress(instance, context);
+            assertEquals(0, progress);
+        }
+
+        @Test
+        @DisplayName("returns 1 for second matching bucket in filter")
+        public void processProgress_returnsOne_forSecondMatchingBucket() {
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.LAVA_BUCKET);
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = filteredType.processProgress(instance, context);
+            assertEquals(1, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — wrong context type")
+    class ProcessProgressWrongContext {
+
+        @Test
+        @DisplayName("returns 0 for non-BucketFill context")
+        public void processProgress_returnsZero_forWrongContextType() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(0, progress);
+        }
+
+        @Test
+        @DisplayName("returns 0 for BucketEmptyQuestContext")
+        public void processProgress_returnsZero_forBucketEmptyContext() {
+            BucketEmptyQuestContext context = mock(BucketEmptyQuestContext.class);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            long progress = baseType.processProgress(instance, context);
+            assertEquals(0, progress);
+        }
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("key namespace is mcrpg")
+        public void getKey_namespaceIsMcrpg() {
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+        }
+
+        @Test
+        @DisplayName("key value is bucket_fill")
+        public void getKey_valueIsBucketFill() {
+            assertEquals("bucket_fill", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("expansion key is present")
+        public void getExpansionKey_isPresent() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("returns new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+
+            BucketFillObjectiveType parsed = baseType.parseConfig(section);
+            assertNotSame(baseType, parsed);
+        }
+
+        @Test
+        @DisplayName("no buckets key produces empty filter that accepts any bucket")
+        public void parseConfig_noBucketsKey_producesEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(false);
+
+            BucketFillObjectiveType parsed = baseType.parseConfig(section);
+
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.POWDER_SNOW_BUCKET);
+            BucketFillQuestContext context = new BucketFillQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            assertEquals(1, parsed.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("buckets key with entries produces filtering type")
+        public void parseConfig_withBuckets_producesFilteringType() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET"));
+
+            BucketFillObjectiveType parsed = baseType.parseConfig(section);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            PlayerBucketFillEvent matchEvent = createMockBucketFillEvent(Material.WATER_BUCKET);
+            assertEquals(1, parsed.processProgress(instance, new BucketFillQuestContext(matchEvent)));
+
+            PlayerBucketFillEvent noMatchEvent = createMockBucketFillEvent(Material.LAVA_BUCKET);
+            assertEquals(0, parsed.processProgress(instance, new BucketFillQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("buckets key with empty list produces empty filter")
+        public void parseConfig_emptyBucketsList_producesEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of());
+
+            BucketFillObjectiveType parsed = baseType.parseConfig(section);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            PlayerBucketFillEvent event = createMockBucketFillEvent(Material.WATER_BUCKET);
+            assertEquals(1, parsed.processProgress(instance, new BucketFillQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("invalid material names are filtered out")
+        public void parseConfig_invalidMaterialNames_areFilteredOut() {
+            Section section = mock(Section.class);
+            when(section.contains("buckets")).thenReturn(true);
+            when(section.getStringList("buckets")).thenReturn(List.of("WATER_BUCKET", "FAKE_BUCKET_TYPE"));
+
+            BucketFillObjectiveType parsed = baseType.parseConfig(section);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            PlayerBucketFillEvent waterEvent = createMockBucketFillEvent(Material.WATER_BUCKET);
+            assertEquals(1, parsed.processProgress(instance, new BucketFillQuestContext(waterEvent)));
+        }
+    }
+
+    /**
+     * @param filledBucketMaterial the material of the filled bucket item
+     * @return a mock event whose {@code getItemStack().getType()} returns the given material
+     */
+    private PlayerBucketFillEvent createMockBucketFillEvent(Material filledBucketMaterial) {
+        PlayerBucketFillEvent event = mock(PlayerBucketFillEvent.class);
+        ItemStack itemStack = mock(ItemStack.class);
+        when(itemStack.getType()).thenReturn(filledBucketMaterial);
+        when(event.getItemStack()).thenReturn(itemStack);
+        return event;
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/SoundRewardTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/SoundRewardTypeTest.java
@@ -1,0 +1,312 @@
+package us.eunoians.mcrpg.quest.reward.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.Sound;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("SoundRewardType")
+public class SoundRewardTypeTest extends McRPGBaseTest {
+
+    private SoundRewardType baseType;
+
+    @BeforeEach
+    public void setup() {
+        baseType = new SoundRewardType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:sound")
+        public void getKey_returnsSoundKey() {
+            assertEquals(SoundRewardType.KEY, baseType.getKey());
+        }
+
+        @Test
+        @DisplayName("key namespace is mcrpg")
+        public void getKey_namespaceIsMcrpg() {
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+        }
+
+        @Test
+        @DisplayName("key value is sound")
+        public void getKey_valueIsSound() {
+            assertEquals("sound", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, baseType.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("describeForDisplay")
+    class DescribeForDisplay {
+
+        @Test
+        @DisplayName("returns empty string")
+        public void describeForDisplay_returnsEmptyString() {
+            assertEquals("", baseType.describeForDisplay());
+        }
+
+        @Test
+        @DisplayName("configured instance also returns empty string")
+        public void describeForDisplay_configuredInstance_returnsEmptyString() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "ENTITY_PLAYER_LEVELUP", "volume", 0.5f, "pitch", 1.2f));
+            assertEquals("", configured.describeForDisplay());
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("base instance serializes to empty map")
+        public void serializeConfig_baseInstance_returnsEmptyMap() {
+            Map<String, Object> serialized = baseType.serializeConfig();
+            assertTrue(serialized.isEmpty());
+        }
+
+        @Test
+        @DisplayName("configured instance serializes all fields")
+        public void serializeConfig_configuredInstance_containsAllFields() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "ENTITY_PLAYER_LEVELUP", "volume", 0.8f, "pitch", 1.5f));
+            Map<String, Object> serialized = configured.serializeConfig();
+
+            assertEquals(Sound.valueOf("ENTITY_PLAYER_LEVELUP").name(), serialized.get("sound"));
+            assertEquals(0.8f, ((Number) serialized.get("volume")).floatValue(), 0.001f);
+            assertEquals(1.5f, ((Number) serialized.get("pitch")).floatValue(), 0.001f);
+        }
+    }
+
+    @Nested
+    @DisplayName("fromSerializedConfig")
+    class FromSerializedConfig {
+
+        @Test
+        @DisplayName("round-trips sound, volume, and pitch")
+        public void fromSerializedConfig_roundTripsCorrectly() {
+            Map<String, Object> config = Map.of(
+                    "sound", "UI_TOAST_CHALLENGE_COMPLETE",
+                    "volume", 0.7f,
+                    "pitch", 1.3f);
+            SoundRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+
+            assertEquals(Sound.valueOf("UI_TOAST_CHALLENGE_COMPLETE").name(), serialized.get("sound"));
+            assertEquals(0.7f, ((Number) serialized.get("volume")).floatValue(), 0.001f);
+            assertEquals(1.3f, ((Number) serialized.get("pitch")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("missing sound key returns base instance with empty serialization")
+        public void fromSerializedConfig_missingSound_returnsBaseInstance() {
+            SoundRewardType configured = baseType.fromSerializedConfig(Map.of("volume", 1.0f));
+            assertTrue(configured.serializeConfig().isEmpty());
+        }
+
+        @Test
+        @DisplayName("invalid sound name returns base instance with empty serialization")
+        public void fromSerializedConfig_invalidSound_returnsBaseInstance() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "NOT_A_REAL_SOUND_NAME"));
+            assertTrue(configured.serializeConfig().isEmpty());
+        }
+
+        @Test
+        @DisplayName("missing volume defaults to 1.0")
+        public void fromSerializedConfig_missingVolume_defaultsToOne() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "ENTITY_PLAYER_LEVELUP"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(1.0f, ((Number) serialized.get("volume")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("missing pitch defaults to 1.0")
+        public void fromSerializedConfig_missingPitch_defaultsToOne() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "ENTITY_PLAYER_LEVELUP"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(1.0f, ((Number) serialized.get("pitch")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("non-numeric volume falls back to default")
+        public void fromSerializedConfig_nonNumericVolume_fallsBackToDefault() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("sound", "ENTITY_PLAYER_LEVELUP");
+            config.put("volume", "not_a_number");
+            config.put("pitch", 1.0f);
+
+            SoundRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(1.0f, ((Number) serialized.get("volume")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("non-numeric pitch falls back to default")
+        public void fromSerializedConfig_nonNumericPitch_fallsBackToDefault() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("sound", "ENTITY_PLAYER_LEVELUP");
+            config.put("volume", 1.0f);
+            config.put("pitch", "invalid");
+
+            SoundRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(1.0f, ((Number) serialized.get("pitch")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("sound name is case-insensitive")
+        public void fromSerializedConfig_caseInsensitiveSound() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "entity_player_levelup"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(Sound.valueOf("ENTITY_PLAYER_LEVELUP").name(), serialized.get("sound"));
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("parses valid sound with default volume and pitch")
+        public void parseConfig_validSound_usesDefaults() {
+            Section section = mock(Section.class);
+            when(section.getString("sound")).thenReturn("ENTITY_PLAYER_LEVELUP");
+            when(section.get("volume")).thenReturn(null);
+            when(section.get("pitch")).thenReturn(null);
+
+            SoundRewardType parsed = baseType.parseConfig(section);
+            Map<String, Object> serialized = parsed.serializeConfig();
+
+            assertEquals(Sound.valueOf("ENTITY_PLAYER_LEVELUP").name(), serialized.get("sound"));
+            assertEquals(1.0f, ((Number) serialized.get("volume")).floatValue(), 0.001f);
+            assertEquals(1.0f, ((Number) serialized.get("pitch")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("parses custom volume and pitch")
+        public void parseConfig_customVolumeAndPitch() {
+            Section section = mock(Section.class);
+            when(section.getString("sound")).thenReturn("BLOCK_NOTE_BLOCK_PLING");
+            when(section.get("volume")).thenReturn(0.5);
+            when(section.get("pitch")).thenReturn(2.0);
+
+            SoundRewardType parsed = baseType.parseConfig(section);
+            Map<String, Object> serialized = parsed.serializeConfig();
+
+            assertEquals(0.5f, ((Number) serialized.get("volume")).floatValue(), 0.001f);
+            assertEquals(2.0f, ((Number) serialized.get("pitch")).floatValue(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("returns new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            when(section.getString("sound")).thenReturn("ENTITY_PLAYER_LEVELUP");
+            when(section.get("volume")).thenReturn(null);
+            when(section.get("pitch")).thenReturn(null);
+
+            SoundRewardType parsed = baseType.parseConfig(section);
+            assertNotSame(baseType, parsed);
+        }
+
+        @Test
+        @DisplayName("null sound name returns base instance")
+        public void parseConfig_nullSound_returnsBaseInstance() {
+            Section section = mock(Section.class);
+            when(section.getString("sound")).thenReturn(null);
+
+            SoundRewardType parsed = baseType.parseConfig(section);
+            assertTrue(parsed.serializeConfig().isEmpty());
+        }
+
+        @Test
+        @DisplayName("invalid sound name returns base instance")
+        public void parseConfig_invalidSound_returnsBaseInstance() {
+            Section section = mock(Section.class);
+            when(section.getString("sound")).thenReturn("TOTALLY_FAKE_SOUND");
+
+            SoundRewardType parsed = baseType.parseConfig(section);
+            assertTrue(parsed.serializeConfig().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("grant")
+    class Grant {
+
+        @Test
+        @DisplayName("base instance grant is a no-op")
+        public void grant_baseInstance_isNoOp() {
+            PlayerMock player = server.addPlayer();
+            assertDoesNotThrow(() -> baseType.grant(player));
+        }
+
+        @Test
+        @DisplayName("configured instance plays sound to player")
+        public void grant_configuredInstance_playsSound() {
+            SoundRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("sound", "ENTITY_PLAYER_LEVELUP", "volume", 1.0f, "pitch", 1.0f));
+            PlayerMock player = server.addPlayer();
+            assertDoesNotThrow(() -> configured.grant(player));
+        }
+    }
+
+    @Nested
+    @DisplayName("Default QuestRewardType methods")
+    class DefaultMethods {
+
+        @Test
+        @DisplayName("withAmountMultiplier returns this")
+        public void withAmountMultiplier_returnsSameInstance() {
+            assertEquals(baseType, baseType.withAmountMultiplier(2.0));
+        }
+
+        @Test
+        @DisplayName("isScalable returns false")
+        public void isScalable_returnsFalse() {
+            assertFalse(baseType.isScalable());
+        }
+
+        @Test
+        @DisplayName("getNumericAmount returns empty")
+        public void getNumericAmount_returnsEmpty() {
+            assertTrue(baseType.getNumericAmount().isEmpty());
+        }
+
+        @Test
+        @DisplayName("withExactAmount returns this")
+        public void withExactAmount_returnsSameInstance() {
+            assertEquals(baseType, baseType.withExactAmount(10));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/TitleRewardTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/TitleRewardTypeTest.java
@@ -1,0 +1,344 @@
+package us.eunoians.mcrpg.quest.reward.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TitleRewardType")
+public class TitleRewardTypeTest extends McRPGBaseTest {
+
+    private TitleRewardType baseType;
+
+    @BeforeEach
+    public void setup() {
+        baseType = new TitleRewardType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:title_message")
+        public void getKey_returnsTitleMessageKey() {
+            assertEquals(TitleRewardType.KEY, baseType.getKey());
+        }
+
+        @Test
+        @DisplayName("key namespace is mcrpg")
+        public void getKey_namespaceIsMcrpg() {
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+        }
+
+        @Test
+        @DisplayName("key value is title_message")
+        public void getKey_valueIsTitleMessage() {
+            assertEquals("title_message", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, baseType.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("describeForDisplay")
+    class DescribeForDisplay {
+
+        @Test
+        @DisplayName("returns empty string")
+        public void describeForDisplay_returnsEmptyString() {
+            assertEquals("", baseType.describeForDisplay());
+        }
+
+        @Test
+        @DisplayName("configured instance also returns empty string")
+        public void describeForDisplay_configuredInstance_returnsEmptyString() {
+            TitleRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("title", "Hello", "subtitle", "World"));
+            assertEquals("", configured.describeForDisplay());
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("base instance serializes with defaults")
+        public void serializeConfig_baseInstance_containsDefaults() {
+            Map<String, Object> serialized = baseType.serializeConfig();
+            assertEquals("", serialized.get("title"));
+            assertEquals("", serialized.get("subtitle"));
+            assertEquals(10, serialized.get("fade-in"));
+            assertEquals(70, serialized.get("stay"));
+            assertEquals(20, serialized.get("fade-out"));
+        }
+
+        @Test
+        @DisplayName("configured instance serializes all fields")
+        public void serializeConfig_configuredInstance_containsAllFields() {
+            TitleRewardType configured = baseType.fromSerializedConfig(Map.of(
+                    "title", "Quest Complete!",
+                    "subtitle", "Well done.",
+                    "fade-in", 5,
+                    "stay", 40,
+                    "fade-out", 10));
+            Map<String, Object> serialized = configured.serializeConfig();
+
+            assertEquals("Quest Complete!", serialized.get("title"));
+            assertEquals("Well done.", serialized.get("subtitle"));
+            assertEquals(5, serialized.get("fade-in"));
+            assertEquals(40, serialized.get("stay"));
+            assertEquals(10, serialized.get("fade-out"));
+        }
+    }
+
+    @Nested
+    @DisplayName("fromSerializedConfig")
+    class FromSerializedConfig {
+
+        @Test
+        @DisplayName("round-trips all fields correctly")
+        public void fromSerializedConfig_roundTripsCorrectly() {
+            Map<String, Object> config = Map.of(
+                    "title", "<primary>Tutorial Complete!",
+                    "subtitle", "<body>You're ready.",
+                    "fade-in", 15,
+                    "stay", 80,
+                    "fade-out", 25);
+            TitleRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+
+            assertEquals("<primary>Tutorial Complete!", serialized.get("title"));
+            assertEquals("<body>You're ready.", serialized.get("subtitle"));
+            assertEquals(15, serialized.get("fade-in"));
+            assertEquals(80, serialized.get("stay"));
+            assertEquals(25, serialized.get("fade-out"));
+        }
+
+        @Test
+        @DisplayName("missing title defaults to empty string")
+        public void fromSerializedConfig_missingTitle_defaultsToEmpty() {
+            TitleRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("subtitle", "Just a subtitle"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("", serialized.get("title"));
+        }
+
+        @Test
+        @DisplayName("missing subtitle defaults to empty string")
+        public void fromSerializedConfig_missingSubtitle_defaultsToEmpty() {
+            TitleRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("title", "Just a title"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("", serialized.get("subtitle"));
+        }
+
+        @Test
+        @DisplayName("missing timing fields default correctly")
+        public void fromSerializedConfig_missingTimings_defaultCorrectly() {
+            TitleRewardType configured = baseType.fromSerializedConfig(
+                    Map.of("title", "Hello"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(10, serialized.get("fade-in"));
+            assertEquals(70, serialized.get("stay"));
+            assertEquals(20, serialized.get("fade-out"));
+        }
+
+        @Test
+        @DisplayName("non-numeric fade-in falls back to default")
+        public void fromSerializedConfig_nonNumericFadeIn_fallsBackToDefault() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("title", "Hello");
+            config.put("fade-in", "not_a_number");
+
+            TitleRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(10, serialized.get("fade-in"));
+        }
+
+        @Test
+        @DisplayName("non-numeric stay falls back to default")
+        public void fromSerializedConfig_nonNumericStay_fallsBackToDefault() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("title", "Hello");
+            config.put("stay", "invalid");
+
+            TitleRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(70, serialized.get("stay"));
+        }
+
+        @Test
+        @DisplayName("non-numeric fade-out falls back to default")
+        public void fromSerializedConfig_nonNumericFadeOut_fallsBackToDefault() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("title", "Hello");
+            config.put("fade-out", "bad");
+
+            TitleRewardType configured = baseType.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(20, serialized.get("fade-out"));
+        }
+
+        @Test
+        @DisplayName("empty config returns instance with all defaults")
+        public void fromSerializedConfig_emptyConfig_usesAllDefaults() {
+            TitleRewardType configured = baseType.fromSerializedConfig(Map.of());
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("", serialized.get("title"));
+            assertEquals("", serialized.get("subtitle"));
+            assertEquals(10, serialized.get("fade-in"));
+            assertEquals(70, serialized.get("stay"));
+            assertEquals(20, serialized.get("fade-out"));
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("parses all fields")
+        public void parseConfig_allFields() {
+            Section section = mock(Section.class);
+            when(section.contains("title")).thenReturn(true);
+            when(section.getString("title")).thenReturn("Big Title");
+            when(section.contains("subtitle")).thenReturn(true);
+            when(section.getString("subtitle")).thenReturn("Small Sub");
+            when(section.get("fade-in")).thenReturn(5);
+            when(section.get("stay")).thenReturn(40);
+            when(section.get("fade-out")).thenReturn(10);
+
+            TitleRewardType parsed = baseType.parseConfig(section);
+            Map<String, Object> serialized = parsed.serializeConfig();
+
+            assertEquals("Big Title", serialized.get("title"));
+            assertEquals("Small Sub", serialized.get("subtitle"));
+            assertEquals(5, serialized.get("fade-in"));
+            assertEquals(40, serialized.get("stay"));
+            assertEquals(10, serialized.get("fade-out"));
+        }
+
+        @Test
+        @DisplayName("missing title and subtitle default to empty")
+        public void parseConfig_missingTitleAndSubtitle_defaultToEmpty() {
+            Section section = mock(Section.class);
+            when(section.contains("title")).thenReturn(false);
+            when(section.contains("subtitle")).thenReturn(false);
+            when(section.get("fade-in")).thenReturn(null);
+            when(section.get("stay")).thenReturn(null);
+            when(section.get("fade-out")).thenReturn(null);
+
+            TitleRewardType parsed = baseType.parseConfig(section);
+            Map<String, Object> serialized = parsed.serializeConfig();
+
+            assertEquals("", serialized.get("title"));
+            assertEquals("", serialized.get("subtitle"));
+        }
+
+        @Test
+        @DisplayName("returns new instance")
+        public void parseConfig_returnsNewInstance() {
+            Section section = mock(Section.class);
+            when(section.contains("title")).thenReturn(false);
+            when(section.contains("subtitle")).thenReturn(false);
+            when(section.get("fade-in")).thenReturn(null);
+            when(section.get("stay")).thenReturn(null);
+            when(section.get("fade-out")).thenReturn(null);
+
+            TitleRewardType parsed = baseType.parseConfig(section);
+            assertNotSame(baseType, parsed);
+        }
+
+        @Test
+        @DisplayName("null getString returns empty title")
+        public void parseConfig_nullGetString_defaultsToEmpty() {
+            Section section = mock(Section.class);
+            when(section.contains("title")).thenReturn(true);
+            when(section.getString("title")).thenReturn(null);
+            when(section.contains("subtitle")).thenReturn(false);
+            when(section.get("fade-in")).thenReturn(null);
+            when(section.get("stay")).thenReturn(null);
+            when(section.get("fade-out")).thenReturn(null);
+
+            TitleRewardType parsed = baseType.parseConfig(section);
+            Map<String, Object> serialized = parsed.serializeConfig();
+            assertEquals("", serialized.get("title"));
+        }
+    }
+
+    @Nested
+    @DisplayName("grant")
+    class Grant {
+
+        @Test
+        @DisplayName("base instance grant does not throw")
+        public void grant_baseInstance_doesNotThrow() {
+            PlayerMock player = server.addPlayer();
+            assertDoesNotThrow(() -> baseType.grant(player));
+        }
+
+        @Test
+        @DisplayName("configured instance shows title to player")
+        public void grant_configuredInstance_showsTitle() {
+            TitleRewardType configured = baseType.fromSerializedConfig(Map.of(
+                    "title", "Congrats!",
+                    "subtitle", "You did it.",
+                    "fade-in", 10,
+                    "stay", 70,
+                    "fade-out", 20));
+            PlayerMock player = server.addPlayer();
+            assertDoesNotThrow(() -> configured.grant(player));
+        }
+    }
+
+    @Nested
+    @DisplayName("Default QuestRewardType methods")
+    class DefaultMethods {
+
+        @Test
+        @DisplayName("withAmountMultiplier returns this")
+        public void withAmountMultiplier_returnsSameInstance() {
+            assertEquals(baseType, baseType.withAmountMultiplier(2.0));
+        }
+
+        @Test
+        @DisplayName("isScalable returns false")
+        public void isScalable_returnsFalse() {
+            assertFalse(baseType.isScalable());
+        }
+
+        @Test
+        @DisplayName("getNumericAmount returns empty")
+        public void getNumericAmount_returnsEmpty() {
+            assertTrue(baseType.getNumericAmount().isEmpty());
+        }
+
+        @Test
+        @DisplayName("withExactAmount returns this")
+        public void withExactAmount_returnsSameInstance() {
+            assertEquals(baseType, baseType.withExactAmount(10));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `BucketEmptyObjectiveTypeCoverageTest` (19 tests): canProcess, processProgress with/without bucket filter, wrong context type handling, identity, parseConfig edge cases (empty list, invalid materials, no buckets key)
- Add `BucketFillObjectiveTypeCoverageTest` (19 tests): same coverage pattern for the fill variant, correctly mocking `getItemStack().getType()` instead of `getBucket()`
- Add `SoundRewardTypeTest` (~30 tests): identity, describeForDisplay, serializeConfig round-trips, fromSerializedConfig (missing/invalid sound, missing volume/pitch defaults, non-numeric fallbacks, case-insensitive sound names), parseConfig, grant smoke tests, default QuestRewardType methods
- Add `TitleRewardTypeTest` (~28 tests): identity, describeForDisplay, serializeConfig with defaults and configured values, fromSerializedConfig (round-trips, missing fields, non-numeric timing fallbacks, empty config), parseConfig (all fields, missing fields, null getString), grant smoke tests, default QuestRewardType methods

## Test plan

- [x] All 4 new test files compile and pass
- [x] Full test suite run — only pre-existing `QuestRewardDistributionResolverPotBehaviorTest` failures (6 tests, present on `recode` base branch)
- [x] Testing audit persona reviewed — addressed grant assertion gaps (`assertDoesNotThrow`) and `assertNotSame(true, ...)` → `assertFalse()` fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Die2JoeWQdKGfBiSQkXGvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Die2JoeWQdKGfBiSQkXGvb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for bucket fill and bucket empty quest objectives, including filtering, configuration parsing, context handling, and identity metadata.
  * Added coverage for sound rewards, including serialization, configuration defaults, playback, and amount behavior.
  * Added coverage for title rewards, including serialization, defaults, configuration parsing, display behavior, and granting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->