### PR TITLE
[Unit Tests] Add quest objective type and AbilityObjectiveFilter coverage tests

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/AbilityObjectiveFilterTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/AbilityObjectiveFilterTest.java
@@ -1,240 +1,337 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import com.diamonddagger590.mccore.registry.RegistryAccess;
 import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
 import us.eunoians.mcrpg.ability.AbilityType;
 import us.eunoians.mcrpg.ability.combo.ComboActivatable;
 import us.eunoians.mcrpg.ability.impl.type.PassiveAbility;
 import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+import us.eunoians.mcrpg.util.McRPGMethods;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
-public class AbilityObjectiveFilterTest {
+@DisplayName("AbilityObjectiveFilter")
+public class AbilityObjectiveFilterTest extends McRPGBaseTest {
 
-    @Test
-    @DisplayName("Given an EMPTY filter, when matchesAbility is called with any ability, then it returns true")
-    public void matchesAbility_returnsTrue_whenFilterIsEmpty() {
-        Ability mockAbility = mock(Ability.class);
-        when(mockAbility.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
-        assertTrue(AbilityObjectiveFilter.EMPTY.matchesAbility(mockAbility));
+    @Nested
+    @DisplayName("EMPTY sentinel")
+    class EmptySentinel {
+
+        @Test
+        @DisplayName("matches any ability")
+        public void matchesAbility_returnsTrue_forAnyAbility() {
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            assertTrue(AbilityObjectiveFilter.EMPTY.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("matchesAbilityKey returns true for any key")
+        public void matchesAbilityKey_returnsTrue_forAnyKey() {
+            assertTrue(AbilityObjectiveFilter.EMPTY.matchesAbilityKey(new NamespacedKey("mcrpg", "bleed")));
+        }
+
+        @Test
+        @DisplayName("getAbilityFilter returns empty")
+        public void getAbilityFilter_returnsEmpty() {
+            assertTrue(AbilityObjectiveFilter.EMPTY.getAbilityFilter().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getAbilityTypeFilter returns empty")
+        public void getAbilityTypeFilter_returnsEmpty() {
+            assertTrue(AbilityObjectiveFilter.EMPTY.getAbilityTypeFilter().isEmpty());
+        }
     }
 
-    @Test
-    @DisplayName("Given a specific key filter, when matchesAbility is called with the same key, then it returns true")
-    public void matchesAbility_returnsTrue_whenKeyMatchesFilter() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, null);
-        Ability mockAbility = mock(Ability.class);
-        when(mockAbility.getAbilityKey()).thenReturn(key);
-        assertTrue(filter.matchesAbility(mockAbility));
+    @Nested
+    @DisplayName("NEVER_MATCH sentinel")
+    class NeverMatchSentinel {
+
+        @Test
+        @DisplayName("does not match any ability")
+        public void matchesAbility_returnsFalse_forAnyAbility() {
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            assertFalse(AbilityObjectiveFilter.NEVER_MATCH.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("matchesAbilityKey returns false for non-matching key")
+        public void matchesAbilityKey_returnsFalse_forNonMatchingKey() {
+            assertFalse(AbilityObjectiveFilter.NEVER_MATCH.matchesAbilityKey(new NamespacedKey("mcrpg", "bleed")));
+        }
+
+        @Test
+        @DisplayName("getAbilityFilter returns the unknown sentinel key")
+        public void getAbilityFilter_returnsSentinelKey() {
+            assertTrue(AbilityObjectiveFilter.NEVER_MATCH.getAbilityFilter().isPresent());
+            assertEquals(new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "unknown"),
+                    AbilityObjectiveFilter.NEVER_MATCH.getAbilityFilter().get());
+        }
     }
 
-    @Test
-    @DisplayName("Given a specific key filter, when matchesAbility is called with a different key, then it returns false")
-    public void matchesAbility_returnsFalse_whenKeyDoesNotMatchFilter() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, null);
-        Ability mockAbility = mock(Ability.class);
-        when(mockAbility.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "other"));
-        assertFalse(filter.matchesAbility(mockAbility));
+    @Nested
+    @DisplayName("Specific ability key filter")
+    class SpecificAbilityFilter {
+
+        private final NamespacedKey targetKey = new NamespacedKey("mcrpg", "bleed");
+        private final AbilityObjectiveFilter filter = new AbilityObjectiveFilter(targetKey, null);
+
+        @Test
+        @DisplayName("matches ability with same key")
+        public void matchesAbility_returnsTrue_whenKeyMatches() {
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(targetKey);
+            assertTrue(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("does not match ability with different key")
+        public void matchesAbility_returnsFalse_whenKeyDiffers() {
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "vampire"));
+            assertFalse(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("matchesAbilityKey returns true for matching key")
+        public void matchesAbilityKey_returnsTrue_whenKeyMatches() {
+            assertTrue(filter.matchesAbilityKey(targetKey));
+        }
+
+        @Test
+        @DisplayName("matchesAbilityKey returns false for non-matching key")
+        public void matchesAbilityKey_returnsFalse_whenKeyDiffers() {
+            assertFalse(filter.matchesAbilityKey(new NamespacedKey("mcrpg", "vampire")));
+        }
+
+        @Test
+        @DisplayName("getAbilityFilter returns the configured key")
+        public void getAbilityFilter_returnsConfiguredKey() {
+            assertTrue(filter.getAbilityFilter().isPresent());
+            assertEquals(targetKey, filter.getAbilityFilter().get());
+        }
+
+        @Test
+        @DisplayName("getAbilityTypeFilter returns empty when only key set")
+        public void getAbilityTypeFilter_returnsEmpty() {
+            assertTrue(filter.getAbilityTypeFilter().isEmpty());
+        }
+
+        @Test
+        @DisplayName("key filter takes priority over type even when ability type matches")
+        public void matchesAbility_usesKeyPriority_overType() {
+            AbilityObjectiveFilter filterWithBoth = new AbilityObjectiveFilter(targetKey, AbilityType.PASSIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "vampire"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            assertFalse(filterWithBoth.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("key filter matches regardless of type when key matches")
+        public void matchesAbility_returnsTrue_whenKeyMatchesRegardlessOfType() {
+            AbilityObjectiveFilter filterWithBoth = new AbilityObjectiveFilter(targetKey, AbilityType.ACTIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(targetKey);
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            assertTrue(filterWithBoth.matchesAbility(ability));
+        }
     }
 
-    @Test
-    @DisplayName("Given an ACTIVE type filter, when matchesAbility is called with an ACTIVE ability, then it returns true")
-    public void matchesAbility_returnsTrue_whenActiveFilterAndAbilityIsActive() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.ACTIVE);
-        Ability mockAbility = mock(Ability.class, withSettings().extraInterfaces(ComboActivatable.class));
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.ACTIVE);
-        assertTrue(filter.matchesAbility(mockAbility));
+    @Nested
+    @DisplayName("Ability type filter")
+    class AbilityTypeFilterTests {
+
+        @Test
+        @DisplayName("PASSIVE filter matches PASSIVE abilities")
+        public void matchesAbility_returnsTrue_whenPassiveMatchesPassive() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            assertTrue(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("PASSIVE filter does not match ACTIVE abilities")
+        public void matchesAbility_returnsFalse_whenPassiveDoesNotMatchActive() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            assertFalse(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("PASSIVE filter does not match INNATE abilities")
+        public void matchesAbility_returnsFalse_whenPassiveDoesNotMatchInnate() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.INNATE);
+            assertFalse(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("ACTIVE filter matches ACTIVE abilities")
+        public void matchesAbility_returnsTrue_whenActiveMatchesActive() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.ACTIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            assertTrue(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("ACTIVE filter does not match INNATE abilities")
+        public void matchesAbility_returnsFalse_whenActiveDoesNotMatchInnate() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.ACTIVE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.INNATE);
+            assertFalse(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("INNATE filter matches INNATE abilities")
+        public void matchesAbility_returnsTrue_whenInnateMatchesInnate() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.INNATE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.INNATE);
+            assertTrue(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("INNATE filter does not match ACTIVE abilities")
+        public void matchesAbility_returnsFalse_whenInnateDoesNotMatchActive() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.INNATE);
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            assertFalse(filter.matchesAbility(ability));
+        }
+
+        @Test
+        @DisplayName("getAbilityFilter returns empty when only type set")
+        public void getAbilityFilter_returnsEmpty() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
+            assertTrue(filter.getAbilityFilter().isEmpty());
+        }
+
+        @Test
+        @DisplayName("getAbilityTypeFilter returns the configured type")
+        public void getAbilityTypeFilter_returnsConfiguredType() {
+            AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
+            assertTrue(filter.getAbilityTypeFilter().isPresent());
+            assertEquals(AbilityType.PASSIVE, filter.getAbilityTypeFilter().get());
+        }
     }
 
-    @Test
-    @DisplayName("Given an ACTIVE type filter, when matchesAbility is called with an INNATE ability, then it returns false")
-    public void matchesAbility_returnsFalse_whenActiveFilterAndAbilityIsInnate() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.ACTIVE);
-        Ability mockAbility = mock(Ability.class);
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.INNATE);
-        assertFalse(filter.matchesAbility(mockAbility));
+    @Nested
+    @DisplayName("resolveAbilityName")
+    class ResolveAbilityName {
+
+        @BeforeEach
+        public void ensureAbilityRegistry() {
+            RegistryAccess registryAccess = RegistryAccess.registryAccess();
+            if (registryAccess.registry(McRPGRegistryKey.ABILITY) == null) {
+                registryAccess.register(new AbilityRegistry(mcRPG));
+            }
+        }
+
+        @Test
+        @DisplayName("returns raw key for unregistered ability")
+        public void resolveAbilityName_returnsRawKey_whenNotRegistered() {
+            NamespacedKey unknownKey = new NamespacedKey("mcrpg", "nonexistent_ability");
+            String name = AbilityObjectiveFilter.EMPTY.resolveAbilityName(unknownKey);
+            assertEquals("nonexistent_ability", name);
+        }
+
+        @Test
+        @DisplayName("returns ability name for registered ability")
+        public void resolveAbilityName_returnsAbilityName_whenRegistered() {
+            NamespacedKey bleedKey = new NamespacedKey("mcrpg", "test_resolve");
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(bleedKey);
+            when(ability.getName()).thenReturn("Test Resolve");
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY).register(ability);
+
+            String name = AbilityObjectiveFilter.EMPTY.resolveAbilityName(bleedKey);
+            assertEquals("Test Resolve", name);
+        }
     }
 
-    @Test
-    @DisplayName("Given a PASSIVE type filter, when matchesAbility is called with a PASSIVE ability, then it returns true")
-    public void matchesAbility_returnsTrue_whenPassiveFilterAndAbilityIsPassive() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
-        Ability mockAbility = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class, UnlockableAbility.class));
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.PASSIVE);
-        assertTrue(filter.matchesAbility(mockAbility));
+    @Nested
+    @DisplayName("AbilityType.fromString")
+    class AbilityTypeFromString {
+
+        @Test
+        @DisplayName("parses valid types case-insensitively")
+        public void fromString_returnsType_whenValid() {
+            assertEquals(AbilityType.ACTIVE, AbilityType.fromString("ACTIVE").orElseThrow());
+            assertEquals(AbilityType.PASSIVE, AbilityType.fromString("passive").orElseThrow());
+            assertEquals(AbilityType.INNATE, AbilityType.fromString("Innate").orElseThrow());
+        }
+
+        @Test
+        @DisplayName("returns empty for invalid values")
+        public void fromString_returnsEmpty_whenInvalid() {
+            assertTrue(AbilityType.fromString("UNKNOWN").isEmpty());
+            assertTrue(AbilityType.fromString("").isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns empty for null")
+        public void fromString_returnsEmpty_whenNull() {
+            assertTrue(AbilityType.fromString(null).isEmpty());
+        }
     }
 
-    @Test
-    @DisplayName("Given a PASSIVE type filter, when matchesAbility is called with an INNATE passive ability, then it returns false")
-    public void matchesAbility_returnsFalse_whenPassiveFilterAndAbilityIsInnatePassive() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
-        Ability mockAbility = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class));
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.INNATE);
-        assertFalse(filter.matchesAbility(mockAbility));
-    }
+    @Nested
+    @DisplayName("Ability.getAbilityType default method")
+    class AbilityTypeDefault {
 
-    @Test
-    @DisplayName("Given an INNATE type filter, when matchesAbility is called with an INNATE ability, then it returns true")
-    public void matchesAbility_returnsTrue_whenInnateFilterAndAbilityIsInnate() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.INNATE);
-        Ability mockAbility = mock(Ability.class);
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.INNATE);
-        assertTrue(filter.matchesAbility(mockAbility));
-    }
+        @Test
+        @DisplayName("ComboActivatable returns ACTIVE")
+        public void getAbilityType_returnsActive_whenComboActivatable() {
+            Ability active = mock(Ability.class, withSettings().extraInterfaces(ComboActivatable.class));
+            when(active.getAbilityType()).thenCallRealMethod();
+            assertEquals(AbilityType.ACTIVE, active.getAbilityType());
+        }
 
-    @Test
-    @DisplayName("Given an INNATE type filter, when matchesAbility is called with an ACTIVE ability, then it returns false")
-    public void matchesAbility_returnsFalse_whenInnateFilterAndAbilityIsActive() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.INNATE);
-        Ability mockAbility = mock(Ability.class, withSettings().extraInterfaces(ComboActivatable.class));
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.ACTIVE);
-        assertFalse(filter.matchesAbility(mockAbility));
-    }
+        @Test
+        @DisplayName("PassiveAbility + UnlockableAbility returns PASSIVE")
+        public void getAbilityType_returnsPassive_whenPassiveAndUnlockable() {
+            Ability passive = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class, UnlockableAbility.class));
+            when(passive.getAbilityType()).thenCallRealMethod();
+            assertEquals(AbilityType.PASSIVE, passive.getAbilityType());
+        }
 
-    @Test
-    @DisplayName("Given an INNATE type filter, when matchesAbility is called with a PASSIVE ability, then it returns false")
-    public void matchesAbility_returnsFalse_whenInnateFilterAndAbilityIsPassive() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.INNATE);
-        Ability mockAbility = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class, UnlockableAbility.class));
-        when(mockAbility.getAbilityType()).thenReturn(AbilityType.PASSIVE);
-        assertFalse(filter.matchesAbility(mockAbility));
-    }
+        @Test
+        @DisplayName("PassiveAbility without UnlockableAbility returns INNATE")
+        public void getAbilityType_returnsInnate_whenPassiveWithoutUnlockable() {
+            Ability innate = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class));
+            when(innate.getAbilityType()).thenCallRealMethod();
+            assertEquals(AbilityType.INNATE, innate.getAbilityType());
+        }
 
-    @Test
-    @DisplayName("Given both key and type filters, when matchesAbility is called with matching key, then key filter takes priority")
-    public void matchesAbility_returnsTrue_whenKeyMatchesRegardlessOfType() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, AbilityType.ACTIVE);
-        Ability matchingKey = mock(Ability.class);
-        when(matchingKey.getAbilityKey()).thenReturn(key);
-        assertTrue(filter.matchesAbility(matchingKey));
-    }
-
-    @Test
-    @DisplayName("Given both key and type filters, when matchesAbility is called with wrong key, then it returns false")
-    public void matchesAbility_returnsFalse_whenKeyDoesNotMatchRegardlessOfType() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, AbilityType.ACTIVE);
-        Ability wrongKey = mock(Ability.class, withSettings().extraInterfaces(ComboActivatable.class));
-        when(wrongKey.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "other"));
-        assertFalse(filter.matchesAbility(wrongKey));
-    }
-
-    @Test
-    @DisplayName("Given no key filter, when matchesAbilityKey is called, then it returns true")
-    public void matchesAbilityKey_returnsTrue_whenNoKeyFilter() {
-        assertTrue(AbilityObjectiveFilter.EMPTY.matchesAbilityKey(new NamespacedKey("mcrpg", "anything")));
-    }
-
-    @Test
-    @DisplayName("Given a key filter, when matchesAbilityKey is called with matching key, then it returns true")
-    public void matchesAbilityKey_returnsTrue_whenKeyMatches() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, null);
-        assertTrue(filter.matchesAbilityKey(key));
-    }
-
-    @Test
-    @DisplayName("Given a key filter, when matchesAbilityKey is called with different key, then it returns false")
-    public void matchesAbilityKey_returnsFalse_whenKeyDiffers() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, null);
-        assertFalse(filter.matchesAbilityKey(new NamespacedKey("mcrpg", "other")));
-    }
-
-    @Test
-    @DisplayName("Given an EMPTY filter, when getAbilityFilter is called, then it returns empty")
-    public void getAbilityFilter_returnsEmpty_whenNoKeyFilter() {
-        assertTrue(AbilityObjectiveFilter.EMPTY.getAbilityFilter().isEmpty());
-    }
-
-    @Test
-    @DisplayName("Given a key filter, when getAbilityFilter is called, then it returns the key")
-    public void getAbilityFilter_returnsPresent_whenKeyFilterSet() {
-        NamespacedKey key = new NamespacedKey("mcrpg", "bleed");
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(key, null);
-        assertTrue(filter.getAbilityFilter().isPresent());
-        assertEquals(key, filter.getAbilityFilter().get());
-    }
-
-    @Test
-    @DisplayName("Given an EMPTY filter, when getAbilityTypeFilter is called, then it returns empty")
-    public void getAbilityTypeFilter_returnsEmpty_whenNoTypeFilter() {
-        assertTrue(AbilityObjectiveFilter.EMPTY.getAbilityTypeFilter().isEmpty());
-    }
-
-    @Test
-    @DisplayName("Given a type filter, when getAbilityTypeFilter is called, then it returns the type")
-    public void getAbilityTypeFilter_returnsPresent_whenTypeFilterSet() {
-        AbilityObjectiveFilter filter = new AbilityObjectiveFilter(null, AbilityType.PASSIVE);
-        assertTrue(filter.getAbilityTypeFilter().isPresent());
-        assertEquals(AbilityType.PASSIVE, filter.getAbilityTypeFilter().get());
-    }
-
-    @Test
-    @DisplayName("Given valid ability type strings, when fromString is called, then it parses case-insensitively")
-    public void fromString_returnsType_whenValueIsValid() {
-        assertEquals(AbilityType.ACTIVE, AbilityType.fromString("ACTIVE").orElseThrow());
-        assertEquals(AbilityType.PASSIVE, AbilityType.fromString("passive").orElseThrow());
-        assertEquals(AbilityType.INNATE, AbilityType.fromString("Innate").orElseThrow());
-    }
-
-    @Test
-    @DisplayName("Given invalid or blank strings, when fromString is called, then it returns empty")
-    public void fromString_returnsEmpty_whenValueIsInvalidOrBlank() {
-        assertTrue(AbilityType.fromString("UNKNOWN").isEmpty());
-        assertTrue(AbilityType.fromString("").isEmpty());
-        assertTrue(AbilityType.fromString(null).isEmpty());
-    }
-
-    @Test
-    @DisplayName("Given a ComboActivatable ability, when getAbilityType is called, then it returns ACTIVE")
-    public void getAbilityType_returnsActive_whenComboActivatable() {
-        Ability active = mock(Ability.class, withSettings().extraInterfaces(ComboActivatable.class));
-        when(active.getAbilityType()).thenCallRealMethod();
-        assertEquals(AbilityType.ACTIVE, active.getAbilityType());
-    }
-
-    @Test
-    @DisplayName("Given a PassiveAbility and UnlockableAbility, when getAbilityType is called, then it returns PASSIVE")
-    public void getAbilityType_returnsPassive_whenPassiveAndUnlockable() {
-        Ability passive = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class, UnlockableAbility.class));
-        when(passive.getAbilityType()).thenCallRealMethod();
-        assertEquals(AbilityType.PASSIVE, passive.getAbilityType());
-    }
-
-    @Test
-    @DisplayName("Given a PassiveAbility without UnlockableAbility, when getAbilityType is called, then it returns INNATE")
-    public void getAbilityType_returnsInnate_whenPassiveWithoutUnlockable() {
-        Ability innatePassive = mock(Ability.class, withSettings().extraInterfaces(PassiveAbility.class));
-        when(innatePassive.getAbilityType()).thenCallRealMethod();
-        assertEquals(AbilityType.INNATE, innatePassive.getAbilityType());
-    }
-
-    @Test
-    @DisplayName("Given a plain ability with no special interfaces, when getAbilityType is called, then it returns INNATE")
-    public void getAbilityType_returnsInnate_whenPlainAbility() {
-        Ability plain = mock(Ability.class);
-        when(plain.getAbilityType()).thenCallRealMethod();
-        assertEquals(AbilityType.INNATE, plain.getAbilityType());
-    }
-
-    @Test
-    @DisplayName("Given the NEVER_MATCH filter, when matchesAbility is called with an ability whose key is not mcrpg:unknown, then it returns false")
-    public void matchesAbility_returnsFalse_whenFilterIsNeverMatch() {
-        Ability mockAbility = mock(Ability.class);
-        when(mockAbility.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
-        assertFalse(AbilityObjectiveFilter.NEVER_MATCH.matchesAbility(mockAbility));
-    }
-
-    @Test
-    @DisplayName("Given the NEVER_MATCH filter, when matchesAbilityKey is called with a real ability key, then it returns false")
-    public void matchesAbilityKey_returnsFalse_whenFilterIsNeverMatch() {
-        assertFalse(AbilityObjectiveFilter.NEVER_MATCH.matchesAbilityKey(new NamespacedKey("mcrpg", "bleed")));
+        @Test
+        @DisplayName("plain ability with no interfaces returns INNATE")
+        public void getAbilityType_returnsInnate_whenPlainAbility() {
+            Ability plain = mock(Ability.class);
+            when(plain.getAbilityType()).thenCallRealMethod();
+            assertEquals(AbilityType.INNATE, plain.getAbilityType());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/AbilityUnlockObjectiveTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/AbilityUnlockObjectiveTypeCoverageTest.java
@@ -1,0 +1,344 @@
+package us.eunoians.mcrpg.quest.objective.type.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityType;
+import us.eunoians.mcrpg.ability.impl.type.UnlockableAbility;
+import us.eunoians.mcrpg.event.ability.AbilityUnlockEvent;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AbilityUnlockObjectiveType — extended coverage")
+public class AbilityUnlockObjectiveTypeCoverageTest extends McRPGBaseTest {
+
+    private AbilityUnlockObjectiveType baseType;
+
+    @BeforeEach
+    public void setup() {
+        baseType = new AbilityUnlockObjectiveType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns ability_unlock key")
+        public void getKey_returnsAbilityUnlockKey() {
+            assertEquals(AbilityUnlockObjectiveType.KEY, baseType.getKey());
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+            assertEquals("ability_unlock", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, baseType.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for AbilityUnlockQuestContext")
+        public void canProcess_returnsTrue_forCorrectContext() {
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            AbilityUnlockQuestContext context = new AbilityUnlockQuestContext(event);
+            assertTrue(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic mock context")
+        public void canProcess_returnsFalse_forGenericContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for BlockBreakQuestContext")
+        public void canProcess_returnsFalse_forBlockBreakContext() {
+            BlockBreakQuestContext context = mock(BlockBreakQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for LoadoutEquipQuestContext")
+        public void canProcess_returnsFalse_forLoadoutEquipContext() {
+            LoadoutEquipQuestContext context = mock(LoadoutEquipQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — empty filter (base type)")
+    class ProcessProgressEmptyFilter {
+
+        @Test
+        @DisplayName("returns 1 for any ability unlock when no filter is set")
+        public void processProgress_returnsOne_whenNoFilter() {
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            AbilityUnlockQuestContext context = new AbilityUnlockQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, baseType.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 for wrong context type")
+        public void processProgress_returnsZero_whenWrongContextType() {
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, baseType.processProgress(instance, wrongContext));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — specific ability key filter")
+    class ProcessProgressAbilityKeyFilter {
+
+        private AbilityUnlockObjectiveType configured;
+
+        @BeforeEach
+        public void setupConfigured() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("mcrpg:bleed");
+            when(section.contains("ability-type")).thenReturn(false);
+            configured = baseType.parseConfig(section);
+        }
+
+        @Test
+        @DisplayName("returns 1 when ability key matches")
+        public void processProgress_returnsOne_whenKeyMatches() {
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("returns 0 when ability key does not match")
+        public void processProgress_returnsZero_whenKeyDoesNotMatch() {
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "vampire"));
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — ability type filter")
+    class ProcessProgressAbilityTypeFilter {
+
+        @Test
+        @DisplayName("returns 1 when PASSIVE filter matches PASSIVE ability")
+        public void processProgress_returnsOne_whenPassiveTypeMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("PASSIVE");
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("returns 0 when PASSIVE filter does not match ACTIVE ability")
+        public void processProgress_returnsZero_whenPassiveFilterDoesNotMatchActive() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("PASSIVE");
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "rage_spike"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("returns 1 when ACTIVE filter matches ACTIVE ability")
+        public void processProgress_returnsOne_whenActiveTypeMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("ACTIVE");
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "rage_spike"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("returns 1 when INNATE filter matches INNATE ability")
+        public void processProgress_returnsOne_whenInnateTypeMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("INNATE");
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "some_innate"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.INNATE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("no filters creates instance with EMPTY filter")
+        public void parseConfig_returnsNewInstance_withNoFilters() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(false);
+
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "anything"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("ability key filter is parsed from config")
+        public void parseConfig_parsesAbilityKeyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("mcrpg:deeper_wound");
+            when(section.contains("ability-type")).thenReturn(false);
+
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+        }
+
+        @Test
+        @DisplayName("ability type filter is parsed from config")
+        public void parseConfig_parsesAbilityTypeFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("ACTIVE");
+
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+        }
+
+        @Test
+        @DisplayName("invalid ability-type returns NEVER_MATCH filter")
+        public void parseConfig_returnsNeverMatch_whenAbilityTypeInvalid() {
+            Section section = mock(Section.class);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("INVALID_TYPE");
+            when(section.contains("ability")).thenReturn(false);
+
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("invalid ability key returns NEVER_MATCH filter")
+        public void parseConfig_returnsNeverMatch_whenAbilityKeyInvalid() {
+            Section section = mock(Section.class);
+            when(section.contains("ability-type")).thenReturn(false);
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("not a valid key!!!");
+
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility ability = mock(UnlockableAbility.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("ability key takes priority over ability type when both present")
+        public void parseConfig_abilityKeyTakesPriority_whenBothPresent() {
+            Section section = mock(Section.class);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("PASSIVE");
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("mcrpg:bleed");
+
+            AbilityUnlockObjectiveType configured = baseType.parseConfig(section);
+
+            UnlockableAbility matchingKey = mock(UnlockableAbility.class);
+            when(matchingKey.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(matchingKey.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            AbilityUnlockEvent event = mock(AbilityUnlockEvent.class);
+            when(event.getAbility()).thenReturn(matchingKey);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, new AbilityUnlockQuestContext(event)));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/AdvancementCompleteObjectiveTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/AdvancementCompleteObjectiveTypeCoverageTest.java
@@ -1,0 +1,222 @@
+package us.eunoians.mcrpg.quest.objective.type.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.NamespacedKey;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("AdvancementCompleteObjectiveType — extended coverage")
+public class AdvancementCompleteObjectiveTypeCoverageTest extends McRPGBaseTest {
+
+    private AdvancementCompleteObjectiveType baseType;
+
+    @BeforeEach
+    public void setup() {
+        baseType = new AdvancementCompleteObjectiveType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns advancement_complete key")
+        public void getKey_returnsAdvancementCompleteKey() {
+            assertEquals(AdvancementCompleteObjectiveType.KEY, baseType.getKey());
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+            assertEquals("advancement_complete", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, baseType.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for AdvancementCompleteQuestContext")
+        public void canProcess_returnsTrue_forCorrectContext() {
+            AdvancementCompleteQuestContext context = mock(AdvancementCompleteQuestContext.class);
+            assertTrue(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic mock context")
+        public void canProcess_returnsFalse_forGenericContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for BlockBreakQuestContext")
+        public void canProcess_returnsFalse_forBlockBreakContext() {
+            BlockBreakQuestContext context = mock(BlockBreakQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for LoadoutEquipQuestContext")
+        public void canProcess_returnsFalse_forLoadoutEquipContext() {
+            LoadoutEquipQuestContext context = mock(LoadoutEquipQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — empty filter (base type)")
+    class ProcessProgressEmptyFilter {
+
+        @Test
+        @DisplayName("returns 1 for any advancement when no filter is set")
+        public void processProgress_returnsOne_whenNoFilter() {
+            AdvancementCompleteQuestContext context = createContext("minecraft:story/iron_tools");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, baseType.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 for wrong context type")
+        public void processProgress_returnsZero_whenWrongContextType() {
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, baseType.processProgress(instance, wrongContext));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — specific advancement filter")
+    class ProcessProgressSpecificFilter {
+
+        private AdvancementCompleteObjectiveType configured;
+
+        @BeforeEach
+        public void setupConfigured() {
+            Section section = mock(Section.class);
+            when(section.contains("advancements")).thenReturn(true);
+            when(section.getStringList("advancements")).thenReturn(
+                    List.of("minecraft:story/iron_tools", "minecraft:story/upgrade_tools"));
+            configured = baseType.parseConfig(section);
+        }
+
+        @Test
+        @DisplayName("returns 1 when advancement key matches")
+        public void processProgress_returnsOne_whenKeyMatches() {
+            AdvancementCompleteQuestContext context = createContext("minecraft:story/iron_tools");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 1 for second matching advancement")
+        public void processProgress_returnsOne_forSecondMatchingAdvancement() {
+            AdvancementCompleteQuestContext context = createContext("minecraft:story/upgrade_tools");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 when advancement key does not match")
+        public void processProgress_returnsZero_whenKeyDoesNotMatch() {
+            AdvancementCompleteQuestContext context = createContext("minecraft:adventure/kill_a_mob");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("no advancements key creates instance with empty filter")
+        public void parseConfig_returnsNewInstance_withEmptyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("advancements")).thenReturn(false);
+
+            AdvancementCompleteObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+
+            AdvancementCompleteQuestContext context = createContext("minecraft:any/advancement");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("advancements list is parsed from config")
+        public void parseConfig_parsesAdvancementsList() {
+            Section section = mock(Section.class);
+            when(section.contains("advancements")).thenReturn(true);
+            when(section.getStringList("advancements")).thenReturn(
+                    List.of("minecraft:story/mine_stone"));
+
+            AdvancementCompleteObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+        }
+
+        @Test
+        @DisplayName("empty advancements list acts as no filter")
+        public void parseConfig_emptyList_actsAsNoFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("advancements")).thenReturn(true);
+            when(section.getStringList("advancements")).thenReturn(List.of());
+
+            AdvancementCompleteObjectiveType configured = baseType.parseConfig(section);
+
+            AdvancementCompleteQuestContext context = createContext("minecraft:any/advancement");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("single advancement in list filters correctly")
+        public void parseConfig_singleAdvancement_filtersCorrectly() {
+            Section section = mock(Section.class);
+            when(section.contains("advancements")).thenReturn(true);
+            when(section.getStringList("advancements")).thenReturn(
+                    List.of("minecraft:story/mine_stone"));
+
+            AdvancementCompleteObjectiveType configured = baseType.parseConfig(section);
+
+            AdvancementCompleteQuestContext matching = createContext("minecraft:story/mine_stone");
+            AdvancementCompleteQuestContext nonMatching = createContext("minecraft:adventure/kill_a_mob");
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+
+            assertEquals(1, configured.processProgress(instance, matching));
+            assertEquals(0, configured.processProgress(instance, nonMatching));
+        }
+    }
+
+    private AdvancementCompleteQuestContext createContext(String advancementKey) {
+        NamespacedKey key = NamespacedKey.fromString(advancementKey);
+        Advancement advancement = mock(Advancement.class);
+        when(advancement.getKey()).thenReturn(key);
+
+        PlayerAdvancementDoneEvent event = mock(PlayerAdvancementDoneEvent.class);
+        when(event.getAdvancement()).thenReturn(advancement);
+
+        return new AdvancementCompleteQuestContext(event);
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/LoadoutEquipObjectiveTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/LoadoutEquipObjectiveTypeCoverageTest.java
@@ -1,0 +1,366 @@
+package us.eunoians.mcrpg.quest.objective.type.builtin;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.Ability;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.AbilityType;
+import us.eunoians.mcrpg.event.loadout.LoadoutAbilityChangeEvent;
+import us.eunoians.mcrpg.expansion.McRPGExpansion;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+import us.eunoians.mcrpg.registry.McRPGRegistryKey;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("LoadoutEquipObjectiveType — extended coverage")
+public class LoadoutEquipObjectiveTypeCoverageTest extends McRPGBaseTest {
+
+    private LoadoutEquipObjectiveType baseType;
+
+    @BeforeEach
+    public void setup() {
+        RegistryAccess registryAccess = RegistryAccess.registryAccess();
+        if (registryAccess.registry(McRPGRegistryKey.ABILITY) == null) {
+            registryAccess.register(new AbilityRegistry(mcRPG));
+        }
+        baseType = new LoadoutEquipObjectiveType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns loadout_equip key")
+        public void getKey_returnsLoadoutEquipKey() {
+            assertEquals(LoadoutEquipObjectiveType.KEY, baseType.getKey());
+            assertEquals("mcrpg", baseType.getKey().getNamespace());
+            assertEquals("loadout_equip", baseType.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        public void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(baseType.getExpansionKey().isPresent());
+            assertEquals(McRPGExpansion.EXPANSION_KEY, baseType.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("canProcess")
+    class CanProcess {
+
+        @Test
+        @DisplayName("returns true for LoadoutEquipQuestContext")
+        public void canProcess_returnsTrue_forCorrectContext() {
+            LoadoutEquipQuestContext context = mock(LoadoutEquipQuestContext.class);
+            assertTrue(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for generic mock context")
+        public void canProcess_returnsFalse_forGenericContext() {
+            QuestObjectiveProgressContext context = mock(QuestObjectiveProgressContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for BlockBreakQuestContext")
+        public void canProcess_returnsFalse_forBlockBreakContext() {
+            BlockBreakQuestContext context = mock(BlockBreakQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+
+        @Test
+        @DisplayName("returns false for AbilityUnlockQuestContext")
+        public void canProcess_returnsFalse_forAbilityUnlockContext() {
+            AbilityUnlockQuestContext context = mock(AbilityUnlockQuestContext.class);
+            assertFalse(baseType.canProcess(context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — wrong context")
+    class ProcessProgressWrongContext {
+
+        @Test
+        @DisplayName("returns 0 for wrong context type")
+        public void processProgress_returnsZero_whenWrongContextType() {
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, baseType.processProgress(instance, wrongContext));
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("no filters creates new instance with EMPTY filter")
+        public void parseConfig_returnsNewInstance_withNoFilters() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(false);
+
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+        }
+
+        @Test
+        @DisplayName("ability key filter is parsed from config")
+        public void parseConfig_parsesAbilityKeyFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("mcrpg:bleed");
+            when(section.contains("ability-type")).thenReturn(false);
+
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+        }
+
+        @Test
+        @DisplayName("ability type filter is parsed from config")
+        public void parseConfig_parsesAbilityTypeFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("ACTIVE");
+
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+            assertNotSame(baseType, configured);
+        }
+
+        @Test
+        @DisplayName("invalid ability-type returns NEVER_MATCH filter")
+        public void parseConfig_returnsNeverMatch_whenAbilityTypeInvalid() {
+            Section section = mock(Section.class);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("INVALID_TYPE");
+            when(section.contains("ability")).thenReturn(false);
+
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "bleed"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("invalid ability key returns NEVER_MATCH filter")
+        public void parseConfig_returnsNeverMatch_whenAbilityKeyInvalid() {
+            Section section = mock(Section.class);
+            when(section.contains("ability-type")).thenReturn(false);
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("not a valid key!!!");
+
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "bleed"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("ability key takes priority over ability type when both present")
+        public void parseConfig_abilityKeyTakesPriority_whenBothPresent() {
+            Section section = mock(Section.class);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("PASSIVE");
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("mcrpg:bleed");
+
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            Ability matchingKey = mock(Ability.class);
+            when(matchingKey.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(matchingKey.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(matchingKey);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "bleed"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — specific ability key filter")
+    class ProcessProgressAbilityKeyFilter {
+
+        private LoadoutEquipObjectiveType configured;
+
+        @BeforeEach
+        public void setupConfigured() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(true);
+            when(section.getString("ability")).thenReturn("mcrpg:bleed");
+            when(section.contains("ability-type")).thenReturn(false);
+            configured = baseType.parseConfig(section);
+        }
+
+        @Test
+        @DisplayName("returns 1 when ability key matches")
+        public void processProgress_returnsOne_whenKeyMatches() {
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "bleed"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 when ability key does not match")
+        public void processProgress_returnsZero_whenKeyDoesNotMatch() {
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "vampire"));
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "vampire"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress — ability type filter")
+    class ProcessProgressAbilityTypeFilter {
+
+        @Test
+        @DisplayName("returns 1 when PASSIVE filter matches PASSIVE ability")
+        public void processProgress_returnsOne_whenPassiveTypeMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("PASSIVE");
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "bleed"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.PASSIVE);
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "bleed"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 when PASSIVE filter does not match ACTIVE ability")
+        public void processProgress_returnsZero_whenPassiveFilterDoesNotMatchActive() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("PASSIVE");
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "rage_spike"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "rage_spike"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 1 when ACTIVE filter matches ACTIVE ability")
+        public void processProgress_returnsOne_whenActiveTypeMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("ACTIVE");
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "rage_spike"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.ACTIVE);
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "rage_spike"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 1 when INNATE filter matches INNATE ability")
+        public void processProgress_returnsOne_whenInnateTypeMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("ability")).thenReturn(false);
+            when(section.contains("ability-type")).thenReturn(true);
+            when(section.getString("ability-type")).thenReturn("INNATE");
+            LoadoutEquipObjectiveType configured = baseType.parseConfig(section);
+
+            Ability ability = mock(Ability.class);
+            when(ability.getAbilityKey()).thenReturn(new NamespacedKey("mcrpg", "some_innate"));
+            when(ability.getAbilityType()).thenReturn(AbilityType.INNATE);
+            RegistryAccess.registryAccess().registry(McRPGRegistryKey.ABILITY)
+                    .register(ability);
+
+            LoadoutAbilityChangeEvent event = createEquipEvent(new NamespacedKey("mcrpg", "some_innate"));
+            LoadoutEquipQuestContext context = new LoadoutEquipQuestContext(event);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1, configured.processProgress(instance, context));
+        }
+    }
+
+    private LoadoutAbilityChangeEvent createEquipEvent(NamespacedKey abilityKey) {
+        return new LoadoutAbilityChangeEvent(
+                UUID.randomUUID(),
+                LoadoutAbilityChangeEvent.ChangeReason.EQUIP,
+                null,
+                abilityKey,
+                0
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Rewrite `AbilityObjectiveFilterTest` with `@Nested` groups, proper `action_outcome_whenCondition` naming, and new coverage for `resolveAbilityName`, `AbilityType.fromString`, and `Ability.getAbilityType` default method
- Add `LoadoutEquipObjectiveTypeCoverageTest` (~19 tests) covering identity, `canProcess`, `processProgress` with key/type/empty filters, and `parseConfig` edge cases (invalid key, invalid type, key-takes-priority)
- Add `AdvancementCompleteObjectiveTypeCoverageTest` (~15 tests) covering identity, `canProcess`, `processProgress` with empty/specific advancement filters, and `parseConfig` including empty list behavior
- Add `AbilityUnlockObjectiveTypeCoverageTest` (~21 tests) covering identity, `canProcess`, `processProgress` with key/type filters, and `parseConfig` with invalid inputs and priority behavior

## Test plan

- [x] All 4 test files pass individually
- [x] Full test suite passes (`./gradlew test` — 4959+ tests, zero failures)
- [x] Testing audit persona applied — no concerns found


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPMNzpsQGwybVpU2AtBkyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPMNzpsQGwybVpU2AtBkyx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for ability, advancement, and loadout objective filters.
  * Added validation for context compatibility, progress matching, configuration parsing, invalid filters, and filter precedence.
  * Added coverage for ability type detection, name resolution, sentinel behavior, and advancement list handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->