### PR TITLE
[Unit Tests] Expand DAO test coverage for PlayerBoardState, LoadoutDisplay, PlayerLoadoutSelection, and PlayerStat

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/database/table/LoadoutDisplayDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/LoadoutDisplayDAOTest.java
@@ -1,15 +1,20 @@
 package us.eunoians.mcrpg.database.table;
 
 import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
 import com.diamonddagger590.mccore.util.item.CustomItemWrapper;
 import org.bukkit.Material;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.entity.holder.LoadoutHolder;
 import us.eunoians.mcrpg.loadout.Loadout;
 import us.eunoians.mcrpg.loadout.LoadoutDisplay;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -21,7 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,175 +43,477 @@ class LoadoutDisplayDAOTest extends McRPGBaseTest {
 
     private static final UUID PLAYER_UUID = UUID.randomUUID();
 
-    @Test
-    @DisplayName("attemptCreateTable returns false when table already exists")
-    void attemptCreateTable_returnsFalse_whenTableExists() {
-        Connection mockConnection = mock(Connection.class);
-        Database mockDatabase = mock(Database.class);
-        when(mockDatabase.tableExists(mockConnection, LoadoutDisplayDAO.TABLE_NAME)).thenReturn(true);
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-        boolean result = LoadoutDisplayDAO.attemptCreateTable(mockConnection, mockDatabase);
+        @Test
+        @DisplayName("returns false when table already exists")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, LoadoutDisplayDAO.TABLE_NAME)).thenReturn(true);
 
-        assertFalse(result);
+            boolean result = LoadoutDisplayDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("returns true when table does not exist")
+        void attemptCreateTable_returnsTrue_whenTableDoesNotExist() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockDatabase.tableExists(mockConnection, LoadoutDisplayDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = LoadoutDisplayDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("returns false when SQLException is thrown")
+        void attemptCreateTable_returnsFalse_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, LoadoutDisplayDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            boolean result = LoadoutDisplayDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
     }
 
-    @Test
-    @DisplayName("attemptCreateTable returns true when table does not exist")
-    void attemptCreateTable_returnsTrue_whenTableDoesNotExist() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        Database mockDatabase = mock(Database.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockDatabase.tableExists(mockConnection, LoadoutDisplayDAO.TABLE_NAME)).thenReturn(false);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
 
-        boolean result = LoadoutDisplayDAO.attemptCreateTable(mockConnection, mockDatabase);
+        @Test
+        @DisplayName("skips all migrations when version is current")
+        void updateTable_skipsAll_whenVersionIsCurrent() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
 
-        assertTrue(result);
-        verify(mockStatement).executeUpdate();
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME))
+                        .thenReturn(2);
+
+                LoadoutDisplayDAO.updateTable(mockConnection);
+
+                verify(mockConnection, never()).prepareStatement(anyString());
+            }
+        }
+
+        @Test
+        @DisplayName("creates index and sets version when at version 0")
+        void updateTable_createsIndex_whenAtVersionZero() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockIndexStatement = mock(PreparedStatement.class);
+            DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+            ResultSet mockMetaResultSet = mock(ResultSet.class);
+            PreparedStatement mockPragmaStatement = mock(PreparedStatement.class);
+            ResultSet mockPragmaResultSet = mock(ResultSet.class);
+
+            when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.contains("CREATE INDEX")))
+                    .thenReturn(mockIndexStatement);
+            when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+            when(mockMetaData.getColumns(isNull(), isNull(), anyString(), anyString()))
+                    .thenReturn(mockMetaResultSet);
+            when(mockMetaResultSet.next()).thenReturn(true);
+            when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.contains("PRAGMA")))
+                    .thenReturn(mockPragmaStatement);
+            when(mockPragmaStatement.executeQuery()).thenReturn(mockPragmaResultSet);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME))
+                        .thenReturn(0);
+
+                LoadoutDisplayDAO.updateTable(mockConnection);
+
+                verify(mockIndexStatement).executeUpdate();
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME, 1));
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME, 2));
+            }
+        }
+
+        @Test
+        @DisplayName("skips index creation and only runs version 2 migration when at version 1")
+        void updateTable_skipsIndex_whenAtVersionOne() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+            ResultSet mockMetaResultSet = mock(ResultSet.class);
+
+            when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+            when(mockMetaData.getColumns(isNull(), isNull(), anyString(), anyString()))
+                    .thenReturn(mockMetaResultSet);
+            when(mockMetaResultSet.next()).thenReturn(true);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME))
+                        .thenReturn(1);
+
+                LoadoutDisplayDAO.updateTable(mockConnection);
+
+                verify(mockConnection, never()).prepareStatement(org.mockito.ArgumentMatchers.contains("CREATE INDEX"));
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME, 2));
+            }
+        }
+
+        @Test
+        @DisplayName("version 2 adds column when column does not exist via metadata")
+        void updateTable_addsColumn_whenColumnMissing() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+            ResultSet mockMetaResultSet = mock(ResultSet.class);
+            PreparedStatement mockPragmaStatement = mock(PreparedStatement.class);
+            ResultSet mockPragmaResultSet = mock(ResultSet.class);
+            PreparedStatement mockAlterStatement = mock(PreparedStatement.class);
+
+            when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+            when(mockMetaData.getColumns(isNull(), isNull(), anyString(), anyString()))
+                    .thenReturn(mockMetaResultSet);
+            when(mockMetaResultSet.next()).thenReturn(false);
+            when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.contains("PRAGMA")))
+                    .thenReturn(mockPragmaStatement);
+            when(mockPragmaStatement.executeQuery()).thenReturn(mockPragmaResultSet);
+            when(mockPragmaResultSet.next()).thenReturn(false);
+            when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.contains("ALTER TABLE")))
+                    .thenReturn(mockAlterStatement);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME))
+                        .thenReturn(1);
+
+                LoadoutDisplayDAO.updateTable(mockConnection);
+
+                verify(mockAlterStatement).executeUpdate();
+            }
+        }
+
+        @Test
+        @DisplayName("version 2 skips alter when column already exists via metadata")
+        void updateTable_skipsAlter_whenColumnExists() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+            ResultSet mockMetaResultSet = mock(ResultSet.class);
+
+            when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+            when(mockMetaData.getColumns(isNull(), isNull(), anyString(), anyString()))
+                    .thenReturn(mockMetaResultSet);
+            when(mockMetaResultSet.next()).thenReturn(true);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, LoadoutDisplayDAO.TABLE_NAME))
+                        .thenReturn(1);
+
+                LoadoutDisplayDAO.updateTable(mockConnection);
+
+                verify(mockConnection, never()).prepareStatement(org.mockito.ArgumentMatchers.contains("ALTER TABLE"));
+            }
+        }
     }
 
-    @Test
-    @DisplayName("attemptCreateTable returns false when SQLException is thrown")
-    void attemptCreateTable_returnsFalse_whenSQLExceptionThrown() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        Database mockDatabase = mock(Database.class);
-        when(mockDatabase.tableExists(mockConnection, LoadoutDisplayDAO.TABLE_NAME)).thenReturn(false);
-        when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+    @Nested
+    @DisplayName("saveLoadoutDisplay (direct)")
+    class SaveLoadoutDisplayDirect {
 
-        boolean result = LoadoutDisplayDAO.attemptCreateTable(mockConnection, mockDatabase);
+        @Test
+        @DisplayName("binds correct parameters")
+        void saveLoadoutDisplay_bindsCorrectParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertFalse(result);
+            CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
+            when(mockItem.customItem()).thenReturn(Optional.of("DIAMOND_SWORD"));
+            when(mockItem.material()).thenReturn(Optional.of(Material.DIAMOND_SWORD));
+
+            LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
+            when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
+            when(mockDisplay.getDisplayName()).thenReturn(Optional.of("My Loadout"));
+
+            int loadoutSlot = 2;
+
+            LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, loadoutSlot, mockDisplay);
+
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setInt(2, loadoutSlot);
+            verify(mockStatement).setString(3, "DIAMOND_SWORD");
+            verify(mockStatement).setString(4, "My Loadout");
+        }
+
+        @Test
+        @DisplayName("binds null display name when absent")
+        void saveLoadoutDisplay_bindsNullDisplayName_whenDisplayNameAbsent() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
+            when(mockItem.customItem()).thenReturn(Optional.of("STONE"));
+            when(mockItem.material()).thenReturn(Optional.of(Material.STONE));
+
+            LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
+            when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
+            when(mockDisplay.getDisplayName()).thenReturn(Optional.empty());
+
+            LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, 1, mockDisplay);
+
+            verify(mockStatement).setString(4, null);
+        }
+
+        @Test
+        @DisplayName("falls back to material name when custom item is absent")
+        void saveLoadoutDisplay_fallsBackToMaterial_whenCustomItemAbsent() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
+            when(mockItem.customItem()).thenReturn(Optional.empty());
+            when(mockItem.material()).thenReturn(Optional.of(Material.OAK_LOG));
+
+            LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
+            when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
+            when(mockDisplay.getDisplayName()).thenReturn(Optional.empty());
+
+            LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, 1, mockDisplay);
+
+            verify(mockStatement).setString(3, "OAK_LOG");
+        }
+
+        @Test
+        @DisplayName("returns empty list when SQLException is thrown")
+        void saveLoadoutDisplay_returnsEmptyList_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
+            when(mockItem.customItem()).thenReturn(Optional.of("STONE"));
+            when(mockItem.material()).thenReturn(Optional.of(Material.STONE));
+
+            LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
+            when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
+            when(mockDisplay.getDisplayName()).thenReturn(Optional.empty());
+
+            List<PreparedStatement> result = LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, 1, mockDisplay);
+
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @Test
-    @DisplayName("saveLoadoutDisplay binds correct parameters")
-    void saveLoadoutDisplay_bindsCorrectParameters() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("saveLoadoutDisplay (Loadout overload)")
+    class SaveLoadoutDisplayLoadout {
 
-        CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
-        when(mockItem.customItem()).thenReturn(Optional.of("DIAMOND_SWORD"));
-        when(mockItem.material()).thenReturn(Optional.of(Material.DIAMOND_SWORD));
+        @Test
+        @DisplayName("returns empty list when display should not be saved")
+        void saveLoadoutDisplay_returnsEmptyList_whenShouldNotSaveDisplay() {
+            Connection mockConnection = mock(Connection.class);
 
-        LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
-        when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
-        when(mockDisplay.getDisplayName()).thenReturn(Optional.of("My Loadout"));
+            Loadout mockLoadout = mock(Loadout.class);
+            when(mockLoadout.shouldSaveDisplay()).thenReturn(false);
 
-        int loadoutSlot = 2;
+            List<PreparedStatement> result = LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, mockLoadout);
 
-        LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, loadoutSlot, mockDisplay);
+            assertTrue(result.isEmpty());
+        }
 
-        verify(mockStatement).setString(1, PLAYER_UUID.toString());
-        verify(mockStatement).setInt(2, loadoutSlot);
-        verify(mockStatement).setString(3, "DIAMOND_SWORD");
-        verify(mockStatement).setString(4, "My Loadout");
+        @Test
+        @DisplayName("delegates to direct overload when display should be saved")
+        void saveLoadoutDisplay_delegatesToOverload_whenShouldSaveDisplay() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
+            when(mockItem.customItem()).thenReturn(Optional.of("CHERRY_SIGN"));
+            when(mockItem.material()).thenReturn(Optional.of(Material.CHERRY_SIGN));
+
+            LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
+            when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
+            when(mockDisplay.getDisplayName()).thenReturn(Optional.of("Custom Name"));
+
+            Loadout mockLoadout = mock(Loadout.class);
+            when(mockLoadout.shouldSaveDisplay()).thenReturn(true);
+            when(mockLoadout.getLoadoutSlot()).thenReturn(3);
+            when(mockLoadout.getDisplay()).thenReturn(mockDisplay);
+
+            List<PreparedStatement> result = LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, mockLoadout);
+
+            assertEquals(1, result.size());
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setInt(2, 3);
+        }
     }
 
-    @Test
-    @DisplayName("saveLoadoutDisplay binds null display name when absent")
-    void saveLoadoutDisplay_bindsNullDisplayName_whenDisplayNameAbsent() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("saveAllLoadoutDisplays")
+    class SaveAllLoadoutDisplays {
 
-        CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
-        when(mockItem.customItem()).thenReturn(Optional.of("STONE"));
-        when(mockItem.material()).thenReturn(Optional.of(Material.STONE));
+        @Test
+        @DisplayName("iterates over all loadout slots and collects statements")
+        void saveAllLoadoutDisplays_iteratesAllSlots() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockDeleteStatement = mock(PreparedStatement.class);
+            PreparedStatement mockInsertStatement = mock(PreparedStatement.class);
 
-        LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
-        when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
-        when(mockDisplay.getDisplayName()).thenReturn(Optional.empty());
+            when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.contains("DELETE")))
+                    .thenReturn(mockDeleteStatement);
+            when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.contains("INSERT")))
+                    .thenReturn(mockInsertStatement);
 
-        LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, 1, mockDisplay);
+            CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
+            when(mockItem.customItem()).thenReturn(Optional.of("STONE"));
+            when(mockItem.material()).thenReturn(Optional.of(Material.STONE));
 
-        verify(mockStatement).setString(4, null);
+            LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
+            when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
+            when(mockDisplay.getDisplayName()).thenReturn(Optional.empty());
+
+            Loadout mockLoadout = mock(Loadout.class);
+            when(mockLoadout.shouldSaveDisplay()).thenReturn(true);
+            when(mockLoadout.getLoadoutSlot()).thenReturn(1);
+            when(mockLoadout.getDisplay()).thenReturn(mockDisplay);
+
+            LoadoutHolder mockHolder = mock(LoadoutHolder.class);
+            when(mockHolder.getMaxLoadoutAmount()).thenReturn(2);
+            when(mockHolder.getUUID()).thenReturn(PLAYER_UUID);
+            when(mockHolder.getLoadout(1)).thenReturn(mockLoadout);
+            when(mockHolder.getLoadout(2)).thenReturn(mockLoadout);
+
+            List<PreparedStatement> result = LoadoutDisplayDAO.saveAllLoadoutDisplays(mockConnection, mockHolder);
+
+            assertFalse(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns empty list when holder has zero loadout slots")
+        void saveAllLoadoutDisplays_returnsEmpty_whenNoSlots() {
+            Connection mockConnection = mock(Connection.class);
+
+            LoadoutHolder mockHolder = mock(LoadoutHolder.class);
+            when(mockHolder.getMaxLoadoutAmount()).thenReturn(0);
+            when(mockHolder.getUUID()).thenReturn(PLAYER_UUID);
+
+            List<PreparedStatement> result = LoadoutDisplayDAO.saveAllLoadoutDisplays(mockConnection, mockHolder);
+
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @Test
-    @DisplayName("saveLoadoutDisplay with Loadout returns empty list when display should not be saved")
-    void saveLoadoutDisplay_returnsEmptyList_whenShouldNotSaveDisplay() {
-        Connection mockConnection = mock(Connection.class);
+    @Nested
+    @DisplayName("deleteLoadoutDisplay")
+    class DeleteLoadoutDisplay {
 
-        Loadout mockLoadout = mock(Loadout.class);
-        when(mockLoadout.shouldSaveDisplay()).thenReturn(false);
+        @Test
+        @DisplayName("binds correct parameters")
+        void deleteLoadoutDisplay_bindsCorrectParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            int loadoutSlot = 5;
 
-        List<PreparedStatement> result = LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, mockLoadout);
+            List<PreparedStatement> result = LoadoutDisplayDAO.deleteLoadoutDisplay(mockConnection, PLAYER_UUID, loadoutSlot);
 
-        assertTrue(result.isEmpty());
+            assertEquals(1, result.size());
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setInt(2, loadoutSlot);
+        }
+
+        @Test
+        @DisplayName("returns empty list when SQLException is thrown")
+        void deleteLoadoutDisplay_returnsEmptyList_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            List<PreparedStatement> result = LoadoutDisplayDAO.deleteLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
+
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @Test
-    @DisplayName("saveLoadoutDisplay with Loadout delegates to overload when display should be saved")
-    void saveLoadoutDisplay_delegatesToOverload_whenShouldSaveDisplay() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("getLoadoutDisplay")
+    class GetLoadoutDisplay {
 
-        CustomItemWrapper mockItem = mock(CustomItemWrapper.class);
-        when(mockItem.customItem()).thenReturn(Optional.of("CHERRY_SIGN"));
-        when(mockItem.material()).thenReturn(Optional.of(Material.CHERRY_SIGN));
+        @Test
+        @DisplayName("returns empty when no row exists")
+        void getLoadoutDisplay_returnsEmpty_whenNoRow() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        LoadoutDisplay mockDisplay = mock(LoadoutDisplay.class);
-        when(mockDisplay.getDisplayItem()).thenReturn(mockItem);
-        when(mockDisplay.getDisplayName()).thenReturn(Optional.of("Custom Name"));
+            Optional<LoadoutDisplay> result = LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
 
-        Loadout mockLoadout = mock(Loadout.class);
-        when(mockLoadout.shouldSaveDisplay()).thenReturn(true);
-        when(mockLoadout.getLoadoutSlot()).thenReturn(3);
-        when(mockLoadout.getDisplay()).thenReturn(mockDisplay);
+            assertTrue(result.isEmpty());
+        }
 
-        List<PreparedStatement> result = LoadoutDisplayDAO.saveLoadoutDisplay(mockConnection, PLAYER_UUID, mockLoadout);
+        @Test
+        @DisplayName("returns display when row exists")
+        void getLoadoutDisplay_returnsDisplay_whenRowExists() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("display_item")).thenReturn("DIAMOND_SWORD");
+            when(mockResultSet.getString("display_name")).thenReturn("Battle Loadout");
 
-        assertEquals(1, result.size());
-        verify(mockStatement).setString(1, PLAYER_UUID.toString());
-        verify(mockStatement).setInt(2, 3);
-    }
+            Optional<LoadoutDisplay> result = LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
 
-    @Test
-    @DisplayName("deleteLoadoutDisplay binds correct parameters")
-    void deleteLoadoutDisplay_bindsCorrectParameters() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        int loadoutSlot = 5;
+            assertTrue(result.isPresent());
+        }
 
-        List<PreparedStatement> result = LoadoutDisplayDAO.deleteLoadoutDisplay(mockConnection, PLAYER_UUID, loadoutSlot);
+        @Test
+        @DisplayName("returns display with null display name")
+        void getLoadoutDisplay_returnsDisplay_whenDisplayNameIsNull() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("display_item")).thenReturn("STONE");
+            when(mockResultSet.getString("display_name")).thenReturn(null);
 
-        assertEquals(1, result.size());
-        verify(mockStatement).setString(1, PLAYER_UUID.toString());
-        verify(mockStatement).setInt(2, loadoutSlot);
-    }
+            Optional<LoadoutDisplay> result = LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
 
-    @Test
-    @DisplayName("getLoadoutDisplay returns empty when no row exists")
-    void getLoadoutDisplay_returnsEmpty_whenNoRow() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+            assertTrue(result.isPresent());
+        }
 
-        Optional<LoadoutDisplay> result = LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
+        @Test
+        @DisplayName("binds UUID and loadout slot parameters")
+        void getLoadoutDisplay_bindsParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        assertTrue(result.isEmpty());
-    }
+            LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 4);
 
-    @Test
-    @DisplayName("getLoadoutDisplay returns display when row exists")
-    void getLoadoutDisplay_returnsDisplay_whenRowExists() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
-        when(mockResultSet.getString("display_item")).thenReturn("DIAMOND_SWORD");
-        when(mockResultSet.getString("display_name")).thenReturn("Battle Loadout");
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setInt(2, 4);
+        }
 
-        Optional<LoadoutDisplay> result = LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
+        @Test
+        @DisplayName("returns empty on SQLException")
+        void getLoadoutDisplay_returnsEmpty_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
 
-        assertTrue(result.isPresent());
+            Optional<LoadoutDisplay> result = LoadoutDisplayDAO.getLoadoutDisplay(mockConnection, PLAYER_UUID, 1);
+
+            assertTrue(result.isEmpty());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/LoadoutDisplayDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/LoadoutDisplayDAOTest.java
@@ -387,7 +387,7 @@ class LoadoutDisplayDAOTest extends McRPGBaseTest {
 
             List<PreparedStatement> result = LoadoutDisplayDAO.saveAllLoadoutDisplays(mockConnection, mockHolder);
 
-            assertFalse(result.isEmpty());
+            assertEquals(4, result.size());
         }
 
         @Test

--- a/src/test/java/us/eunoians/mcrpg/database/table/PlayerLoadoutSelectionDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/PlayerLoadoutSelectionDAOTest.java
@@ -1,7 +1,11 @@
 package us.eunoians.mcrpg.database.table;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
 import java.sql.Connection;
@@ -16,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,133 +32,238 @@ class PlayerLoadoutSelectionDAOTest extends McRPGBaseTest {
 
     private static final UUID PLAYER_UUID = UUID.randomUUID();
 
-    @Test
-    @DisplayName("getActiveLoadout returns stored loadout id")
-    void getActiveLoadout_returnsStoredId() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
-        when(mockResultSet.getInt("active_loadout_id")).thenReturn(3);
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-        int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+        @Test
+        @DisplayName("returns false when table already exists")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME)).thenReturn(true);
 
-        assertEquals(3, result);
+            boolean result = PlayerLoadoutSelectionDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("returns true and executes CREATE TABLE when table does not exist")
+        void attemptCreateTable_returnsTrue_whenTableDoesNotExist() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = PlayerLoadoutSelectionDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("returns false when SQLException is thrown during creation")
+        void attemptCreateTable_returnsFalse_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            boolean result = PlayerLoadoutSelectionDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("CREATE TABLE SQL references the loadout info table")
+        void attemptCreateTable_referencesLoadoutInfoTable() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            PlayerLoadoutSelectionDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            verify(mockConnection).prepareStatement(org.mockito.ArgumentMatchers.contains("CREATE TABLE"));
+        }
     }
 
-    @Test
-    @DisplayName("getActiveLoadout binds UUID parameter")
-    void getActiveLoadout_bindsUuidParameter() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
-        when(mockResultSet.getInt("active_loadout_id")).thenReturn(1);
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
 
-        PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+        @Test
+        @DisplayName("skips migration when version is current")
+        void updateTable_skips_whenVersionIsCurrent() {
+            Connection mockConnection = mock(Connection.class);
 
-        verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME))
+                        .thenReturn(1);
+
+                PlayerLoadoutSelectionDAO.updateTable(mockConnection);
+
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME, 1),
+                        org.mockito.Mockito.never());
+            }
+        }
+
+        @Test
+        @DisplayName("sets version to 1 when at version 0")
+        void updateTable_setsVersionToOne_whenAtVersionZero() {
+            Connection mockConnection = mock(Connection.class);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME))
+                        .thenReturn(0);
+
+                PlayerLoadoutSelectionDAO.updateTable(mockConnection);
+
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(mockConnection, PlayerLoadoutSelectionDAO.TABLE_NAME, 1));
+            }
+        }
     }
 
-    @Test
-    @DisplayName("getActiveLoadout returns minimum of 1 when stored value is zero")
-    void getActiveLoadout_returnsMinimumOne_whenStoredValueIsZero() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
-        when(mockResultSet.getInt("active_loadout_id")).thenReturn(0);
+    @Nested
+    @DisplayName("getActiveLoadout")
+    class GetActiveLoadout {
 
-        int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+        @Test
+        @DisplayName("returns stored loadout id")
+        void getActiveLoadout_returnsStoredId() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getInt("active_loadout_id")).thenReturn(3);
 
-        assertEquals(1, result);
+            int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+
+            assertEquals(3, result);
+        }
+
+        @Test
+        @DisplayName("binds UUID parameter")
+        void getActiveLoadout_bindsUuidParameter() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getInt("active_loadout_id")).thenReturn(1);
+
+            PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+        }
+
+        @Test
+        @DisplayName("returns minimum of 1 when stored value is zero")
+        void getActiveLoadout_returnsMinimumOne_whenStoredValueIsZero() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getInt("active_loadout_id")).thenReturn(0);
+
+            int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+
+            assertEquals(1, result);
+        }
+
+        @Test
+        @DisplayName("returns minimum of 1 when stored value is negative")
+        void getActiveLoadout_returnsMinimumOne_whenStoredValueIsNegative() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getInt("active_loadout_id")).thenReturn(-5);
+
+            int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+
+            assertEquals(1, result);
+        }
+
+        @Test
+        @DisplayName("defaults to 1 on SQL exception")
+        void getActiveLoadout_defaultsToOne_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+
+            assertEquals(1, result);
+        }
+
+        @Test
+        @DisplayName("returns 1 when no row exists")
+        void getActiveLoadout_returnsOne_whenNoRowExists() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+            when(mockResultSet.getInt("active_loadout_id")).thenReturn(0);
+
+            int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+
+            assertEquals(1, result);
+        }
     }
 
-    @Test
-    @DisplayName("getActiveLoadout returns minimum of 1 when stored value is negative")
-    void getActiveLoadout_returnsMinimumOne_whenStoredValueIsNegative() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
-        when(mockResultSet.getInt("active_loadout_id")).thenReturn(-5);
+    @Nested
+    @DisplayName("setActiveLoadout")
+    class SetActiveLoadout {
 
-        int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+        @Test
+        @DisplayName("uses REPLACE INTO and binds UUID and loadout id")
+        void setActiveLoadout_bindsAllParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertEquals(1, result);
-    }
+            List<PreparedStatement> result = PlayerLoadoutSelectionDAO.setActiveLoadout(mockConnection, PLAYER_UUID, 2);
 
-    @Test
-    @DisplayName("getActiveLoadout defaults to 1 on SQL exception")
-    void getActiveLoadout_defaultsToOne_whenSqlExceptionThrown() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+            assertFalse(result.isEmpty());
+            verify(mockConnection).prepareStatement(org.mockito.ArgumentMatchers.contains("REPLACE INTO"));
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setInt(2, 2);
+        }
 
-        int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
+        @Test
+        @DisplayName("returns list with one prepared statement")
+        void setActiveLoadout_returnsSingleStatement() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertEquals(1, result);
-    }
+            List<PreparedStatement> result = PlayerLoadoutSelectionDAO.setActiveLoadout(mockConnection, PLAYER_UUID, 1);
 
-    @Test
-    @DisplayName("setActiveLoadout uses REPLACE INTO and binds UUID and loadout id")
-    void setActiveLoadout_bindsAllParameters() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            assertEquals(1, result.size());
+            assertTrue(result.contains(mockStatement));
+        }
 
-        List<PreparedStatement> result = PlayerLoadoutSelectionDAO.setActiveLoadout(mockConnection, PLAYER_UUID, 2);
+        @Test
+        @DisplayName("returns empty list on SQL exception")
+        void setActiveLoadout_returnsEmptyList_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
 
-        assertFalse(result.isEmpty());
-        verify(mockConnection).prepareStatement(org.mockito.ArgumentMatchers.contains("REPLACE INTO"));
-        verify(mockStatement).setString(1, PLAYER_UUID.toString());
-        verify(mockStatement).setInt(2, 2);
-    }
+            List<PreparedStatement> result = PlayerLoadoutSelectionDAO.setActiveLoadout(mockConnection, PLAYER_UUID, 2);
 
-    @Test
-    @DisplayName("setActiveLoadout returns list with one prepared statement")
-    void setActiveLoadout_returnsSingleStatement() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-
-        List<PreparedStatement> result = PlayerLoadoutSelectionDAO.setActiveLoadout(mockConnection, PLAYER_UUID, 1);
-
-        assertEquals(1, result.size());
-        assertTrue(result.contains(mockStatement));
-    }
-
-    @Test
-    @DisplayName("getActiveLoadout returns 1 when no row exists")
-    void getActiveLoadout_returnsOne_whenNoRowExists() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
-        when(mockResultSet.getInt("active_loadout_id")).thenReturn(0);
-
-        int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
-
-        assertEquals(1, result);
-    }
-
-    @Test
-    @DisplayName("setActiveLoadout returns empty list on SQL exception")
-    void setActiveLoadout_returnsEmptyList_whenSqlExceptionThrown() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
-
-        List<PreparedStatement> result = PlayerLoadoutSelectionDAO.setActiveLoadout(mockConnection, PLAYER_UUID, 2);
-
-        assertTrue(result.isEmpty());
+            assertTrue(result.isEmpty());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/PlayerLoadoutSelectionDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/PlayerLoadoutSelectionDAOTest.java
@@ -207,7 +207,7 @@ class PlayerLoadoutSelectionDAOTest extends McRPGBaseTest {
         }
 
         @Test
-        @DisplayName("returns 1 when no row exists")
+        @DisplayName("returns 1 when no row exists and getInt throws after empty result set")
         void getActiveLoadout_returnsOne_whenNoRowExists() throws SQLException {
             Connection mockConnection = mock(Connection.class);
             PreparedStatement mockStatement = mock(PreparedStatement.class);
@@ -215,7 +215,8 @@ class PlayerLoadoutSelectionDAOTest extends McRPGBaseTest {
             when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
             when(mockStatement.executeQuery()).thenReturn(mockResultSet);
             when(mockResultSet.next()).thenReturn(false);
-            when(mockResultSet.getInt("active_loadout_id")).thenReturn(0);
+            when(mockResultSet.getInt("active_loadout_id"))
+                    .thenThrow(new SQLException("ResultSet is empty"));
 
             int result = PlayerLoadoutSelectionDAO.getActiveLoadout(mockConnection, PLAYER_UUID);
 

--- a/src/test/java/us/eunoians/mcrpg/database/table/PlayerStatDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/PlayerStatDAOTest.java
@@ -1,7 +1,9 @@
 package us.eunoians.mcrpg.database.table;
 
+import com.diamonddagger590.mccore.database.Database;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
@@ -9,12 +11,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -33,128 +38,323 @@ class PlayerStatDAOTest extends McRPGBaseTest {
     private static final NamespacedKey MANA_KEY = new NamespacedKey("mcrpg", "mana");
     private static final UUID PLAYER_UUID = UUID.randomUUID();
 
-    // saveStat
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-    @DisplayName("saveStat uses REPLACE INTO and binds all three parameters")
-    @Test
-    void saveStat_bindsAllParameters() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        @Test
+        @DisplayName("returns false when table already exists")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_player_stat")).thenReturn(true);
 
-        PlayerStatDAO.saveStat(mockConnection, PLAYER_UUID, MANA_KEY, 75.0);
+            boolean result = PlayerStatDAO.attemptCreateTable(mockConnection, mockDatabase);
 
-        verify(mockConnection).prepareStatement(org.mockito.ArgumentMatchers.contains("REPLACE INTO"));
-        verify(mockStatement).setString(1, PLAYER_UUID.toString());
-        verify(mockStatement).setString(2, MANA_KEY.toString());
-        verify(mockStatement).setDouble(3, 75.0);
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("returns true and executes CREATE TABLE when table does not exist")
+        void attemptCreateTable_returnsTrue_whenTableDoesNotExist() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_player_stat")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = PlayerStatDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("returns false when SQLException is thrown during creation")
+        void attemptCreateTable_returnsFalse_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_player_stat")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            boolean result = PlayerStatDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("CREATE TABLE SQL includes composite primary key")
+        void attemptCreateTable_includesCompositePrimaryKey() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_player_stat")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            PlayerStatDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            verify(mockConnection).prepareStatement(org.mockito.ArgumentMatchers.contains("PRIMARY KEY"));
+        }
     }
 
-    @DisplayName("saveStat returns the prepared statement")
-    @Test
-    void saveStat_returnsPreparedStatement() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("saveStat")
+    class SaveStat {
 
-        PreparedStatement result = PlayerStatDAO.saveStat(mockConnection, PLAYER_UUID, MANA_KEY, 50.0);
+        @Test
+        @DisplayName("uses REPLACE INTO and binds all three parameters")
+        void saveStat_bindsAllParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertEquals(mockStatement, result);
+            PlayerStatDAO.saveStat(mockConnection, PLAYER_UUID, MANA_KEY, 75.0);
+
+            verify(mockConnection).prepareStatement(org.mockito.ArgumentMatchers.contains("REPLACE INTO"));
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setString(2, MANA_KEY.toString());
+            verify(mockStatement).setDouble(3, 75.0);
+        }
+
+        @Test
+        @DisplayName("returns the prepared statement")
+        void saveStat_returnsPreparedStatement() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            PreparedStatement result = PlayerStatDAO.saveStat(mockConnection, PLAYER_UUID, MANA_KEY, 50.0);
+
+            assertEquals(mockStatement, result);
+        }
+
+        @Test
+        @DisplayName("propagates SQLException to caller")
+        void saveStat_propagatesSQLException() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            assertThrows(SQLException.class, () -> PlayerStatDAO.saveStat(mockConnection, PLAYER_UUID, MANA_KEY, 50.0));
+        }
     }
 
-    // loadStat
+    @Nested
+    @DisplayName("saveStats")
+    class SaveStats {
 
-    @DisplayName("loadStat returns empty when no row exists")
-    @Test
-    void loadStat_returnsEmptyWhenNoResults() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+        @Test
+        @DisplayName("returns one statement per map entry")
+        void saveStats_returnsOneStatementPerEntry() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        Optional<Double> result = PlayerStatDAO.loadStat(mockConnection, PLAYER_UUID, MANA_KEY);
+            NamespacedKey healthKey = new NamespacedKey("mcrpg", "health");
+            Map<NamespacedKey, Double> stats = new LinkedHashMap<>();
+            stats.put(MANA_KEY, 50.0);
+            stats.put(healthKey, 100.0);
 
-        assertTrue(result.isEmpty());
+            List<PreparedStatement> result = PlayerStatDAO.saveStats(mockConnection, PLAYER_UUID, stats);
+
+            assertEquals(2, result.size());
+        }
+
+        @Test
+        @DisplayName("returns empty list for empty map")
+        void saveStats_returnsEmptyList_whenMapIsEmpty() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+
+            List<PreparedStatement> result = PlayerStatDAO.saveStats(mockConnection, PLAYER_UUID, Map.of());
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("propagates SQLException from saveStat")
+        void saveStats_propagatesSQLException() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            Map<NamespacedKey, Double> stats = Map.of(MANA_KEY, 50.0);
+
+            assertThrows(SQLException.class, () -> PlayerStatDAO.saveStats(mockConnection, PLAYER_UUID, stats));
+        }
+
+        @Test
+        @DisplayName("binds correct values for each stat entry")
+        void saveStats_bindsCorrectValuesForEachEntry() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement1 = mock(PreparedStatement.class);
+            PreparedStatement mockStatement2 = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString()))
+                    .thenReturn(mockStatement1)
+                    .thenReturn(mockStatement2);
+
+            NamespacedKey healthKey = new NamespacedKey("mcrpg", "health");
+            Map<NamespacedKey, Double> stats = new LinkedHashMap<>();
+            stats.put(MANA_KEY, 50.0);
+            stats.put(healthKey, 100.0);
+
+            List<PreparedStatement> result = PlayerStatDAO.saveStats(mockConnection, PLAYER_UUID, stats);
+
+            assertEquals(2, result.size());
+            verify(mockStatement1).setString(2, MANA_KEY.toString());
+            verify(mockStatement1).setDouble(3, 50.0);
+            verify(mockStatement2).setString(2, healthKey.toString());
+            verify(mockStatement2).setDouble(3, 100.0);
+        }
     }
 
-    @DisplayName("loadStat returns the persisted value when a row exists")
-    @Test
-    void loadStat_returnsValueWhenPresent() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true, false);
-        when(mockResultSet.getDouble("current_value")).thenReturn(42.0);
+    @Nested
+    @DisplayName("loadStat")
+    class LoadStat {
 
-        Optional<Double> result = PlayerStatDAO.loadStat(mockConnection, PLAYER_UUID, MANA_KEY);
+        @Test
+        @DisplayName("returns empty when no row exists")
+        void loadStat_returnsEmptyWhenNoResults() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        assertTrue(result.isPresent());
-        assertEquals(42.0, result.get());
+            Optional<Double> result = PlayerStatDAO.loadStat(mockConnection, PLAYER_UUID, MANA_KEY);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns the persisted value when a row exists")
+        void loadStat_returnsValueWhenPresent() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getDouble("current_value")).thenReturn(42.0);
+
+            Optional<Double> result = PlayerStatDAO.loadStat(mockConnection, PLAYER_UUID, MANA_KEY);
+
+            assertTrue(result.isPresent());
+            assertEquals(42.0, result.get());
+        }
+
+        @Test
+        @DisplayName("binds UUID and stat key parameters")
+        void loadStat_bindsParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            PlayerStatDAO.loadStat(mockConnection, PLAYER_UUID, MANA_KEY);
+
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setString(2, MANA_KEY.toString());
+        }
+
+        @Test
+        @DisplayName("returns empty on SQLException")
+        void loadStat_returnsEmpty_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            Optional<Double> result = PlayerStatDAO.loadStat(mockConnection, PLAYER_UUID, MANA_KEY);
+
+            assertTrue(result.isEmpty());
+        }
     }
 
-    // loadAllStats
+    @Nested
+    @DisplayName("loadAllStats")
+    class LoadAllStats {
 
-    @DisplayName("loadAllStats returns empty map when no rows exist")
-    @Test
-    void loadAllStats_returnsEmptyWhenNoResults() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+        @Test
+        @DisplayName("returns empty map when no rows exist")
+        void loadAllStats_returnsEmptyWhenNoResults() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
+            Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
 
-        assertTrue(result.isEmpty());
-    }
+            assertTrue(result.isEmpty());
+        }
 
-    @DisplayName("loadAllStats silently skips rows whose stat_key cannot be parsed as a NamespacedKey")
-    @Test
-    void loadAllStats_skipsNullKey() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        // Row 1: invalid key (spaces → NamespacedKey.fromString returns null) — getDouble NOT called
-        // Row 2: valid key — getDouble IS called (first and only call, returns 88.0)
-        when(mockResultSet.next()).thenReturn(true, true, false);
-        when(mockResultSet.getString("stat_key"))
-                .thenReturn("not a valid key", MANA_KEY.toString());
-        when(mockResultSet.getDouble("current_value"))
-                .thenReturn(88.0);
+        @Test
+        @DisplayName("silently skips rows whose stat_key cannot be parsed as a NamespacedKey")
+        void loadAllStats_skipsNullKey() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("stat_key"))
+                    .thenReturn("not a valid key", MANA_KEY.toString());
+            when(mockResultSet.getDouble("current_value"))
+                    .thenReturn(88.0);
 
-        Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
+            Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
 
-        assertFalse(result.containsKey(null));
-        assertEquals(1, result.size());
-        assertEquals(88.0, result.get(MANA_KEY));
-    }
+            assertFalse(result.containsKey(null));
+            assertEquals(1, result.size());
+            assertEquals(88.0, result.get(MANA_KEY));
+        }
 
-    @DisplayName("loadAllStats returns all valid rows")
-    @Test
-    void loadAllStats_returnsAllValidRows() throws SQLException {
-        NamespacedKey healthKey = new NamespacedKey("mcrpg", "health");
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true, true, false);
-        when(mockResultSet.getString("stat_key"))
-                .thenReturn(MANA_KEY.toString(), healthKey.toString());
-        when(mockResultSet.getDouble("current_value"))
-                .thenReturn(60.0, 100.0);
+        @Test
+        @DisplayName("returns all valid rows")
+        void loadAllStats_returnsAllValidRows() throws SQLException {
+            NamespacedKey healthKey = new NamespacedKey("mcrpg", "health");
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("stat_key"))
+                    .thenReturn(MANA_KEY.toString(), healthKey.toString());
+            when(mockResultSet.getDouble("current_value"))
+                    .thenReturn(60.0, 100.0);
 
-        Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
+            Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
 
-        assertEquals(2, result.size());
-        assertEquals(60.0, result.get(MANA_KEY));
-        assertEquals(100.0, result.get(healthKey));
+            assertEquals(2, result.size());
+            assertEquals(60.0, result.get(MANA_KEY));
+            assertEquals(100.0, result.get(healthKey));
+        }
+
+        @Test
+        @DisplayName("binds UUID parameter")
+        void loadAllStats_bindsUuidParameter() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
+
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+        }
+
+        @Test
+        @DisplayName("returns empty map on SQLException")
+        void loadAllStats_returnsEmptyMap_whenSQLExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            Map<NamespacedKey, Double> result = PlayerStatDAO.loadAllStats(mockConnection, PLAYER_UUID);
+
+            assertTrue(result.isEmpty());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
@@ -1,8 +1,12 @@
 package us.eunoians.mcrpg.database.table.board;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
 import java.sql.Connection;
@@ -13,93 +17,456 @@ import java.sql.Types;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-public class PlayerBoardStateDAOTest extends McRPGBaseTest {
+@DisplayName("PlayerBoardStateDAO")
+class PlayerBoardStateDAOTest extends McRPGBaseTest {
 
-    @DisplayName("saveState returns prepared statements")
-    @Test
-    void saveState_returnsPreparedStatements() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    private static final UUID PLAYER_UUID = UUID.randomUUID();
+    private static final NamespacedKey BOARD_KEY = new NamespacedKey("mcrpg", "main_board");
 
-        UUID playerUUID = UUID.randomUUID();
-        UUID offeringId = UUID.randomUUID();
-        UUID questInstanceUUID = UUID.randomUUID();
-        NamespacedKey boardKey = new NamespacedKey("mcrpg", "main_board");
-        long acceptedAt = System.currentTimeMillis();
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-        List<PreparedStatement> statements = PlayerBoardStateDAO.saveState(
-                mockConnection,
-                playerUUID,
-                boardKey,
-                offeringId,
-                "ACCEPTED",
-                acceptedAt,
-                questInstanceUUID
-        );
+        @Test
+        @DisplayName("Returns false when table already exists")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerBoardStateDAO.TABLE_NAME)).thenReturn(true);
 
-        assertNotNull(statements);
-        assertFalse(statements.isEmpty());
+            boolean result = PlayerBoardStateDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Returns true when table is created successfully")
+        void attemptCreateTable_returnsTrue_whenCreatedSuccessfully() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerBoardStateDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            boolean result = PlayerBoardStateDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Returns false when SQLException is thrown during creation")
+        void attemptCreateTable_returnsFalse_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabase.tableExists(mockConnection, PlayerBoardStateDAO.TABLE_NAME)).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("create failed"));
+
+            boolean result = PlayerBoardStateDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
     }
 
-    @DisplayName("saveState handles null optional fields")
-    @Test
-    void saveState_handlesNullOptionalFields() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
 
-        UUID playerUUID = UUID.randomUUID();
-        UUID offeringId = UUID.randomUUID();
-        NamespacedKey boardKey = new NamespacedKey("mcrpg", "main_board");
+        @Test
+        @DisplayName("No-ops when table is already at current version")
+        void updateTable_noOps_whenAlreadyAtCurrentVersion() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
 
-        PlayerBoardStateDAO.saveState(mockConnection, playerUUID, boardKey, offeringId, "VISIBLE", null, null);
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, PlayerBoardStateDAO.TABLE_NAME))
+                        .thenReturn(1);
 
-        verify(mockStatement).setNull(eq(5), eq(Types.BIGINT));
-        verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+                PlayerBoardStateDAO.updateTable(mockConnection);
+
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(eq(mockConnection), eq(PlayerBoardStateDAO.TABLE_NAME), eq(1)),
+                        org.mockito.Mockito.never());
+            }
+        }
+
+        @Test
+        @DisplayName("Creates indexes when upgrading from version 0")
+        void updateTable_createsIndexes_whenUpgradingFromVersionZero() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            try (MockedStatic<TableVersionHistoryDAO> mockedHistory = mockStatic(TableVersionHistoryDAO.class)) {
+                mockedHistory.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, PlayerBoardStateDAO.TABLE_NAME))
+                        .thenReturn(0);
+
+                PlayerBoardStateDAO.updateTable(mockConnection);
+
+                verify(mockStatement, org.mockito.Mockito.times(2)).executeUpdate();
+                mockedHistory.verify(() -> TableVersionHistoryDAO.setTableVersion(mockConnection, PlayerBoardStateDAO.TABLE_NAME, 1));
+            }
+        }
     }
 
-    @DisplayName("countActiveQuestsFromBoard returns zero when no results")
-    @Test
-    void countActiveQuestsFromBoard_returnsZeroWhenNoResults() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+    @Nested
+    @DisplayName("saveState")
+    class SaveState {
 
-        int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(
-                mockConnection,
-                UUID.randomUUID(),
-                new NamespacedKey("mcrpg", "main_board")
-        );
+        @Test
+        @DisplayName("Returns prepared statements with correct parameter bindings")
+        void saveState_bindsAllParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertEquals(0, result);
+            UUID offeringId = UUID.randomUUID();
+            UUID questInstanceUUID = UUID.randomUUID();
+            long acceptedAt = 1000L;
+
+            List<PreparedStatement> statements = PlayerBoardStateDAO.saveState(
+                    mockConnection, PLAYER_UUID, BOARD_KEY, offeringId, "ACCEPTED", acceptedAt, questInstanceUUID);
+
+            assertEquals(1, statements.size());
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setString(2, BOARD_KEY.toString());
+            verify(mockStatement).setString(3, offeringId.toString());
+            verify(mockStatement).setString(4, "ACCEPTED");
+            verify(mockStatement).setLong(5, acceptedAt);
+            verify(mockStatement).setString(6, questInstanceUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Handles null optional fields by setting SQL NULL")
+        void saveState_setsNulls_whenOptionalFieldsAreNull() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            PlayerBoardStateDAO.saveState(mockConnection, PLAYER_UUID, BOARD_KEY, UUID.randomUUID(), "VISIBLE", null, null);
+
+            verify(mockStatement).setNull(eq(5), eq(Types.BIGINT));
+            verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+        }
+
+        @Test
+        @DisplayName("Returns empty list when SQLException is thrown")
+        void saveState_returnsEmptyList_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("connection error"));
+
+            List<PreparedStatement> result = PlayerBoardStateDAO.saveState(
+                    mockConnection, PLAYER_UUID, BOARD_KEY, UUID.randomUUID(), "ACCEPTED", 1000L, UUID.randomUUID());
+
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("countActiveQuestsFromBoard returns count when present")
-    @Test
-    void countActiveQuestsFromBoard_returnsCountWhenPresent() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true, false);
-        when(mockResultSet.getInt(1)).thenReturn(3);
+    @Nested
+    @DisplayName("deleteForPlayer")
+    class DeleteForPlayer {
 
-        int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(
-                mockConnection,
-                UUID.randomUUID(),
-                new NamespacedKey("mcrpg", "main_board")
-        );
+        @Test
+        @DisplayName("Binds UUID parameter and returns deleted row count")
+        void deleteForPlayer_bindsAndReturnsRowCount() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(5);
 
-        assertEquals(3, result);
+            int result = PlayerBoardStateDAO.deleteForPlayer(mockConnection, PLAYER_UUID);
+
+            assertEquals(5, result);
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+        }
+
+        @Test
+        @DisplayName("Returns 0 when no rows are deleted")
+        void deleteForPlayer_returnsZero_whenNoRowsDeleted() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int result = PlayerBoardStateDAO.deleteForPlayer(mockConnection, PLAYER_UUID);
+
+            assertEquals(0, result);
+        }
+
+        @Test
+        @DisplayName("Returns 0 when SQLException is thrown")
+        void deleteForPlayer_returnsZero_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("error"));
+
+            int result = PlayerBoardStateDAO.deleteForPlayer(mockConnection, PLAYER_UUID);
+
+            assertEquals(0, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("loadAcceptedForPlayer")
+    class LoadAcceptedForPlayer {
+
+        @Test
+        @DisplayName("Returns entries with offering and quest instance UUIDs")
+        void loadAcceptedForPlayer_returnsEntries() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+            UUID offeringId = UUID.randomUUID();
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getString("offering_id")).thenReturn(offeringId.toString());
+            when(mockResultSet.getString("quest_instance_uuid")).thenReturn(questUUID.toString());
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, PLAYER_UUID);
+
+            assertEquals(1, entries.size());
+            assertEquals(offeringId, entries.get(0).offeringId());
+            assertEquals(questUUID, entries.get(0).questInstanceUUID());
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+        }
+
+        @Test
+        @DisplayName("Handles null quest_instance_uuid")
+        void loadAcceptedForPlayer_handlesNullQuestUUID() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getString("offering_id")).thenReturn(UUID.randomUUID().toString());
+            when(mockResultSet.getString("quest_instance_uuid")).thenReturn(null);
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, PLAYER_UUID);
+
+            assertEquals(1, entries.size());
+            assertNull(entries.get(0).questInstanceUUID());
+        }
+
+        @Test
+        @DisplayName("Returns empty list when no accepted entries exist")
+        void loadAcceptedForPlayer_returnsEmptyList_whenNoEntries() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, PLAYER_UUID);
+
+            assertTrue(entries.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Returns empty list when SQLException is thrown")
+        void loadAcceptedForPlayer_returnsEmptyList_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("error"));
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, PLAYER_UUID);
+
+            assertTrue(entries.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStateByQuestInstanceUUID")
+    class UpdateStateByQuestInstanceUUID {
+
+        @Test
+        @DisplayName("Binds parameters and returns updated row count")
+        void updateStateByQuestInstanceUUID_bindsAndReturnsCount() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(1);
+
+            UUID questUUID = UUID.randomUUID();
+            int result = PlayerBoardStateDAO.updateStateByQuestInstanceUUID(mockConnection, questUUID, "COMPLETED");
+
+            assertEquals(1, result);
+            verify(mockStatement).setString(1, "COMPLETED");
+            verify(mockStatement).setString(2, questUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Returns 0 when no rows match")
+        void updateStateByQuestInstanceUUID_returnsZero_whenNoRowsMatch() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int result = PlayerBoardStateDAO.updateStateByQuestInstanceUUID(mockConnection, UUID.randomUUID(), "CANCELLED");
+
+            assertEquals(0, result);
+        }
+
+        @Test
+        @DisplayName("Returns 0 when SQLException is thrown")
+        void updateStateByQuestInstanceUUID_returnsZero_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("error"));
+
+            int result = PlayerBoardStateDAO.updateStateByQuestInstanceUUID(mockConnection, UUID.randomUUID(), "COMPLETED");
+
+            assertEquals(0, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("bulkCancelExpiredBoardStates")
+    class BulkCancelExpiredBoardStates {
+
+        @Test
+        @DisplayName("Returns number of updated rows")
+        void bulkCancelExpiredBoardStates_returnsUpdatedCount() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(7);
+
+            int result = PlayerBoardStateDAO.bulkCancelExpiredBoardStates(mockConnection);
+
+            assertEquals(7, result);
+        }
+
+        @Test
+        @DisplayName("Returns 0 when no rows match")
+        void bulkCancelExpiredBoardStates_returnsZero_whenNoRowsMatch() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int result = PlayerBoardStateDAO.bulkCancelExpiredBoardStates(mockConnection);
+
+            assertEquals(0, result);
+        }
+
+        @Test
+        @DisplayName("Returns 0 when SQLException is thrown")
+        void bulkCancelExpiredBoardStates_returnsZero_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("error"));
+
+            int result = PlayerBoardStateDAO.bulkCancelExpiredBoardStates(mockConnection);
+
+            assertEquals(0, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("countActiveQuestsFromBoard")
+    class CountActiveQuestsFromBoard {
+
+        @Test
+        @DisplayName("Returns count when row exists")
+        void countActiveQuestsFromBoard_returnsCount_whenRowExists() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getInt(1)).thenReturn(3);
+
+            int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(mockConnection, PLAYER_UUID, BOARD_KEY);
+
+            assertEquals(3, result);
+        }
+
+        @Test
+        @DisplayName("Binds player UUID and board key parameters")
+        void countActiveQuestsFromBoard_bindsParameters() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getInt(1)).thenReturn(0);
+
+            PlayerBoardStateDAO.countActiveQuestsFromBoard(mockConnection, PLAYER_UUID, BOARD_KEY);
+
+            verify(mockStatement).setString(1, PLAYER_UUID.toString());
+            verify(mockStatement).setString(2, BOARD_KEY.toString());
+        }
+
+        @Test
+        @DisplayName("Returns 0 when no result row exists")
+        void countActiveQuestsFromBoard_returnsZero_whenNoResultRow() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(mockConnection, PLAYER_UUID, BOARD_KEY);
+
+            assertEquals(0, result);
+        }
+
+        @Test
+        @DisplayName("Returns 0 when SQLException is thrown")
+        void countActiveQuestsFromBoard_returnsZero_whenSqlExceptionThrown() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("error"));
+
+            int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(mockConnection, PLAYER_UUID, BOARD_KEY);
+
+            assertEquals(0, result);
+        }
+    }
+
+    @Nested
+    @DisplayName("AcceptedBoardEntry")
+    class AcceptedBoardEntryTest {
+
+        @Test
+        @DisplayName("Record accessors return constructor values")
+        void acceptedBoardEntry_accessorsReturnValues() {
+            UUID offeringId = UUID.randomUUID();
+            UUID questUUID = UUID.randomUUID();
+
+            PlayerBoardStateDAO.AcceptedBoardEntry entry = new PlayerBoardStateDAO.AcceptedBoardEntry(offeringId, questUUID);
+
+            assertEquals(offeringId, entry.offeringId());
+            assertEquals(questUUID, entry.questInstanceUUID());
+        }
+
+        @Test
+        @DisplayName("Record supports null quest instance UUID")
+        void acceptedBoardEntry_supportsNullQuestUUID() {
+            UUID offeringId = UUID.randomUUID();
+
+            PlayerBoardStateDAO.AcceptedBoardEntry entry = new PlayerBoardStateDAO.AcceptedBoardEntry(offeringId, null);
+
+            assertNotNull(entry.offeringId());
+            assertNull(entry.questInstanceUUID());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
@@ -263,6 +263,33 @@ class PlayerBoardStateDAOTest extends McRPGBaseTest {
         }
 
         @Test
+        @DisplayName("Returns multiple entries when multiple rows exist")
+        void loadAcceptedForPlayer_returnsMultipleEntries() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+            UUID offeringId1 = UUID.randomUUID();
+            UUID questUUID1 = UUID.randomUUID();
+            UUID offeringId2 = UUID.randomUUID();
+            UUID questUUID2 = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("offering_id"))
+                    .thenReturn(offeringId1.toString(), offeringId2.toString());
+            when(mockResultSet.getString("quest_instance_uuid"))
+                    .thenReturn(questUUID1.toString(), questUUID2.toString());
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, PLAYER_UUID);
+
+            assertEquals(2, entries.size());
+            assertEquals(offeringId1, entries.get(0).offeringId());
+            assertEquals(offeringId2, entries.get(1).offeringId());
+        }
+
+        @Test
         @DisplayName("Returns empty list when no accepted entries exist")
         void loadAcceptedForPlayer_returnsEmptyList_whenNoEntries() throws SQLException {
             Connection mockConnection = mock(Connection.class);


### PR DESCRIPTION
## Summary

- **PlayerBoardStateDAO**: Expanded from 4 to ~29 tests — covers all 8 public methods (`attemptCreateTable`, `updateTable`, `saveState`, `deleteForPlayer`, `loadAcceptedForPlayer`, `updateStateByQuestInstanceUUID`, `bulkCancelExpiredBoardStates`, `countActiveQuestsFromBoard`) plus `AcceptedBoardEntry` record, including multi-row iteration and SQL exception paths
- **LoadoutDisplayDAO**: Expanded from 9 to ~22 tests — adds `updateTable` v1/v2 migration tests, `saveAllLoadoutDisplays` with exact statement count assertion, `columnExists` metadata/PRAGMA paths, material fallback when custom item is absent, and SQL exception paths
- **PlayerLoadoutSelectionDAO**: Expanded from 8 to ~14 tests — adds `attemptCreateTable` (exists/create/exception), `updateTable` version tracking, and fixes the no-row test to exercise the catch-block path matching real JDBC behavior
- **PlayerStatDAO**: Expanded from 7 to ~16 tests — adds `attemptCreateTable` (exists/create/exception/PK verification), `saveStats` batch (multi-entry, empty map, exception propagation, per-entry binding), and SQL exception paths for load methods

All tests use the established mock-based JDBC pattern (Mockito mocks for `Connection`, `PreparedStatement`, `ResultSet`) and follow the `@Nested`/`@DisplayName`/`action_outcome_whenCondition` naming conventions.

## Test plan

- [x] Full test suite passes (`./gradlew test` — BUILD SUCCESSFUL)
- [x] Testing audit persona (`persona-testing.mdc`) reviewed — all findings addressed
- [x] JaCoCo coverage report generated

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEUot1ASeqchbi29i1ofUS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for loadout displays, player loadouts, player statistics, and board state handling.
  * Added validation for table creation, schema updates, data saving, retrieval, and version management.
  * Improved coverage of empty results, missing optional values, database errors, and fallback behavior.
  * Added checks for SQL parameter binding, default values, and aggregate calculations.
  * Reorganized tests into clearer operation-based sections for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->