### PR TITLE
Expand Claude review workflow permissions and fix logger documentation

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -65,7 +65,7 @@ jobs:
           claude_args: |
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 40
-            --allowedTools "Task,Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Task,Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
 
   # On-demand: an @claude mention in a PR comment or review comment. Tag mode
   # (no prompt) — claude-code-action handles the sticky comment natively here.
@@ -101,5 +101,5 @@ jobs:
           claude_args: |
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 40
-            --allowedTools "Task,Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Task,Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment"
             --append-system-prompt "If asked to review or re-review this PR, follow .github/claude-review-prompt.md including its re-review convergence protocol. Otherwise answer the request directly."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,7 +622,7 @@ Use a builder when a class meets **any** of these criteria:
 - **No ability state stored on the ability object** — ability state is per-holder, stored in `AbilityData`/`AbilityAttribute`; ability objects are shared singletons
 - **Don't put McRPG-specific logic in McCore** — McCore changes affect all downstream plugins
 - **No fully-qualified type references in method bodies** — always declare a top-level `import` statement for the type; writing `org.bukkit.Location loc` inline is forbidden even when it compiles
-- **No `e.printStackTrace()`** — always use `Logger.log(Level.SEVERE, "context message", e)` so stack traces route through the server logger and are preserved in log aggregators
+- **No `e.printStackTrace()`** — always use `CorePlugin.getInstance().getLogger().log(Level.SEVERE, "context message", e)` so stack traces route through the server logger and are preserved in log aggregators
 - **No `Optional.get()` without a guard** — always use `orElse`, `orElseGet`, `orElseThrow`, or check `isPresent()` first; bare `.get()` is a guaranteed crash on the empty path
 - **No Bukkit API calls from async threads** — any world, entity, or inventory mutation must be scheduled on the main thread via `Bukkit.getScheduler().runTask(plugin, () -> { ... })`
 - **No blocking `.get()` on a `CompletableFuture` from the main thread** — this deadlocks if the future's completion path needs the main thread scheduler


### PR DESCRIPTION
## Summary
This PR expands the Claude code review workflow's allowed tools to enable deeper git history inspection, and corrects the logging convention documentation to reflect the actual recommended pattern.

## Changes

- **Workflow permissions**: Added `Bash(git diff:*)`, `Bash(git log:*)`, and `Bash(git show:*)` to the `allowedTools` list in both the scheduled and on-demand Claude review jobs. This enables Claude to inspect commit history and diffs beyond the current PR context, improving code review depth and context awareness.

- **Logger documentation**: Updated `CLAUDE.md` to correct the logging convention from the generic `Logger.log()` pattern to the more specific `CorePlugin.getInstance().getLogger().log()` pattern. This aligns the documentation with the actual recommended approach for routing stack traces through the server logger and preserving them in log aggregators.

## Implementation Details

Both workflow job configurations (`scheduled-review` and `on-demand-review`) were updated identically to maintain consistency. The git-based tools allow Claude to:
- Compare changes across commits with `git diff`
- Inspect commit history with `git log`
- Examine specific commits with `git show`

This enables more thorough analysis of code changes in context of the repository's evolution.

https://claude.ai/code/session_017q76Se6Yvwmjow3t3FSLEX