### PR TITLE
[Unit Tests] Expand DAO test coverage for QuestStageInstance, QuestObjectiveContribution, and BoardCooldown

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/database/table/board/BoardCooldownDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/BoardCooldownDAOTest.java
@@ -1,8 +1,12 @@
 package us.eunoians.mcrpg.database.table.board;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
 import java.sql.Connection;
@@ -16,108 +20,519 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
+@DisplayName("BoardCooldownDAO")
 public class BoardCooldownDAOTest extends McRPGBaseTest {
 
-    @DisplayName("saveCooldown returns prepared statements")
-    @Test
-    void saveCooldown_returnsPreparedStatements() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("saveCooldown")
+    class SaveCooldown {
 
-        List<PreparedStatement> statements = BoardCooldownDAO.saveCooldown(
-                mockConnection,
-                "cooldown-1",
-                "rotation",
-                "player",
-                UUID.randomUUID().toString(),
-                new NamespacedKey("mcrpg", "mine_stone"),
-                new NamespacedKey("mcrpg", "daily_personal"),
-                1000000L
-        );
+        @DisplayName("Given all non-null keys, when saving, then prepared statements are returned")
+        @Test
+        void saveCooldown_allKeys_returnsPreparedStatements() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertNotNull(statements);
-        assertFalse(statements.isEmpty());
+            List<PreparedStatement> statements = BoardCooldownDAO.saveCooldown(
+                    mockConnection,
+                    "cooldown-1",
+                    "rotation",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    new NamespacedKey("mcrpg", "mine_stone"),
+                    new NamespacedKey("mcrpg", "daily_personal"),
+                    1000000L
+            );
+
+            assertNotNull(statements);
+            assertEquals(1, statements.size());
+        }
+
+        @DisplayName("Given null keys, when saving, then setNull is called for both nullable columns")
+        @Test
+        void saveCooldown_nullKeys_setsNull() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            BoardCooldownDAO.saveCooldown(
+                    mockConnection,
+                    "cooldown-2",
+                    "rotation",
+                    "land",
+                    "land-uuid-123",
+                    null,
+                    null,
+                    2000000L
+            );
+
+            verify(mockStatement).setNull(eq(5), eq(Types.VARCHAR));
+            verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+        }
+
+        @DisplayName("Given all parameters, when saving, then all parameters are bound correctly")
+        @Test
+        void saveCooldown_bindsAllParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            String cooldownId = "cd-123";
+            String cooldownType = "quest_repeat";
+            String scopeType = "player";
+            String scopeId = UUID.randomUUID().toString();
+            NamespacedKey questKey = new NamespacedKey("mcrpg", "mine_stone");
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily");
+            long expiresAt = 9999999L;
+
+            BoardCooldownDAO.saveCooldown(mockConnection, cooldownId, cooldownType, scopeType, scopeId, questKey, categoryKey, expiresAt);
+
+            verify(mockStatement).setString(eq(1), eq(cooldownId));
+            verify(mockStatement).setString(eq(2), eq(cooldownType));
+            verify(mockStatement).setString(eq(3), eq(scopeType));
+            verify(mockStatement).setString(eq(4), eq(scopeId));
+            verify(mockStatement).setString(eq(5), eq(questKey.toString()));
+            verify(mockStatement).setString(eq(6), eq(categoryKey.toString()));
+            verify(mockStatement).setLong(eq(7), eq(expiresAt));
+        }
+
+        @DisplayName("Given a SQLException from prepareStatement, when saving, then empty list is returned")
+        @Test
+        void saveCooldown_sqlException_returnsEmptyList() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            List<PreparedStatement> result = BoardCooldownDAO.saveCooldown(
+                    mockConnection, "cd-err", "type", "scope", "id", null, null, 0L
+            );
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("saveCooldown handles null keys")
-    @Test
-    void saveCooldown_handlesNullKeys() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("isOnCooldown")
+    class IsOnCooldown {
 
-        BoardCooldownDAO.saveCooldown(
-                mockConnection,
-                "cooldown-2",
-                "rotation",
-                "land",
-                "land-uuid-123",
-                null,
-                null,
-                2000000L
-        );
+        @DisplayName("Given no matching rows, when checking cooldown, then returns false")
+        @Test
+        void isOnCooldown_noResults_returnsFalse() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        verify(mockStatement).setNull(eq(5), eq(Types.VARCHAR));
-        verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+            boolean result = BoardCooldownDAO.isOnCooldown(
+                    mockConnection, "rotation", "player", UUID.randomUUID().toString(), null, null
+            );
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Given a matching row, when checking cooldown, then returns true")
+        @Test
+        void isOnCooldown_hasResult_returnsTrue() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+
+            boolean result = BoardCooldownDAO.isOnCooldown(
+                    mockConnection, "rotation", "player", UUID.randomUUID().toString(), null, null
+            );
+
+            assertTrue(result);
+        }
+
+        @DisplayName("Given both optional keys are provided, when checking, then all parameters are bound")
+        @Test
+        void isOnCooldown_withBothKeys_bindsAllParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            String scopeId = UUID.randomUUID().toString();
+            NamespacedKey questKey = new NamespacedKey("mcrpg", "mine_stone");
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily");
+
+            BoardCooldownDAO.isOnCooldown(mockConnection, "quest_repeat", "player", scopeId, questKey, categoryKey);
+
+            verify(mockStatement).setString(eq(1), eq("quest_repeat"));
+            verify(mockStatement).setString(eq(2), eq("player"));
+            verify(mockStatement).setString(eq(3), eq(scopeId));
+            verify(mockStatement).setString(eq(5), eq(questKey.toString()));
+            verify(mockStatement).setString(eq(6), eq(categoryKey.toString()));
+        }
+
+        @DisplayName("Given only questDefinitionKey is provided, when checking, then questKey is bound at index 5")
+        @Test
+        void isOnCooldown_withQuestKeyOnly_bindsCorrectly() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            NamespacedKey questKey = new NamespacedKey("mcrpg", "mine_stone");
+
+            BoardCooldownDAO.isOnCooldown(mockConnection, "quest_repeat", "player", "scope-id", questKey, null);
+
+            verify(mockStatement).setString(eq(5), eq(questKey.toString()));
+            verify(mockStatement, never()).setString(eq(6), anyString());
+        }
+
+        @DisplayName("Given only categoryKey is provided, when checking, then categoryKey is bound at index 5")
+        @Test
+        void isOnCooldown_withCategoryKeyOnly_bindsCategoryAtIndex5() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily");
+
+            BoardCooldownDAO.isOnCooldown(mockConnection, "rotation", "player", "scope-id", null, categoryKey);
+
+            verify(mockStatement).setString(eq(5), eq(categoryKey.toString()));
+            verify(mockStatement, never()).setString(eq(6), anyString());
+        }
+
+        @DisplayName("Given a SQLException from executeQuery, when checking, then returns false")
+        @Test
+        void isOnCooldown_sqlException_returnsFalse() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenThrow(new SQLException("Test exception"));
+
+            boolean result = BoardCooldownDAO.isOnCooldown(
+                    mockConnection, "rotation", "player", "scope-id", null, null
+            );
+
+            assertFalse(result);
+        }
     }
 
-    @DisplayName("isOnCooldown returns false when no results")
-    @Test
-    void isOnCooldown_returnsFalseWhenNoResults() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+    @Nested
+    @DisplayName("listCooldowns")
+    class ListCooldowns {
 
-        boolean result = BoardCooldownDAO.isOnCooldown(
-                mockConnection,
-                "rotation",
-                "player",
-                UUID.randomUUID().toString(),
-                null,
-                null
-        );
+        @DisplayName("Given cooldown rows exist, when listing, then records are returned")
+        @Test
+        void listCooldowns_withRows_returnsRecords() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(true, true, false);
 
-        assertFalse(result);
+            when(mockRs.getString("cooldown_type")).thenReturn("quest_repeat", "category_rotation");
+            when(mockRs.getString("quest_definition_key")).thenReturn("mcrpg:mine_stone", null);
+            when(mockRs.getString("category_key")).thenReturn(null, "mcrpg:daily");
+            when(mockRs.getLong("expires_at")).thenReturn(5000L, 9000L);
+
+            List<BoardCooldownDAO.CooldownRecord> result = BoardCooldownDAO.listCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString()
+            );
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+
+            BoardCooldownDAO.CooldownRecord first = result.get(0);
+            assertEquals("quest_repeat", first.cooldownType());
+            assertEquals("mcrpg:mine_stone", first.questDefinitionKey());
+            assertNull(first.categoryKey());
+            assertEquals(5000L, first.expiresAt());
+
+            BoardCooldownDAO.CooldownRecord second = result.get(1);
+            assertEquals("category_rotation", second.cooldownType());
+            assertNull(second.questDefinitionKey());
+            assertEquals("mcrpg:daily", second.categoryKey());
+            assertEquals(9000L, second.expiresAt());
+        }
+
+        @DisplayName("Given no cooldown rows, when listing, then empty list is returned")
+        @Test
+        void listCooldowns_noRows_returnsEmptyList() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false);
+
+            List<BoardCooldownDAO.CooldownRecord> result = BoardCooldownDAO.listCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString()
+            );
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given scope parameters, when listing, then parameters are bound correctly")
+        @Test
+        void listCooldowns_bindsParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false);
+
+            String scopeType = "land";
+            String scopeId = "my-land";
+            BoardCooldownDAO.listCooldowns(mockConnection, scopeType, scopeId);
+
+            verify(mockPs).setString(eq(1), eq(scopeType));
+            verify(mockPs).setString(eq(2), eq(scopeId));
+        }
+
+        @DisplayName("Given a SQLException from executeQuery, when listing, then empty list is returned")
+        @Test
+        void listCooldowns_sqlException_returnsEmptyList() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenThrow(new SQLException("Test exception"));
+
+            List<BoardCooldownDAO.CooldownRecord> result = BoardCooldownDAO.listCooldowns(
+                    mockConnection, "player", "scope-id"
+            );
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("isOnCooldown returns true when present")
-    @Test
-    void isOnCooldown_returnsTrueWhenPresent() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
+    @Nested
+    @DisplayName("deleteCooldowns")
+    class DeleteCooldowns {
 
-        boolean result = BoardCooldownDAO.isOnCooldown(
-                mockConnection,
-                "rotation",
-                "player",
-                UUID.randomUUID().toString(),
-                null,
-                null
-        );
+        @DisplayName("Given no categoryKey, when deleting, then all scope cooldowns are targeted")
+        @Test
+        void deleteCooldowns_noCategoryKey_deletesAll() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeUpdate()).thenReturn(3);
 
-        assertTrue(result);
+            String scopeType = "player";
+            String scopeId = UUID.randomUUID().toString();
+            int deleted = BoardCooldownDAO.deleteCooldowns(mockConnection, scopeType, scopeId, null);
+
+            assertEquals(3, deleted);
+            verify(mockPs).setString(eq(1), eq(scopeType));
+            verify(mockPs).setString(eq(2), eq(scopeId));
+            verify(mockPs, never()).setString(eq(3), anyString());
+        }
+
+        @DisplayName("Given a categoryKey, when deleting, then category filter is applied")
+        @Test
+        void deleteCooldowns_withCategoryKey_appliesFilter() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeUpdate()).thenReturn(1);
+
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily");
+            int deleted = BoardCooldownDAO.deleteCooldowns(mockConnection, "player", "scope-id", categoryKey);
+
+            assertEquals(1, deleted);
+            verify(mockPs).setString(eq(3), eq(categoryKey.toString()));
+        }
+
+        @DisplayName("Given a SQLException from executeUpdate, when deleting, then returns 0")
+        @Test
+        void deleteCooldowns_sqlException_returnsZero() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeUpdate()).thenThrow(new SQLException("Test exception"));
+
+            int deleted = BoardCooldownDAO.deleteCooldowns(mockConnection, "player", "scope-id", null);
+
+            assertEquals(0, deleted);
+        }
+
+        @DisplayName("Given no matching rows, when deleting, then returns 0")
+        @Test
+        void deleteCooldowns_noMatchingRows_returnsZero() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeUpdate()).thenReturn(0);
+
+            int deleted = BoardCooldownDAO.deleteCooldowns(mockConnection, "player", "scope-id", null);
+
+            assertEquals(0, deleted);
+        }
     }
 
-    @DisplayName("pruneExpiredCooldowns returns prepared statements")
-    @Test
-    void pruneExpiredCooldowns_returnsPreparedStatements() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("pruneExpiredCooldowns")
+    class PruneExpiredCooldowns {
 
-        List<PreparedStatement> statements = BoardCooldownDAO.pruneExpiredCooldowns(mockConnection);
+        @DisplayName("Given a valid connection, when pruning, then prepared statements are returned")
+        @Test
+        void pruneExpiredCooldowns_returnsPreparedStatements() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertNotNull(statements);
-        assertFalse(statements.isEmpty());
+            List<PreparedStatement> statements = BoardCooldownDAO.pruneExpiredCooldowns(mockConnection);
+
+            assertNotNull(statements);
+            assertEquals(1, statements.size());
+        }
+
+        @DisplayName("Given a SQLException from prepareStatement, when pruning, then empty list is returned")
+        @Test
+        void pruneExpiredCooldowns_sqlException_returnsEmptyList() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            List<PreparedStatement> statements = BoardCooldownDAO.pruneExpiredCooldowns(mockConnection);
+
+            assertNotNull(statements);
+            assertTrue(statements.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @DisplayName("Given the table already exists, when creating, then returns false")
+        @Test
+        void attemptCreateTable_tableExists_returnsFalse() {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, BoardCooldownDAO.TABLE_NAME)).thenReturn(true);
+
+            boolean result = BoardCooldownDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Given the table does not exist, when creating successfully, then returns true")
+        @Test
+        void attemptCreateTable_newTable_returnsTrue() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(database.tableExists(conn, BoardCooldownDAO.TABLE_NAME)).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            boolean result = BoardCooldownDAO.attemptCreateTable(conn, database);
+
+            assertTrue(result);
+            verify(mockPs).executeUpdate();
+        }
+
+        @DisplayName("Given a SQLException during creation, when creating, then returns false")
+        @Test
+        void attemptCreateTable_sqlException_returnsFalse() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, BoardCooldownDAO.TABLE_NAME)).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            boolean result = BoardCooldownDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @DisplayName("Given the table is at current version, when updating, then no migration runs")
+        @Test
+        void updateTable_currentVersion_noMigration() throws SQLException {
+            Connection conn = mock(Connection.class);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedVersionDAO = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedVersionDAO.when(() -> TableVersionHistoryDAO.getLatestVersion(conn, BoardCooldownDAO.TABLE_NAME)).thenReturn(1);
+
+                BoardCooldownDAO.updateTable(conn);
+
+                verify(conn, never()).prepareStatement(anyString());
+            }
+        }
+
+        @DisplayName("Given version 0, when updating, then indexes are created and version is set")
+        @Test
+        void updateTable_version0_createsIndexesAndSetsVersion() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedVersionDAO = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedVersionDAO.when(() -> TableVersionHistoryDAO.getLatestVersion(conn, BoardCooldownDAO.TABLE_NAME)).thenReturn(0);
+
+                BoardCooldownDAO.updateTable(conn);
+
+                verify(conn, times(2)).prepareStatement(anyString());
+                verify(mockPs, times(2)).executeUpdate();
+                mockedVersionDAO.verify(() -> TableVersionHistoryDAO.setTableVersion(conn, BoardCooldownDAO.TABLE_NAME, 1));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("CooldownRecord")
+    class CooldownRecordTests {
+
+        @DisplayName("Given record parameters, when created, then all fields are accessible")
+        @Test
+        void cooldownRecord_fieldsAccessible() {
+            BoardCooldownDAO.CooldownRecord record = new BoardCooldownDAO.CooldownRecord(
+                    "quest_repeat", "mcrpg:mine_stone", "mcrpg:daily", 12345L
+            );
+
+            assertEquals("quest_repeat", record.cooldownType());
+            assertEquals("mcrpg:mine_stone", record.questDefinitionKey());
+            assertEquals("mcrpg:daily", record.categoryKey());
+            assertEquals(12345L, record.expiresAt());
+        }
+
+        @DisplayName("Given nullable fields set to null, when created, then null fields return null")
+        @Test
+        void cooldownRecord_nullableFields() {
+            BoardCooldownDAO.CooldownRecord record = new BoardCooldownDAO.CooldownRecord(
+                    "rotation", null, null, 0L
+            );
+
+            assertEquals("rotation", record.cooldownType());
+            assertNull(record.questDefinitionKey());
+            assertNull(record.categoryKey());
+        }
+
+        @DisplayName("Given two equal records, when compared, then they are equal")
+        @Test
+        void cooldownRecord_equality() {
+            BoardCooldownDAO.CooldownRecord a = new BoardCooldownDAO.CooldownRecord("t", "q", "c", 1L);
+            BoardCooldownDAO.CooldownRecord b = new BoardCooldownDAO.CooldownRecord("t", "q", "c", 1L);
+
+            assertEquals(a, b);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/QuestObjectiveContributionDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/QuestObjectiveContributionDAOTest.java
@@ -1,7 +1,11 @@
 package us.eunoians.mcrpg.database.table.quest;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.QuestTestHelper;
 import us.eunoians.mcrpg.quest.definition.QuestDefinition;
@@ -11,58 +15,329 @@ import us.eunoians.mcrpg.quest.impl.stage.QuestStageInstance;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+@DisplayName("QuestObjectiveContributionDAO")
 public class QuestObjectiveContributionDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given an objective with contributions, when saving, then prepared statements are returned")
-    @Test
-    public void saveContributions_withContributions_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("saveContributions")
+    class SaveContributions {
 
-        UUID playerUUID = UUID.randomUUID();
-        QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_test");
-        QuestInstance quest = QuestTestHelper.startedQuestWithPlayer(def, playerUUID);
-        QuestStageInstance stage = quest.getQuestStageInstances().get(0);
-        QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
-        obj.progress(5, playerUUID);
+        @DisplayName("Given an objective with contributions, when saving, then prepared statements are returned")
+        @Test
+        void saveContributions_withContributions_returnsPreparedStatements() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
 
-        List<PreparedStatement> result = QuestObjectiveContributionDAO.saveContributions(conn, obj);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+            UUID playerUUID = UUID.randomUUID();
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_test");
+            QuestInstance quest = QuestTestHelper.startedQuestWithPlayer(def, playerUUID);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+            QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
+            obj.progress(5, playerUUID);
+
+            List<PreparedStatement> result = QuestObjectiveContributionDAO.saveContributions(conn, obj);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+        }
+
+        @DisplayName("Given an objective without contributions, when saving, then empty list is returned")
+        @Test
+        void saveContributions_noContributions_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_empty");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+            QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
+
+            List<PreparedStatement> result = QuestObjectiveContributionDAO.saveContributions(conn, obj);
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given an objective with multiple contributors, when saving, then one statement per contributor")
+        @Test
+        void saveContributions_multipleContributors_oneStatementEach() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID player1 = UUID.randomUUID();
+            UUID player2 = UUID.randomUUID();
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_multi");
+            QuestInstance quest = QuestTestHelper.startedQuestWithPlayer(def, player1);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+            QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
+            obj.progress(3, player1);
+            obj.progress(7, player2);
+
+            List<PreparedStatement> result = QuestObjectiveContributionDAO.saveContributions(conn, obj);
+            assertEquals(2, result.size());
+        }
+
+        @DisplayName("Given a contribution, when saving, then parameters are bound correctly")
+        @Test
+        void saveContributions_bindsParameters() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID playerUUID = UUID.randomUUID();
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_bind");
+            QuestInstance quest = QuestTestHelper.startedQuestWithPlayer(def, playerUUID);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+            QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
+            obj.progress(10, playerUUID);
+
+            QuestObjectiveContributionDAO.saveContributions(conn, obj);
+
+            verify(mockPs).setString(eq(1), eq(obj.getQuestObjectiveUUID().toString()));
+            verify(mockPs).setString(eq(2), eq(playerUUID.toString()));
+            verify(mockPs).setLong(eq(3), eq(10L));
+        }
+
+        @DisplayName("Given a SQLException from prepareStatement, when saving, then empty list is returned")
+        @Test
+        void saveContributions_sqlException_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            UUID playerUUID = UUID.randomUUID();
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_error");
+            QuestInstance quest = QuestTestHelper.startedQuestWithPlayer(def, playerUUID);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+            QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
+            obj.progress(5, playerUUID);
+
+            List<PreparedStatement> result = QuestObjectiveContributionDAO.saveContributions(conn, obj);
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("Given an objective without contributions, when saving, then empty list is returned")
-    @Test
-    public void saveContributions_noContributions_returnsEmptyList() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("loadContributions")
+    class LoadContributions {
 
-        QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_contrib_empty");
-        QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
-        QuestStageInstance stage = quest.getQuestStageInstances().get(0);
-        QuestObjectiveInstance obj = stage.getQuestObjectives().get(0);
+        @DisplayName("Given contributions exist, when loading, then map is returned with correct entries")
+        @Test
+        void loadContributions_withRows_returnsMap() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
 
-        List<PreparedStatement> result = QuestObjectiveContributionDAO.saveContributions(conn, obj);
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+            UUID player1 = UUID.randomUUID();
+            UUID player2 = UUID.randomUUID();
+            when(mockRs.next()).thenReturn(true, true, false);
+            when(mockRs.getString("player_uuid")).thenReturn(player1.toString(), player2.toString());
+            when(mockRs.getLong("amount")).thenReturn(15L, 25L);
+
+            UUID objectiveUUID = UUID.randomUUID();
+            Map<UUID, Long> result = QuestObjectiveContributionDAO.loadContributions(conn, objectiveUUID);
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertEquals(15L, result.get(player1));
+            assertEquals(25L, result.get(player2));
+        }
+
+        @DisplayName("Given no contributions exist, when loading, then empty map is returned")
+        @Test
+        void loadContributions_noRows_returnsEmptyMap() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false);
+
+            Map<UUID, Long> result = QuestObjectiveContributionDAO.loadContributions(conn, UUID.randomUUID());
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given an objective UUID, when loading, then the UUID is bound as parameter")
+        @Test
+        void loadContributions_bindsObjectiveUUID() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false);
+
+            UUID objectiveUUID = UUID.randomUUID();
+            QuestObjectiveContributionDAO.loadContributions(conn, objectiveUUID);
+
+            verify(mockPs).setString(eq(1), eq(objectiveUUID.toString()));
+        }
+
+        @DisplayName("Given a SQLException from executeQuery, when loading, then empty map is returned")
+        @Test
+        void loadContributions_sqlException_returnsEmptyMap() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenThrow(new SQLException("Test exception"));
+
+            Map<UUID, Long> result = QuestObjectiveContributionDAO.loadContributions(conn, UUID.randomUUID());
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given a single contributor, when loading, then map contains one entry")
+        @Test
+        void loadContributions_singleContributor_returnsOneEntry() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+
+            UUID playerUUID = UUID.randomUUID();
+            when(mockRs.next()).thenReturn(true, false);
+            when(mockRs.getString("player_uuid")).thenReturn(playerUUID.toString());
+            when(mockRs.getLong("amount")).thenReturn(42L);
+
+            Map<UUID, Long> result = QuestObjectiveContributionDAO.loadContributions(conn, UUID.randomUUID());
+
+            assertEquals(1, result.size());
+            assertEquals(42L, result.get(playerUUID));
+        }
     }
 
-    @DisplayName("Given an objective UUID, when deleting contributions, then prepared statements are returned")
-    @Test
-    public void deleteContributions_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("deleteContributions")
+    class DeleteContributions {
 
-        List<PreparedStatement> result = QuestObjectiveContributionDAO.deleteContributions(conn, UUID.randomUUID());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+        @DisplayName("Given an objective UUID, when deleting contributions, then prepared statements are returned")
+        @Test
+        void deleteContributions_returnsPreparedStatements() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+            List<PreparedStatement> result = QuestObjectiveContributionDAO.deleteContributions(conn, UUID.randomUUID());
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.size());
+        }
+
+        @DisplayName("Given an objective UUID, when deleting, then UUID is bound as parameter")
+        @Test
+        void deleteContributions_bindsUUID() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID objectiveUUID = UUID.randomUUID();
+            QuestObjectiveContributionDAO.deleteContributions(conn, objectiveUUID);
+
+            verify(mockPs).setString(eq(1), eq(objectiveUUID.toString()));
+        }
+
+        @DisplayName("Given a SQLException from prepareStatement, when deleting, then empty list is returned")
+        @Test
+        void deleteContributions_sqlException_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            List<PreparedStatement> result = QuestObjectiveContributionDAO.deleteContributions(conn, UUID.randomUUID());
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @DisplayName("Given the table already exists, when creating, then returns false")
+        @Test
+        void attemptCreateTable_tableExists_returnsFalse() {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, QuestObjectiveContributionDAO.TABLE_NAME)).thenReturn(true);
+
+            boolean result = QuestObjectiveContributionDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Given the table does not exist, when creating successfully, then returns true")
+        @Test
+        void attemptCreateTable_newTable_returnsTrue() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(database.tableExists(conn, QuestObjectiveContributionDAO.TABLE_NAME)).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            boolean result = QuestObjectiveContributionDAO.attemptCreateTable(conn, database);
+
+            assertTrue(result);
+            verify(mockPs).executeUpdate();
+        }
+
+        @DisplayName("Given a SQLException during creation, when creating, then returns false")
+        @Test
+        void attemptCreateTable_sqlException_returnsFalse() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, QuestObjectiveContributionDAO.TABLE_NAME)).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            boolean result = QuestObjectiveContributionDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @DisplayName("Given the table is at current version, when updating, then no migration runs")
+        @Test
+        void updateTable_currentVersion_noMigration() {
+            Connection conn = mock(Connection.class);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedVersionDAO = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedVersionDAO.when(() -> TableVersionHistoryDAO.getLatestVersion(conn, QuestObjectiveContributionDAO.TABLE_NAME)).thenReturn(1);
+
+                QuestObjectiveContributionDAO.updateTable(conn);
+
+                mockedVersionDAO.verify(() -> TableVersionHistoryDAO.setTableVersion(eq(conn), anyString(), anyInt()), never());
+            }
+        }
+
+        @DisplayName("Given version 0, when updating, then version is set to 1")
+        @Test
+        void updateTable_version0_setsVersion() {
+            Connection conn = mock(Connection.class);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedVersionDAO = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedVersionDAO.when(() -> TableVersionHistoryDAO.getLatestVersion(conn, QuestObjectiveContributionDAO.TABLE_NAME)).thenReturn(0);
+
+                QuestObjectiveContributionDAO.updateTable(conn);
+
+                mockedVersionDAO.verify(() -> TableVersionHistoryDAO.setTableVersion(conn, QuestObjectiveContributionDAO.TABLE_NAME, 1));
+            }
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/QuestStageInstanceDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/QuestStageInstanceDAOTest.java
@@ -1,77 +1,486 @@
 package us.eunoians.mcrpg.database.table.quest;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
+import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.QuestTestHelper;
 import us.eunoians.mcrpg.quest.definition.QuestDefinition;
 import us.eunoians.mcrpg.quest.impl.QuestInstance;
 import us.eunoians.mcrpg.quest.impl.stage.QuestStageInstance;
+import us.eunoians.mcrpg.quest.impl.stage.QuestStageState;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+@DisplayName("QuestStageInstanceDAO")
 public class QuestStageInstanceDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given a stage instance, when saving, then prepared statements are returned")
-    @Test
-    public void saveStageInstance_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("saveStageInstance")
+    class SaveStageInstance {
 
-        QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_test");
-        QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
-        QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+        @DisplayName("Given a stage instance, when saving, then prepared statements are returned")
+        @Test
+        void saveStageInstance_returnsPreparedStatements() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
 
-        List<PreparedStatement> result = QuestStageInstanceDAO.saveStageInstance(conn, stage);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_test");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+
+            List<PreparedStatement> result = QuestStageInstanceDAO.saveStageInstance(conn, stage);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.size());
+        }
+
+        @DisplayName("Given a stage instance, when saving, then connection prepareStatement is called")
+        @Test
+        void saveStageInstance_usesConnection() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_conn");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+
+            QuestStageInstanceDAO.saveStageInstance(conn, stage);
+            verify(conn).prepareStatement(anyString());
+        }
+
+        @DisplayName("Given a stage instance, when saving, then parameters are bound correctly")
+        @Test
+        void saveStageInstance_bindsParameters() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_params");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+
+            QuestStageInstanceDAO.saveStageInstance(conn, stage);
+
+            verify(mockPs).setString(eq(1), eq(stage.getQuestStageUUID().toString()));
+            verify(mockPs).setString(eq(2), eq(quest.getQuestUUID().toString()));
+            verify(mockPs).setString(eq(3), eq(stage.getStageKey().toString()));
+            verify(mockPs).setInt(eq(4), eq(stage.getPhaseIndex()));
+            verify(mockPs).setString(eq(5), eq(stage.getQuestStageState().name()));
+        }
+
+        @DisplayName("Given a started stage with no end time, when saving, then end_time is set to null")
+        @Test
+        void saveStageInstance_nullEndTime_setsNullForEndTime() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_null_time");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+
+            QuestStageInstanceDAO.saveStageInstance(conn, stage);
+
+            verify(mockPs).setNull(eq(7), eq(Types.BIGINT));
+        }
+
+        @DisplayName("Given an unstarted stage, when saving, then both time columns are set to null")
+        @Test
+        void saveStageInstance_unstartedStage_setsNullForBothTimes() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_unstarted");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            NamespacedKey stageKey = new NamespacedKey("mcrpg", "test_stage_unstarted");
+            QuestStageInstance stage = new QuestStageInstance(stageKey, UUID.randomUUID(), 0, quest, QuestStageState.NOT_STARTED, null, null);
+
+            QuestStageInstanceDAO.saveStageInstance(conn, stage);
+
+            verify(mockPs).setNull(eq(6), eq(Types.BIGINT));
+            verify(mockPs).setNull(eq(7), eq(Types.BIGINT));
+        }
+
+        @DisplayName("Given a stage with non-null timestamps, when saving, then times are set as longs")
+        @Test
+        void saveStageInstance_nonNullTimestamps_setsLongs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_with_times");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            NamespacedKey stageKey = new NamespacedKey("mcrpg", "test_stage_timed");
+            QuestStageInstance stage = new QuestStageInstance(stageKey, UUID.randomUUID(), 0, quest, QuestStageState.COMPLETED, 5000L, 9000L);
+
+            QuestStageInstanceDAO.saveStageInstance(conn, stage);
+
+            verify(mockPs).setLong(eq(6), eq(5000L));
+            verify(mockPs).setLong(eq(7), eq(9000L));
+        }
+
+        @DisplayName("Given a SQLException from prepareStatement, when saving, then empty list is returned")
+        @Test
+        void saveStageInstance_sqlException_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_error");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+
+            List<PreparedStatement> result = QuestStageInstanceDAO.saveStageInstance(conn, stage);
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("Given a stage instance, when saving, then connection prepareStatement is called")
-    @Test
-    public void saveStageInstance_usesConnection() throws SQLException {
-        Connection conn = mock(Connection.class);
-        PreparedStatement mockPs = mock(PreparedStatement.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+    @Nested
+    @DisplayName("saveAllStageInstances")
+    class SaveAllStageInstances {
 
-        QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_stage_conn");
-        QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
-        QuestStageInstance stage = quest.getQuestStageInstances().get(0);
+        @DisplayName("Given a quest with stages, when saving all, then prepared statements are returned")
+        @Test
+        void saveAllStageInstances_returnsPreparedStatements() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
 
-        QuestStageInstanceDAO.saveStageInstance(conn, stage);
-        verify(conn).prepareStatement(anyString());
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_all_stages");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+
+            List<PreparedStatement> result = QuestStageInstanceDAO.saveAllStageInstances(conn, quest);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertEquals(quest.getQuestStageInstances().size(), result.size());
+        }
     }
 
-    @DisplayName("Given a quest with stages, when saving all, then prepared statements are returned")
-    @Test
-    public void saveAllStageInstances_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("loadStageInstances")
+    class LoadStageInstances {
 
-        QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_all_stages");
-        QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+        @DisplayName("Given a valid stage row, when loading, then stage is returned with correct state")
+        @Test
+        void loadStageInstances_validRow_returnsStage() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(true, false);
 
-        List<PreparedStatement> result = QuestStageInstanceDAO.saveAllStageInstances(conn, quest);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+            UUID stageUUID = UUID.randomUUID();
+            when(mockRs.getString("stage_uuid")).thenReturn(stageUUID.toString());
+            when(mockRs.getString("definition_key")).thenReturn("mcrpg:test_stage");
+            when(mockRs.getInt("phase_index")).thenReturn(0);
+            when(mockRs.getString("state")).thenReturn("IN_PROGRESS");
+            when(mockRs.getLong("start_time")).thenReturn(1000L);
+            when(mockRs.wasNull()).thenReturn(false, false);
+            when(mockRs.getLong("end_time")).thenReturn(0L);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_stage");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            UUID questUUID = quest.getQuestUUID();
+
+            List<QuestStageInstance> result = QuestStageInstanceDAO.loadStageInstances(conn, questUUID, quest);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            QuestStageInstance loaded = result.get(0);
+            assertEquals(stageUUID, loaded.getQuestStageUUID());
+            assertEquals(QuestStageState.IN_PROGRESS, loaded.getQuestStageState());
+            assertEquals(0, loaded.getPhaseIndex());
+        }
+
+        @DisplayName("Given no rows, when loading, then empty list is returned")
+        @Test
+        void loadStageInstances_noRows_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_empty");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+
+            List<QuestStageInstance> result = QuestStageInstanceDAO.loadStageInstances(conn, quest.getQuestUUID(), quest);
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given a malformed definition_key, when loading, then that row is skipped")
+        @Test
+        void loadStageInstances_malformedKey_skipsRow() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(true, true, false);
+
+            UUID badStageUUID = UUID.randomUUID();
+            UUID goodStageUUID = UUID.randomUUID();
+
+            when(mockRs.getString("stage_uuid")).thenReturn(badStageUUID.toString(), goodStageUUID.toString());
+            when(mockRs.getString("definition_key")).thenReturn(":::invalid:::", "mcrpg:valid_stage");
+            when(mockRs.getInt("phase_index")).thenReturn(0, 1);
+            when(mockRs.getString("state")).thenReturn("NOT_STARTED", "IN_PROGRESS");
+            when(mockRs.getLong("start_time")).thenReturn(0L);
+            when(mockRs.wasNull()).thenReturn(true, true);
+            when(mockRs.getLong("end_time")).thenReturn(0L);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_malformed");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+
+            List<QuestStageInstance> result = QuestStageInstanceDAO.loadStageInstances(conn, quest.getQuestUUID(), quest);
+
+            assertEquals(1, result.size());
+            assertEquals(goodStageUUID, result.get(0).getQuestStageUUID());
+        }
+
+        @DisplayName("Given nullable timestamps, when loading, then timestamps are correctly handled")
+        @Test
+        void loadStageInstances_nullableTimestamps_handledCorrectly() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(true, false);
+
+            when(mockRs.getString("stage_uuid")).thenReturn(UUID.randomUUID().toString());
+            when(mockRs.getString("definition_key")).thenReturn("mcrpg:nullable_test");
+            when(mockRs.getInt("phase_index")).thenReturn(0);
+            when(mockRs.getString("state")).thenReturn("NOT_STARTED");
+            when(mockRs.getLong("start_time")).thenReturn(0L);
+            when(mockRs.getLong("end_time")).thenReturn(0L);
+            when(mockRs.wasNull()).thenReturn(true, true);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_nullable");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+
+            List<QuestStageInstance> result = QuestStageInstanceDAO.loadStageInstances(conn, quest.getQuestUUID(), quest);
+
+            assertEquals(1, result.size());
+            QuestStageInstance loaded = result.get(0);
+            assertTrue(loaded.getStartTime().isEmpty());
+            assertTrue(loaded.getEndTime().isEmpty());
+        }
+
+        @DisplayName("Given multiple valid rows, when loading, then all stages are returned")
+        @Test
+        void loadStageInstances_multipleRows_returnsAll() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(true, true, true, false);
+
+            UUID uuid1 = UUID.randomUUID();
+            UUID uuid2 = UUID.randomUUID();
+            UUID uuid3 = UUID.randomUUID();
+
+            when(mockRs.getString("stage_uuid"))
+                    .thenReturn(uuid1.toString(), uuid2.toString(), uuid3.toString());
+            when(mockRs.getString("definition_key"))
+                    .thenReturn("mcrpg:stage_a", "mcrpg:stage_b", "mcrpg:stage_c");
+            when(mockRs.getInt("phase_index"))
+                    .thenReturn(0, 0, 1);
+            when(mockRs.getString("state"))
+                    .thenReturn("COMPLETED", "IN_PROGRESS", "NOT_STARTED");
+            when(mockRs.getLong("start_time")).thenReturn(5000L, 6000L, 0L);
+            when(mockRs.getLong("end_time")).thenReturn(7000L, 0L, 0L);
+            when(mockRs.wasNull()).thenReturn(false, false, false, true, true, true);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_multi");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+
+            List<QuestStageInstance> result = QuestStageInstanceDAO.loadStageInstances(conn, quest.getQuestUUID(), quest);
+
+            assertEquals(3, result.size());
+            assertEquals(QuestStageState.COMPLETED, result.get(0).getQuestStageState());
+            assertEquals(QuestStageState.IN_PROGRESS, result.get(1).getQuestStageState());
+            assertEquals(QuestStageState.NOT_STARTED, result.get(2).getQuestStageState());
+        }
+
+        @DisplayName("Given a quest UUID, when loading, then the quest UUID is bound as parameter")
+        @Test
+        void loadStageInstances_bindsQuestUUID() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            ResultSet mockRs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenReturn(mockRs);
+            when(mockRs.next()).thenReturn(false);
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_bind");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+            UUID questUUID = quest.getQuestUUID();
+
+            QuestStageInstanceDAO.loadStageInstances(conn, questUUID, quest);
+
+            verify(mockPs).setString(eq(1), eq(questUUID.toString()));
+        }
+
+        @DisplayName("Given a SQLException from executeQuery, when loading, then empty list is returned")
+        @Test
+        void loadStageInstances_sqlException_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+            when(mockPs.executeQuery()).thenThrow(new SQLException("Test exception"));
+
+            QuestDefinition def = QuestTestHelper.singlePhaseQuest("dao_load_error");
+            QuestInstance quest = QuestTestHelper.startedQuestInstance(def);
+
+            List<QuestStageInstance> result = QuestStageInstanceDAO.loadStageInstances(conn, quest.getQuestUUID(), quest);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("Given a quest UUID, when deleting stages, then prepared statements are returned")
-    @Test
-    public void deleteStageInstances_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("deleteStageInstances")
+    class DeleteStageInstances {
 
-        List<PreparedStatement> result = QuestStageInstanceDAO.deleteStageInstances(conn, UUID.randomUUID());
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+        @DisplayName("Given a quest UUID, when deleting stages, then prepared statements are returned")
+        @Test
+        void deleteStageInstances_returnsPreparedStatements() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+            List<PreparedStatement> result = QuestStageInstanceDAO.deleteStageInstances(conn, UUID.randomUUID());
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.size());
+        }
+
+        @DisplayName("Given a quest UUID, when deleting, then UUID is bound as parameter")
+        @Test
+        void deleteStageInstances_bindsUUID() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID questUUID = UUID.randomUUID();
+            QuestStageInstanceDAO.deleteStageInstances(conn, questUUID);
+
+            verify(mockPs).setString(eq(1), eq(questUUID.toString()));
+        }
+
+        @DisplayName("Given a SQLException from prepareStatement, when deleting, then empty list is returned")
+        @Test
+        void deleteStageInstances_sqlException_returnsEmptyList() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            List<PreparedStatement> result = QuestStageInstanceDAO.deleteStageInstances(conn, UUID.randomUUID());
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @DisplayName("Given the table already exists, when creating, then returns false")
+        @Test
+        void attemptCreateTable_tableExists_returnsFalse() {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, QuestStageInstanceDAO.TABLE_NAME)).thenReturn(true);
+
+            boolean result = QuestStageInstanceDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Given the table does not exist, when creating successfully, then returns true")
+        @Test
+        void attemptCreateTable_newTable_returnsTrue() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(database.tableExists(conn, QuestStageInstanceDAO.TABLE_NAME)).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            boolean result = QuestStageInstanceDAO.attemptCreateTable(conn, database);
+
+            assertTrue(result);
+            verify(mockPs).executeUpdate();
+        }
+
+        @DisplayName("Given a SQLException during creation, when creating, then returns false")
+        @Test
+        void attemptCreateTable_sqlException_returnsFalse() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, QuestStageInstanceDAO.TABLE_NAME)).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("Test exception"));
+
+            boolean result = QuestStageInstanceDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @DisplayName("Given the table is at current version, when updating, then no migration runs")
+        @Test
+        void updateTable_currentVersion_noMigration() throws SQLException {
+            Connection conn = mock(Connection.class);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedVersionDAO = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedVersionDAO.when(() -> TableVersionHistoryDAO.getLatestVersion(conn, QuestStageInstanceDAO.TABLE_NAME)).thenReturn(1);
+
+                QuestStageInstanceDAO.updateTable(conn);
+
+                verify(conn, never()).prepareStatement(anyString());
+            }
+        }
+
+        @DisplayName("Given version 0, when updating, then index is created and version is set")
+        @Test
+        void updateTable_version0_createsIndexAndSetsVersion() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedVersionDAO = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedVersionDAO.when(() -> TableVersionHistoryDAO.getLatestVersion(conn, QuestStageInstanceDAO.TABLE_NAME)).thenReturn(0);
+
+                QuestStageInstanceDAO.updateTable(conn);
+
+                verify(conn).prepareStatement(anyString());
+                verify(mockPs).executeUpdate();
+                mockedVersionDAO.verify(() -> TableVersionHistoryDAO.setTableVersion(conn, QuestStageInstanceDAO.TABLE_NAME, 1));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Expanded `QuestStageInstanceDAOTest` from 4 tests to 24 — adds full coverage for `loadStageInstances` (valid rows, malformed key skipping, empty results, nullable timestamps, multiple rows, parameter binding, SQL exceptions), `attemptCreateTable`, `updateTable`, and parameter binding/error handling for save/delete
- Expanded `QuestObjectiveContributionDAOTest` from 3 tests to 18 — adds full coverage for `loadContributions` (multiple contributors, single contributor, empty results, parameter binding, SQL exceptions), `attemptCreateTable`, `updateTable`, and parameter binding/error handling for save/delete
- Expanded `BoardCooldownDAOTest` from 5 tests to 15+ — adds coverage for `listCooldowns` (record deserialization, empty results, parameter binding, SQL exceptions), `deleteCooldowns` (with/without category key filter, return value), `attemptCreateTable`, `updateTable`, `isOnCooldown` parameter binding variants (both keys, quest-only, category-only), `CooldownRecord` construction/equality, and SQL exception handling

**Total: 57 new tests (4899 → 4956), 0 failures.**

All tests follow the established DAO test pattern: mocked JDBC (`Connection`, `PreparedStatement`, `ResultSet` via Mockito), `@Nested` groups per method, `action_outcome_whenCondition` naming, descriptive `@DisplayName` labels.

## Test plan

- [x] Full test suite passes (`./gradlew test` — 4956 tests, 0 failures, 0 skipped)
- [x] Testing audit persona reviewed changes — all findings addressed
- [x] No production code changes

---
_Generated by [Claude Code](https://claude.ai/code/session_0182JF4aQdYvyrgekLWWNrip)_