### PR TITLE
[Unit Tests] Add coverage for BreedAnimal objective and experience reward types

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BreedAnimalObjectiveTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/BreedAnimalObjectiveTypeCoverageTest.java
@@ -1,0 +1,198 @@
+package us.eunoians.mcrpg.quest.objective.type.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityBreedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.impl.objective.QuestObjectiveInstance;
+import us.eunoians.mcrpg.quest.objective.type.QuestObjectiveProgressContext;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BreedAnimalObjectiveTypeCoverageTest extends McRPGBaseTest {
+
+    private BreedAnimalObjectiveType type;
+
+    @BeforeEach
+    void setUp() {
+        type = new BreedAnimalObjectiveType();
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("no entities key accepts any entity")
+        void parseConfig_acceptsAnyEntity_whenNoEntitiesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.RABBIT);
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            assertEquals(1L, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("parses entities list and restricts matching")
+        void parseConfig_restrictsToListedEntities() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW", "PIG"));
+
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity cowEntity = mock(LivingEntity.class);
+            when(cowEntity.getType()).thenReturn(EntityType.COW);
+            EntityBreedEvent cowEvent = mock(EntityBreedEvent.class);
+            when(cowEvent.getEntity()).thenReturn(cowEntity);
+
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1L, configured.processProgress(instance, new BreedAnimalQuestContext(cowEvent)));
+
+            LivingEntity wolfEntity = mock(LivingEntity.class);
+            when(wolfEntity.getType()).thenReturn(EntityType.WOLF);
+            EntityBreedEvent wolfEvent = mock(EntityBreedEvent.class);
+            when(wolfEvent.getEntity()).thenReturn(wolfEntity);
+
+            assertEquals(0L, configured.processProgress(instance, new BreedAnimalQuestContext(wolfEvent)));
+        }
+    }
+
+    @Nested
+    @DisplayName("processProgress")
+    class ProcessProgress {
+
+        @Test
+        @DisplayName("returns 0 for wrong context type")
+        void processProgress_returnsZero_whenWrongContextType() {
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0L, type.processProgress(instance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured type returns 1 for any breed event")
+        void processProgress_returnsOne_whenUnconfigured() {
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.COW);
+
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1L, type.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 1 when entity matches filter")
+        void processProgress_returnsOne_whenEntityMatchesFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW"));
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.COW);
+
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1L, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 when entity does not match filter")
+        void processProgress_returnsZero_whenEntityDoesNotMatchFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW"));
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.PIG);
+
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0L, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 1 when one of multiple entities matches")
+        void processProgress_returnsOne_whenOneOfMultipleEntitiesMatches() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW", "SHEEP", "PIG"));
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.SHEEP);
+
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1L, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("returns 0 when entity type matches none in multi-entity filter")
+        void processProgress_returnsZero_whenEntityMatchesNoneInMultiFilter() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("COW", "SHEEP"));
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.CHICKEN);
+
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(0L, configured.processProgress(instance, context));
+        }
+
+        @Test
+        @DisplayName("parsed config with no entities key returns 1 for any entity")
+        void processProgress_returnsOne_whenParsedWithNoEntitiesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            BreedAnimalObjectiveType configured = type.parseConfig(section);
+
+            LivingEntity childEntity = mock(LivingEntity.class);
+            when(childEntity.getType()).thenReturn(EntityType.WOLF);
+
+            EntityBreedEvent event = mock(EntityBreedEvent.class);
+            when(event.getEntity()).thenReturn(childEntity);
+
+            BreedAnimalQuestContext context = new BreedAnimalQuestContext(event);
+            QuestObjectiveInstance instance = mock(QuestObjectiveInstance.class);
+            assertEquals(1L, configured.processProgress(instance, context));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/BoostedExperienceRewardTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/BoostedExperienceRewardTypeCoverageTest.java
@@ -1,0 +1,295 @@
+package us.eunoians.mcrpg.quest.reward.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BoostedExperienceRewardTypeCoverageTest extends McRPGBaseTest {
+
+    private BoostedExperienceRewardType type;
+
+    @BeforeEach
+    void setUp() {
+        type = new BoostedExperienceRewardType();
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("parses amount from section")
+        void parseConfig_parsesAmount() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(500);
+
+            BoostedExperienceRewardType configured = type.parseConfig(section);
+
+            assertEquals(500L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("defaults to 0 when amount is missing")
+        void parseConfig_defaultsToZero_whenAmountMissing() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(0);
+
+            BoostedExperienceRewardType configured = type.parseConfig(section);
+
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("handles negative amount without throwing")
+        void parseConfig_handlesNegativeAmount() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(-5);
+
+            BoostedExperienceRewardType configured = type.parseConfig(section);
+
+            assertEquals(-5L, configured.getNumericAmount().orElse(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("isScalable")
+    class IsScalable {
+
+        @Test
+        @DisplayName("returns true")
+        void isScalable_returnsTrue() {
+            assertTrue(type.isScalable());
+        }
+    }
+
+    @Nested
+    @DisplayName("withExactAmount")
+    class WithExactAmount {
+
+        @Test
+        @DisplayName("sets the exact amount")
+        void withExactAmount_setsExactAmount() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            BoostedExperienceRewardType exact = configured.withExactAmount(999);
+            assertEquals(999L, exact.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("preserves localization route and display label")
+        void withExactAmount_preservesMetadata() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 100, "display", "My Label"));
+            BoostedExperienceRewardType exact = configured.withExactAmount(500);
+            Map<String, Object> serialized = exact.serializeConfig();
+            assertEquals(500, ((Number) serialized.get("amount")).intValue());
+            assertEquals("My Label", serialized.get("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withLocalizationRoute")
+    class WithLocalizationRoute {
+
+        @Test
+        @DisplayName("stores localization route in serialized config")
+        void withLocalizationRoute_storesRoute() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 200));
+            BoostedExperienceRewardType withRoute = configured.withLocalizationRoute(
+                    dev.dejvokep.boostedyaml.route.Route.fromString("quests.test.rewards.xp"));
+            Map<String, Object> serialized = withRoute.serializeConfig();
+            assertEquals("quests.test.rewards.xp", serialized.get("localization-route"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withInlineDisplayLabel")
+    class WithInlineDisplayLabel {
+
+        @Test
+        @DisplayName("stores display label in serialized config")
+        void withInlineDisplayLabel_storesLabel() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 300));
+            BoostedExperienceRewardType withLabel = configured.withInlineDisplayLabel("Custom Label");
+            Map<String, Object> serialized = withLabel.serializeConfig();
+            assertEquals("Custom Label", serialized.get("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("omits display when empty")
+        void serializeConfig_omitsDisplay_whenEmpty() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("display"));
+        }
+
+        @Test
+        @DisplayName("omits localization-route when null")
+        void serializeConfig_omitsRoute_whenNull() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("localization-route"));
+        }
+
+        @Test
+        @DisplayName("includes display when set")
+        void serializeConfig_includesDisplay_whenSet() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 100, "display", "Test Display"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("Test Display", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("includes localization-route when set")
+        void serializeConfig_includesRoute_whenSet() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 100);
+            config.put("localization-route", "quests.my.route");
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("quests.my.route", serialized.get("localization-route"));
+        }
+    }
+
+    @Nested
+    @DisplayName("fromSerializedConfig")
+    class FromSerializedConfig {
+
+        @Test
+        @DisplayName("handles missing amount key")
+        void fromSerializedConfig_handlesNoAmountKey() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of());
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("parses Number type for amount")
+        void fromSerializedConfig_parsesNumber() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 750));
+            assertEquals(750L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("parses String number for amount")
+        void fromSerializedConfig_parsesStringNumber() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", "123"));
+            assertEquals(123L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("returns 0 for non-numeric string amount")
+        void fromSerializedConfig_returnsZero_whenNonNumericString() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", "not_a_number"));
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("deserializes display label")
+        void fromSerializedConfig_deserializesDisplayLabel() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 100);
+            config.put("display", "Custom Display");
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("Custom Display", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("deserializes localization-route")
+        void fromSerializedConfig_deserializesLocalizationRoute() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 100);
+            config.put("localization-route", "path.to.label");
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("path.to.label", serialized.get("localization-route"));
+        }
+
+        @Test
+        @DisplayName("defaults display to empty when absent")
+        void fromSerializedConfig_defaultsDisplayToEmpty() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 50));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("describeForDisplay")
+    class DescribeForDisplay {
+
+        @Test
+        @DisplayName("includes amount in no-arg description")
+        void describeForDisplay_includesAmount() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 500));
+            String description = configured.describeForDisplay();
+            assertEquals("500 Boosted XP", description);
+        }
+
+        @Test
+        @DisplayName("zero amount returns '0 Boosted XP'")
+        void describeForDisplay_zeroAmount() {
+            String description = type.describeForDisplay();
+            assertEquals("0 Boosted XP", description);
+        }
+    }
+
+    @Nested
+    @DisplayName("withAmountMultiplier")
+    class WithAmountMultiplier {
+
+        @Test
+        @DisplayName("preserves display label through scaling")
+        void withAmountMultiplier_preservesDisplayLabel() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 100, "display", "My Label"));
+            BoostedExperienceRewardType scaled = configured.withAmountMultiplier(2.0);
+            Map<String, Object> serialized = scaled.serializeConfig();
+            assertEquals("My Label", serialized.get("display"));
+            assertEquals(200, ((Number) serialized.get("amount")).intValue());
+        }
+
+        @Test
+        @DisplayName("truncates fractional result to int")
+        void withAmountMultiplier_truncatesFractionalResult() {
+            BoostedExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            BoostedExperienceRewardType scaled = configured.withAmountMultiplier(0.33);
+            assertEquals(33L, scaled.getNumericAmount().orElse(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("getNumericAmount")
+    class GetNumericAmount {
+
+        @Test
+        @DisplayName("always returns present OptionalLong")
+        void getNumericAmount_alwaysPresent() {
+            assertTrue(type.getNumericAmount().isPresent());
+        }
+
+        @Test
+        @DisplayName("unconfigured type returns 0")
+        void getNumericAmount_returnsZero_whenUnconfigured() {
+            assertEquals(0L, type.getNumericAmount().getAsLong());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableExperienceRewardTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableExperienceRewardTypeCoverageTest.java
@@ -1,0 +1,339 @@
+package us.eunoians.mcrpg.quest.reward.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedeemableExperienceRewardTypeCoverageTest extends McRPGBaseTest {
+
+    private RedeemableExperienceRewardType type;
+
+    @BeforeEach
+    void setUp() {
+        type = new RedeemableExperienceRewardType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns redeemable_experience key")
+        void getKey_returnsExpectedKey() {
+            assertEquals(RedeemableExperienceRewardType.KEY, type.getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(type.getExpansionKey().isPresent());
+            assertEquals(us.eunoians.mcrpg.expansion.McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("parses amount from section")
+        void parseConfig_parsesAmount() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(500);
+
+            RedeemableExperienceRewardType configured = type.parseConfig(section);
+
+            assertEquals(500L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("defaults to 0 when amount is missing")
+        void parseConfig_defaultsToZero_whenAmountMissing() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(0);
+
+            RedeemableExperienceRewardType configured = type.parseConfig(section);
+
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("handles negative amount without throwing")
+        void parseConfig_handlesNegativeAmount() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(-10);
+
+            RedeemableExperienceRewardType configured = type.parseConfig(section);
+
+            assertEquals(-10L, configured.getNumericAmount().orElse(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("isScalable")
+    class IsScalable {
+
+        @Test
+        @DisplayName("returns true")
+        void isScalable_returnsTrue() {
+            assertTrue(type.isScalable());
+        }
+    }
+
+    @Nested
+    @DisplayName("withExactAmount")
+    class WithExactAmount {
+
+        @Test
+        @DisplayName("sets the exact amount")
+        void withExactAmount_setsExactAmount() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            RedeemableExperienceRewardType exact = configured.withExactAmount(999);
+            assertEquals(999L, exact.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("preserves display label")
+        void withExactAmount_preservesDisplayLabel() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 100, "display", "My Label"));
+            RedeemableExperienceRewardType exact = configured.withExactAmount(500);
+            Map<String, Object> serialized = exact.serializeConfig();
+            assertEquals(500, ((Number) serialized.get("amount")).intValue());
+            assertEquals("My Label", serialized.get("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withLocalizationRoute")
+    class WithLocalizationRoute {
+
+        @Test
+        @DisplayName("stores localization route in serialized config")
+        void withLocalizationRoute_storesRoute() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 200));
+            RedeemableExperienceRewardType withRoute = configured.withLocalizationRoute(
+                    dev.dejvokep.boostedyaml.route.Route.fromString("quests.test.rewards.xp"));
+            Map<String, Object> serialized = withRoute.serializeConfig();
+            assertEquals("quests.test.rewards.xp", serialized.get("localization-route"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withInlineDisplayLabel")
+    class WithInlineDisplayLabel {
+
+        @Test
+        @DisplayName("stores display label in serialized config")
+        void withInlineDisplayLabel_storesLabel() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 300));
+            RedeemableExperienceRewardType withLabel = configured.withInlineDisplayLabel("Custom Label");
+            Map<String, Object> serialized = withLabel.serializeConfig();
+            assertEquals("Custom Label", serialized.get("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("omits display when empty")
+        void serializeConfig_omitsDisplay_whenEmpty() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("display"));
+        }
+
+        @Test
+        @DisplayName("omits localization-route when null")
+        void serializeConfig_omitsRoute_whenNull() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("localization-route"));
+        }
+
+        @Test
+        @DisplayName("includes display when set")
+        void serializeConfig_includesDisplay_whenSet() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 100, "display", "Test Display"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("Test Display", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("includes localization-route when set")
+        void serializeConfig_includesRoute_whenSet() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 100);
+            config.put("localization-route", "quests.my.route");
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("quests.my.route", serialized.get("localization-route"));
+        }
+
+        @Test
+        @DisplayName("round-trips amount correctly")
+        void serializeConfig_roundTripsAmount() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 250));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(250, ((Number) serialized.get("amount")).intValue());
+        }
+    }
+
+    @Nested
+    @DisplayName("fromSerializedConfig")
+    class FromSerializedConfig {
+
+        @Test
+        @DisplayName("handles missing amount key")
+        void fromSerializedConfig_handlesNoAmountKey() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of());
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("parses Number type for amount")
+        void fromSerializedConfig_parsesNumber() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 750));
+            assertEquals(750L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("parses String number for amount")
+        void fromSerializedConfig_parsesStringNumber() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", "123"));
+            assertEquals(123L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("returns 0 for non-numeric string amount")
+        void fromSerializedConfig_returnsZero_whenNonNumericString() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", "not_a_number"));
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("deserializes display label")
+        void fromSerializedConfig_deserializesDisplayLabel() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 100);
+            config.put("display", "Custom Display");
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("Custom Display", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("deserializes localization-route")
+        void fromSerializedConfig_deserializesLocalizationRoute() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 100);
+            config.put("localization-route", "path.to.label");
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("path.to.label", serialized.get("localization-route"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withAmountMultiplier")
+    class WithAmountMultiplier {
+
+        @Test
+        @DisplayName("scales amount correctly")
+        void withAmountMultiplier_scalesAmount() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            RedeemableExperienceRewardType doubled = configured.withAmountMultiplier(2.0);
+            assertEquals(200L, doubled.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("enforces minimum of 1")
+        void withAmountMultiplier_enforcesMinimumOfOne() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 1));
+            RedeemableExperienceRewardType scaled = configured.withAmountMultiplier(0.001);
+            assertTrue(scaled.getNumericAmount().orElse(0) >= 1);
+        }
+
+        @Test
+        @DisplayName("preserves display label through scaling")
+        void withAmountMultiplier_preservesDisplayLabel() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 100, "display", "My Label"));
+            RedeemableExperienceRewardType scaled = configured.withAmountMultiplier(2.0);
+            Map<String, Object> serialized = scaled.serializeConfig();
+            assertEquals("My Label", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("truncates fractional result to int")
+        void withAmountMultiplier_truncatesFractionalResult() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            RedeemableExperienceRewardType scaled = configured.withAmountMultiplier(0.33);
+            assertEquals(33L, scaled.getNumericAmount().orElse(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("describeForDisplay")
+    class DescribeForDisplay {
+
+        @Test
+        @DisplayName("includes amount in no-arg description")
+        void describeForDisplay_includesAmount() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 500));
+            assertEquals("500 Redeemable XP", configured.describeForDisplay());
+        }
+
+        @Test
+        @DisplayName("zero amount returns '0 Redeemable XP'")
+        void describeForDisplay_zeroAmount() {
+            assertEquals("0 Redeemable XP", type.describeForDisplay());
+        }
+
+        @Test
+        @DisplayName("returns non-null string")
+        void describeForDisplay_returnsNonNull() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 100));
+            assertFalse(configured.describeForDisplay().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("getNumericAmount")
+    class GetNumericAmount {
+
+        @Test
+        @DisplayName("always returns present OptionalLong")
+        void getNumericAmount_alwaysPresent() {
+            assertTrue(type.getNumericAmount().isPresent());
+        }
+
+        @Test
+        @DisplayName("unconfigured type returns 0")
+        void getNumericAmount_returnsZero_whenUnconfigured() {
+            assertEquals(0L, type.getNumericAmount().getAsLong());
+        }
+
+        @Test
+        @DisplayName("configured type returns configured amount")
+        void getNumericAmount_returnsConfiguredAmount() {
+            RedeemableExperienceRewardType configured = type.fromSerializedConfig(Map.of("amount", 750));
+            assertEquals(750L, configured.getNumericAmount().getAsLong());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableLevelsRewardTypeCoverageTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/reward/builtin/RedeemableLevelsRewardTypeCoverageTest.java
@@ -1,0 +1,339 @@
+package us.eunoians.mcrpg.quest.reward.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedeemableLevelsRewardTypeCoverageTest extends McRPGBaseTest {
+
+    private RedeemableLevelsRewardType type;
+
+    @BeforeEach
+    void setUp() {
+        type = new RedeemableLevelsRewardType();
+    }
+
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("getKey returns redeemable_levels key")
+        void getKey_returnsExpectedKey() {
+            assertEquals(RedeemableLevelsRewardType.KEY, type.getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns McRPGExpansion key")
+        void getExpansionKey_returnsMcRPGExpansionKey() {
+            assertTrue(type.getExpansionKey().isPresent());
+            assertEquals(us.eunoians.mcrpg.expansion.McRPGExpansion.EXPANSION_KEY, type.getExpansionKey().get());
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig")
+    class ParseConfig {
+
+        @Test
+        @DisplayName("parses amount from section")
+        void parseConfig_parsesAmount() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(3);
+
+            RedeemableLevelsRewardType configured = type.parseConfig(section);
+
+            assertEquals(3L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("defaults to 0 when amount is missing")
+        void parseConfig_defaultsToZero_whenAmountMissing() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(0);
+
+            RedeemableLevelsRewardType configured = type.parseConfig(section);
+
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("handles negative amount without throwing")
+        void parseConfig_handlesNegativeAmount() {
+            Section section = mock(Section.class);
+            when(section.getInt("amount", 0)).thenReturn(-2);
+
+            RedeemableLevelsRewardType configured = type.parseConfig(section);
+
+            assertEquals(-2L, configured.getNumericAmount().orElse(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("isScalable")
+    class IsScalable {
+
+        @Test
+        @DisplayName("returns true")
+        void isScalable_returnsTrue() {
+            assertTrue(type.isScalable());
+        }
+    }
+
+    @Nested
+    @DisplayName("withExactAmount")
+    class WithExactAmount {
+
+        @Test
+        @DisplayName("sets the exact amount")
+        void withExactAmount_setsExactAmount() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 5));
+            RedeemableLevelsRewardType exact = configured.withExactAmount(20);
+            assertEquals(20L, exact.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("preserves display label")
+        void withExactAmount_preservesDisplayLabel() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 5, "display", "My Levels"));
+            RedeemableLevelsRewardType exact = configured.withExactAmount(10);
+            Map<String, Object> serialized = exact.serializeConfig();
+            assertEquals(10, ((Number) serialized.get("amount")).intValue());
+            assertEquals("My Levels", serialized.get("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withLocalizationRoute")
+    class WithLocalizationRoute {
+
+        @Test
+        @DisplayName("stores localization route in serialized config")
+        void withLocalizationRoute_storesRoute() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 5));
+            RedeemableLevelsRewardType withRoute = configured.withLocalizationRoute(
+                    dev.dejvokep.boostedyaml.route.Route.fromString("quests.test.rewards.levels"));
+            Map<String, Object> serialized = withRoute.serializeConfig();
+            assertEquals("quests.test.rewards.levels", serialized.get("localization-route"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withInlineDisplayLabel")
+    class WithInlineDisplayLabel {
+
+        @Test
+        @DisplayName("stores display label in serialized config")
+        void withInlineDisplayLabel_storesLabel() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 10));
+            RedeemableLevelsRewardType withLabel = configured.withInlineDisplayLabel("Custom Levels");
+            Map<String, Object> serialized = withLabel.serializeConfig();
+            assertEquals("Custom Levels", serialized.get("display"));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializeConfig")
+    class SerializeConfig {
+
+        @Test
+        @DisplayName("omits display when empty")
+        void serializeConfig_omitsDisplay_whenEmpty() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 5));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("display"));
+        }
+
+        @Test
+        @DisplayName("omits localization-route when null")
+        void serializeConfig_omitsRoute_whenNull() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 5));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertFalse(serialized.containsKey("localization-route"));
+        }
+
+        @Test
+        @DisplayName("includes display when set")
+        void serializeConfig_includesDisplay_whenSet() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 5, "display", "Test Display"));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("Test Display", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("includes localization-route when set")
+        void serializeConfig_includesRoute_whenSet() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 5);
+            config.put("localization-route", "quests.my.route");
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("quests.my.route", serialized.get("localization-route"));
+        }
+
+        @Test
+        @DisplayName("round-trips amount correctly")
+        void serializeConfig_roundTripsAmount() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 8));
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals(8, ((Number) serialized.get("amount")).intValue());
+        }
+    }
+
+    @Nested
+    @DisplayName("fromSerializedConfig")
+    class FromSerializedConfig {
+
+        @Test
+        @DisplayName("handles missing amount key")
+        void fromSerializedConfig_handlesNoAmountKey() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of());
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("parses Number type for amount")
+        void fromSerializedConfig_parsesNumber() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 15));
+            assertEquals(15L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("parses String number for amount")
+        void fromSerializedConfig_parsesStringNumber() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", "7"));
+            assertEquals(7L, configured.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("returns 0 for non-numeric string amount")
+        void fromSerializedConfig_returnsZero_whenNonNumericString() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", "not_a_number"));
+            assertEquals(0L, configured.getNumericAmount().orElse(-1));
+        }
+
+        @Test
+        @DisplayName("deserializes display label")
+        void fromSerializedConfig_deserializesDisplayLabel() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 5);
+            config.put("display", "Custom Display");
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("Custom Display", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("deserializes localization-route")
+        void fromSerializedConfig_deserializesLocalizationRoute() {
+            Map<String, Object> config = new HashMap<>();
+            config.put("amount", 5);
+            config.put("localization-route", "path.to.label");
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(config);
+            Map<String, Object> serialized = configured.serializeConfig();
+            assertEquals("path.to.label", serialized.get("localization-route"));
+        }
+    }
+
+    @Nested
+    @DisplayName("withAmountMultiplier")
+    class WithAmountMultiplier {
+
+        @Test
+        @DisplayName("scales amount correctly")
+        void withAmountMultiplier_scalesAmount() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 10));
+            RedeemableLevelsRewardType tripled = configured.withAmountMultiplier(3.0);
+            assertEquals(30L, tripled.getNumericAmount().orElse(0));
+        }
+
+        @Test
+        @DisplayName("enforces minimum of 1")
+        void withAmountMultiplier_enforcesMinimumOfOne() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 1));
+            RedeemableLevelsRewardType scaled = configured.withAmountMultiplier(0.001);
+            assertTrue(scaled.getNumericAmount().orElse(0) >= 1);
+        }
+
+        @Test
+        @DisplayName("preserves display label through scaling")
+        void withAmountMultiplier_preservesDisplayLabel() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(
+                    Map.of("amount", 10, "display", "My Levels"));
+            RedeemableLevelsRewardType scaled = configured.withAmountMultiplier(2.0);
+            Map<String, Object> serialized = scaled.serializeConfig();
+            assertEquals("My Levels", serialized.get("display"));
+        }
+
+        @Test
+        @DisplayName("truncates fractional result to int")
+        void withAmountMultiplier_truncatesFractionalResult() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 10));
+            RedeemableLevelsRewardType scaled = configured.withAmountMultiplier(0.33);
+            assertEquals(3L, scaled.getNumericAmount().orElse(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("describeForDisplay")
+    class DescribeForDisplay {
+
+        @Test
+        @DisplayName("includes amount in no-arg description")
+        void describeForDisplay_includesAmount() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 5));
+            assertEquals("5 Redeemable Level(s)", configured.describeForDisplay());
+        }
+
+        @Test
+        @DisplayName("zero amount returns '0 Redeemable Level(s)'")
+        void describeForDisplay_zeroAmount() {
+            assertEquals("0 Redeemable Level(s)", type.describeForDisplay());
+        }
+
+        @Test
+        @DisplayName("returns non-null string")
+        void describeForDisplay_returnsNonNull() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 3));
+            assertFalse(configured.describeForDisplay().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("getNumericAmount")
+    class GetNumericAmount {
+
+        @Test
+        @DisplayName("always returns present OptionalLong")
+        void getNumericAmount_alwaysPresent() {
+            assertTrue(type.getNumericAmount().isPresent());
+        }
+
+        @Test
+        @DisplayName("unconfigured type returns 0")
+        void getNumericAmount_returnsZero_whenUnconfigured() {
+            assertEquals(0L, type.getNumericAmount().getAsLong());
+        }
+
+        @Test
+        @DisplayName("configured type returns configured amount")
+        void getNumericAmount_returnsConfiguredAmount() {
+            RedeemableLevelsRewardType configured = type.fromSerializedConfig(Map.of("amount", 15));
+            assertEquals(15L, configured.getNumericAmount().getAsLong());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `BreedAnimalObjectiveTypeCoverageTest` — covers `parseConfig` (with/without entities key), `processProgress` (entity filter matching, non-matching, multi-entity, wrong context type)
- Add `BoostedExperienceRewardTypeCoverageTest` — covers `parseConfig`, `isScalable`, `withExactAmount`, `withLocalizationRoute`, `withInlineDisplayLabel`, `serializeConfig` conditional fields, `fromSerializedConfig` edge cases (missing key, String number, non-numeric), `describeForDisplay`, `withAmountMultiplier` metadata preservation
- Add `RedeemableExperienceRewardTypeCoverageTest` — full coverage of identity, parseConfig, scaling, serialization, deserialization edge cases, and display
- Add `RedeemableLevelsRewardTypeCoverageTest` — same coverage pattern as the other reward types

These supplement existing minimal test files (`BreedAnimalObjectiveTypeTest`, `BoostedExperienceRewardTypeTest`) which only covered identity and basic operations.

## Test plan

- [x] All new tests pass (`./gradlew test` — BUILD SUCCESSFUL)
- [x] No regressions in existing tests
- [x] Testing audit persona reviewed and findings addressed (unused import removed, weak assertions strengthened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6ZFAWio9YD8RoZLt2uAdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6ZFAWio9YD8RoZLt2uAdE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for animal-breeding objectives.
  * Added coverage for boosted experience, redeemable experience, and redeemable levels rewards.
  * Verified configuration parsing, serialization, scaling, display text, metadata handling, and numeric amount behavior.
  * Covered defaults, invalid values, negative amounts, entity matching, and fractional scaling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->