### PR TITLE
[Unit Tests] Add McRPGStatisticCacheManager tests and expand scope DAO coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/LandQuestScopeDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/LandQuestScopeDAOTest.java
@@ -1,50 +1,250 @@
 package us.eunoians.mcrpg.database.table.quest.scope;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.impl.scope.impl.LandQuestScope;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class LandQuestScopeDAOTest extends McRPGBaseTest {
+@DisplayName("LandQuestScopeDAO")
+class LandQuestScopeDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given a valid land scope, when saving, then prepared statements are returned")
-    @Test
-    public void saveScope_validScope_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    private Connection mockConnection;
+    private PreparedStatement mockStatement;
+    private ResultSet mockResultSet;
+    private Database mockDatabase;
 
-        UUID questUUID = UUID.randomUUID();
-        LandQuestScope scope = new LandQuestScope(questUUID, "my_land");
-
-        List<PreparedStatement> result = LandQuestScopeDAO.saveScope(conn, scope);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+    @BeforeEach
+    void setUp() throws SQLException {
+        mockConnection = mock(Connection.class);
+        mockStatement = mock(PreparedStatement.class);
+        mockResultSet = mock(ResultSet.class);
+        mockDatabase = mock(Database.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
     }
 
-    @DisplayName("Given a valid land scope, when saving, then connection is used")
-    @Test
-    public void saveScope_usesConnection() throws SQLException {
-        Connection conn = mock(Connection.class);
-        PreparedStatement mockPs = mock(PreparedStatement.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-        UUID questUUID = UUID.randomUUID();
-        LandQuestScope scope = new LandQuestScope(questUUID, "my_land");
+        @Test
+        @DisplayName("Given table already exists, when attempting to create, then returns false")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_land_quest_scope")).thenReturn(true);
 
-        LandQuestScopeDAO.saveScope(conn, scope);
-        verify(conn).prepareStatement(anyString());
+            boolean result = LandQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given table does not exist, when attempting to create, then creates table and returns true")
+        void attemptCreateTable_returnsTrue_whenTableCreated() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_land_quest_scope")).thenReturn(false);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            boolean result = LandQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockConnection).prepareStatement(anyString());
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given SQL exception during create, when attempting to create, then returns false")
+        void attemptCreateTable_returnsFalse_whenSqlException() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_land_quest_scope")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("create failed"));
+
+            boolean result = LandQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @Test
+        @DisplayName("Given table is already at current version, when updating, then no version update is performed")
+        void updateTable_noOp_whenAlreadyCurrentVersion() {
+            try (MockedStatic<TableVersionHistoryDAO> tvhMock = mockStatic(TableVersionHistoryDAO.class)) {
+                tvhMock.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, "mcrpg_land_quest_scope"))
+                        .thenReturn(1);
+
+                LandQuestScopeDAO.updateTable(mockConnection);
+
+                tvhMock.verify(() -> TableVersionHistoryDAO.setTableVersion(
+                        mockConnection, "mcrpg_land_quest_scope", 1), org.mockito.Mockito.never());
+            }
+        }
+
+        @Test
+        @DisplayName("Given table is at version 0, when updating, then sets version to 1")
+        void updateTable_setsVersion_whenAtVersion0() {
+            try (MockedStatic<TableVersionHistoryDAO> tvhMock = mockStatic(TableVersionHistoryDAO.class)) {
+                tvhMock.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, "mcrpg_land_quest_scope"))
+                        .thenReturn(0);
+
+                LandQuestScopeDAO.updateTable(mockConnection);
+
+                tvhMock.verify(() -> TableVersionHistoryDAO.setTableVersion(
+                        mockConnection, "mcrpg_land_quest_scope", 1));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getLandName")
+    class GetLandName {
+
+        @Test
+        @DisplayName("Given a row exists, when getting land name, then returns the land name string")
+        void getLandName_returnsLandName_whenRowExists() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("land_name")).thenReturn("TestLand");
+
+            String result = LandQuestScopeDAO.getLandName(mockConnection, questUUID);
+
+            assertEquals("TestLand", result);
+            verify(mockStatement).setString(1, questUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Given no row exists, when getting land name, then throws IllegalStateException")
+        void getLandName_throwsIllegalState_whenNoRowFound() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(false);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> LandQuestScopeDAO.getLandName(mockConnection, questUUID));
+            assertTrue(exception.getMessage().contains(questUUID.toString()));
+        }
+
+        @Test
+        @DisplayName("Given SQL exception, when getting land name, then throws RuntimeException wrapping SQLException")
+        void getLandName_throwsRuntimeException_whenSqlException() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("query failed"));
+
+            assertThrows(RuntimeException.class,
+                    () -> LandQuestScopeDAO.getLandName(mockConnection, questUUID));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllActiveLandQuests")
+    class FindAllActiveLandQuests {
+
+        @Test
+        @DisplayName("Given multiple active quests, when finding all, then returns all entries")
+        void findAllActiveLandQuests_returnsAllEntries_whenMultipleRows() throws SQLException {
+            UUID quest1 = UUID.randomUUID();
+            UUID quest2 = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("quest_uuid")).thenReturn(quest1.toString(), quest2.toString());
+            when(mockResultSet.getString("land_name")).thenReturn("LandA", "LandB");
+
+            Map<UUID, String> result = LandQuestScopeDAO.findAllActiveLandQuests(mockConnection);
+
+            assertEquals(2, result.size());
+            assertEquals("LandA", result.get(quest1));
+            assertEquals("LandB", result.get(quest2));
+        }
+
+        @Test
+        @DisplayName("Given no active quests, when finding all, then returns empty map")
+        void findAllActiveLandQuests_returnsEmptyMap_whenNoRows() throws SQLException {
+            when(mockResultSet.next()).thenReturn(false);
+
+            Map<UUID, String> result = LandQuestScopeDAO.findAllActiveLandQuests(mockConnection);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given a single active quest, when finding all, then returns single entry with correct binding")
+        void findAllActiveLandQuests_returnsSingleEntry_whenOneRow() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getString("quest_uuid")).thenReturn(questUUID.toString());
+            when(mockResultSet.getString("land_name")).thenReturn("MySingleLand");
+
+            Map<UUID, String> result = LandQuestScopeDAO.findAllActiveLandQuests(mockConnection);
+
+            assertEquals(1, result.size());
+            assertEquals("MySingleLand", result.get(questUUID));
+        }
+
+        @Test
+        @DisplayName("Given SQL exception, when finding all, then returns empty map")
+        void findAllActiveLandQuests_returnsEmptyMap_whenSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("query failed"));
+
+            Map<UUID, String> result = LandQuestScopeDAO.findAllActiveLandQuests(mockConnection);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("saveScope")
+    class SaveScope {
+
+        @Test
+        @DisplayName("Given a valid land scope, when saving, then returns prepared statements with correct bindings")
+        void saveScope_returnsStatements_whenValidScope() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            LandQuestScope scope = new LandQuestScope(questUUID, "my_land");
+
+            List<PreparedStatement> result = LandQuestScopeDAO.saveScope(mockConnection, scope);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            verify(mockStatement).setString(1, questUUID.toString());
+            verify(mockStatement).setString(2, "my_land");
+        }
+
+        @Test
+        @DisplayName("Given SQL exception during prepare, when saving, then returns empty list")
+        void saveScope_returnsEmptyList_whenSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("prepare failed"));
+
+            UUID questUUID = UUID.randomUUID();
+            LandQuestScope scope = new LandQuestScope(questUUID, "my_land");
+
+            List<PreparedStatement> result = LandQuestScopeDAO.saveScope(mockConnection, scope);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/PermissionQuestScopeDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/PermissionQuestScopeDAOTest.java
@@ -1,50 +1,236 @@
 package us.eunoians.mcrpg.database.table.quest.scope;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.impl.scope.impl.PermissionQuestScope;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class PermissionQuestScopeDAOTest extends McRPGBaseTest {
+@DisplayName("PermissionQuestScopeDAO")
+class PermissionQuestScopeDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given a valid permission scope, when saving, then prepared statements are returned")
-    @Test
-    public void saveScope_validScope_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    private Connection mockConnection;
+    private PreparedStatement mockStatement;
+    private ResultSet mockResultSet;
+    private Database mockDatabase;
 
-        UUID questUUID = UUID.randomUUID();
-        PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.some.permission");
-
-        List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(conn, scope);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+    @BeforeEach
+    void setUp() throws SQLException {
+        mockConnection = mock(Connection.class);
+        mockStatement = mock(PreparedStatement.class);
+        mockResultSet = mock(ResultSet.class);
+        mockDatabase = mock(Database.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
     }
 
-    @DisplayName("Given a valid permission scope, when saving, then connection is used")
-    @Test
-    public void saveScope_usesConnection() throws SQLException {
-        Connection conn = mock(Connection.class);
-        PreparedStatement mockPs = mock(PreparedStatement.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-        UUID questUUID = UUID.randomUUID();
-        PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.some.permission");
+        @Test
+        @DisplayName("Given table already exists, when attempting to create, then returns false")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_permission_quest_scope")).thenReturn(true);
 
-        PermissionQuestScopeDAO.saveScope(conn, scope);
-        verify(conn).prepareStatement(anyString());
+            boolean result = PermissionQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given table does not exist, when attempting to create, then creates table and returns true")
+        void attemptCreateTable_returnsTrue_whenTableCreated() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_permission_quest_scope")).thenReturn(false);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            boolean result = PermissionQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockConnection).prepareStatement(anyString());
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given SQL exception during create, when attempting to create, then returns false")
+        void attemptCreateTable_returnsFalse_whenSqlException() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_permission_quest_scope")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("create failed"));
+
+            boolean result = PermissionQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
+
+        @Test
+        @DisplayName("Given table is already at current version, when updating, then no version update is performed")
+        void updateTable_noOp_whenAlreadyCurrentVersion() {
+            try (MockedStatic<TableVersionHistoryDAO> tvhMock = mockStatic(TableVersionHistoryDAO.class)) {
+                tvhMock.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, "mcrpg_permission_quest_scope"))
+                        .thenReturn(1);
+
+                PermissionQuestScopeDAO.updateTable(mockConnection);
+
+                tvhMock.verify(() -> TableVersionHistoryDAO.setTableVersion(
+                        mockConnection, "mcrpg_permission_quest_scope", 1), org.mockito.Mockito.never());
+            }
+        }
+
+        @Test
+        @DisplayName("Given table is at version 0, when updating, then sets version to 1")
+        void updateTable_setsVersion_whenAtVersion0() {
+            try (MockedStatic<TableVersionHistoryDAO> tvhMock = mockStatic(TableVersionHistoryDAO.class)) {
+                tvhMock.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, "mcrpg_permission_quest_scope"))
+                        .thenReturn(0);
+
+                PermissionQuestScopeDAO.updateTable(mockConnection);
+
+                tvhMock.verify(() -> TableVersionHistoryDAO.setTableVersion(
+                        mockConnection, "mcrpg_permission_quest_scope", 1));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getPermissionNode")
+    class GetPermissionNode {
+
+        @Test
+        @DisplayName("Given a row exists, when getting permission node, then returns the permission node string")
+        void getPermissionNode_returnsNode_whenRowExists() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("permission_node")).thenReturn("mcrpg.test.perm");
+
+            String result = PermissionQuestScopeDAO.getPermissionNode(mockConnection, questUUID);
+
+            assertEquals("mcrpg.test.perm", result);
+            verify(mockStatement).setString(1, questUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Given no row exists, when getting permission node, then throws IllegalStateException")
+        void getPermissionNode_throwsIllegalState_whenNoRowFound() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(false);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> PermissionQuestScopeDAO.getPermissionNode(mockConnection, questUUID));
+            assertTrue(exception.getMessage().contains(questUUID.toString()));
+        }
+
+        @Test
+        @DisplayName("Given SQL exception, when getting permission node, then throws RuntimeException wrapping SQLException")
+        void getPermissionNode_throwsRuntimeException_whenSqlException() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("query failed"));
+
+            assertThrows(RuntimeException.class,
+                    () -> PermissionQuestScopeDAO.getPermissionNode(mockConnection, questUUID));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllActivePermissionQuests")
+    class FindAllActivePermissionQuests {
+
+        @Test
+        @DisplayName("Given multiple active quests, when finding all, then returns all entries")
+        void findAllActivePermissionQuests_returnsAllEntries_whenMultipleRows() throws SQLException {
+            UUID quest1 = UUID.randomUUID();
+            UUID quest2 = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("quest_uuid")).thenReturn(quest1.toString(), quest2.toString());
+            when(mockResultSet.getString("permission_node")).thenReturn("perm.one", "perm.two");
+
+            Map<UUID, String> result = PermissionQuestScopeDAO.findAllActivePermissionQuests(mockConnection);
+
+            assertEquals(2, result.size());
+            assertEquals("perm.one", result.get(quest1));
+            assertEquals("perm.two", result.get(quest2));
+        }
+
+        @Test
+        @DisplayName("Given no active quests, when finding all, then returns empty map")
+        void findAllActivePermissionQuests_returnsEmptyMap_whenNoRows() throws SQLException {
+            when(mockResultSet.next()).thenReturn(false);
+
+            Map<UUID, String> result = PermissionQuestScopeDAO.findAllActivePermissionQuests(mockConnection);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given SQL exception, when finding all, then returns empty map")
+        void findAllActivePermissionQuests_returnsEmptyMap_whenSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("query failed"));
+
+            Map<UUID, String> result = PermissionQuestScopeDAO.findAllActivePermissionQuests(mockConnection);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("saveScope")
+    class SaveScope {
+
+        @Test
+        @DisplayName("Given a valid permission scope, when saving, then returns prepared statements with correct bindings")
+        void saveScope_returnsStatements_whenValidScope() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.admin.test");
+
+            List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(mockConnection, scope);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            verify(mockStatement).setString(1, questUUID.toString());
+            verify(mockStatement).setString(2, "mcrpg.admin.test");
+        }
+
+        @Test
+        @DisplayName("Given SQL exception during prepare, when saving, then returns empty list")
+        void saveScope_returnsEmptyList_whenSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("prepare failed"));
+
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.test");
+
+            List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(mockConnection, scope);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/SinglePlayerQuestScopeDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/SinglePlayerQuestScopeDAOTest.java
@@ -1,60 +1,286 @@
 package us.eunoians.mcrpg.database.table.quest.scope;
 
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.TableVersionHistoryDAO;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.exception.quest.QuestScopeInvalidStateException;
 import us.eunoians.mcrpg.quest.impl.scope.impl.SinglePlayerQuestScope;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-public class SinglePlayerQuestScopeDAOTest extends McRPGBaseTest {
+@DisplayName("SinglePlayerQuestScopeDAO")
+class SinglePlayerQuestScopeDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given a valid single player scope, when saving, then prepared statements are returned")
-    @Test
-    public void saveScope_validScope_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    private Connection mockConnection;
+    private PreparedStatement mockStatement;
+    private ResultSet mockResultSet;
+    private Database mockDatabase;
 
-        SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
-        scope.setPlayerInScope(UUID.randomUUID());
-
-        List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(conn, scope);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+    @BeforeEach
+    void setUp() throws SQLException {
+        mockConnection = mock(Connection.class);
+        mockStatement = mock(PreparedStatement.class);
+        mockResultSet = mock(ResultSet.class);
+        mockDatabase = mock(Database.class);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
     }
 
-    @DisplayName("Given an invalid scope without player, when saving, then exception is thrown")
-    @Test
-    public void saveScope_invalidScope_throwsException() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
 
-        SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+        @Test
+        @DisplayName("Given table already exists, when attempting to create, then returns false")
+        void attemptCreateTable_returnsFalse_whenTableExists() {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_single_player_quest_scope")).thenReturn(true);
 
-        assertThrows(QuestScopeInvalidStateException.class,
-                () -> SinglePlayerQuestScopeDAO.saveScope(conn, scope));
+            boolean result = SinglePlayerQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("Given table does not exist, when attempting to create, then creates table and returns true")
+        void attemptCreateTable_returnsTrue_whenTableCreated() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_single_player_quest_scope")).thenReturn(false);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            boolean result = SinglePlayerQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertTrue(result);
+            verify(mockConnection).prepareStatement(anyString());
+            verify(mockStatement).executeUpdate();
+        }
+
+        @Test
+        @DisplayName("Given SQL exception during create, when attempting to create, then returns false")
+        void attemptCreateTable_returnsFalse_whenSqlException() throws SQLException {
+            when(mockDatabase.tableExists(mockConnection, "mcrpg_single_player_quest_scope")).thenReturn(false);
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("create failed"));
+
+            boolean result = SinglePlayerQuestScopeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+            assertFalse(result);
+        }
     }
 
-    @DisplayName("Given a valid single player scope, when saving, then connection is used")
-    @Test
-    public void saveScope_usesConnection() throws SQLException {
-        Connection conn = mock(Connection.class);
-        PreparedStatement mockPs = mock(PreparedStatement.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+    @Nested
+    @DisplayName("updateTable")
+    class UpdateTable {
 
-        SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
-        scope.setPlayerInScope(UUID.randomUUID());
+        @Test
+        @DisplayName("Given table is already at current version, when updating, then no version update is performed")
+        void updateTable_noOp_whenAlreadyCurrentVersion() {
+            try (MockedStatic<TableVersionHistoryDAO> tvhMock = mockStatic(TableVersionHistoryDAO.class)) {
+                tvhMock.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, "mcrpg_single_player_quest_scope"))
+                        .thenReturn(1);
 
-        SinglePlayerQuestScopeDAO.saveScope(conn, scope);
-        verify(conn).prepareStatement(anyString());
+                SinglePlayerQuestScopeDAO.updateTable(mockConnection);
+
+                tvhMock.verify(() -> TableVersionHistoryDAO.setTableVersion(
+                        mockConnection, "mcrpg_single_player_quest_scope", 1), org.mockito.Mockito.never());
+            }
+        }
+
+        @Test
+        @DisplayName("Given table is at version 0, when updating, then sets version to 1")
+        void updateTable_setsVersion_whenAtVersion0() {
+            try (MockedStatic<TableVersionHistoryDAO> tvhMock = mockStatic(TableVersionHistoryDAO.class)) {
+                tvhMock.when(() -> TableVersionHistoryDAO.getLatestVersion(mockConnection, "mcrpg_single_player_quest_scope"))
+                        .thenReturn(0);
+
+                SinglePlayerQuestScopeDAO.updateTable(mockConnection);
+
+                tvhMock.verify(() -> TableVersionHistoryDAO.setTableVersion(
+                        mockConnection, "mcrpg_single_player_quest_scope", 1));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findPlayerUuidForQuest")
+    class FindPlayerUuidForQuest {
+
+        @Test
+        @DisplayName("Given a row exists, when finding player UUID, then returns the player UUID")
+        void findPlayerUuidForQuest_returnsUuid_whenRowExists() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            UUID playerUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("player_uuid")).thenReturn(playerUUID.toString());
+
+            Optional<UUID> result = SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(mockConnection, questUUID);
+
+            assertTrue(result.isPresent());
+            assertEquals(playerUUID, result.get());
+            verify(mockStatement).setString(1, questUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Given no row exists, when finding player UUID, then returns empty Optional")
+        void findPlayerUuidForQuest_returnsEmpty_whenNoRowFound() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(false);
+
+            Optional<UUID> result = SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(mockConnection, questUUID);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given SQL exception, when finding player UUID, then throws RuntimeException")
+        void findPlayerUuidForQuest_throwsRuntimeException_whenSqlException() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("query failed"));
+
+            assertThrows(RuntimeException.class,
+                    () -> SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(mockConnection, questUUID));
+        }
+    }
+
+    @Nested
+    @DisplayName("getPlayerInScope")
+    class GetPlayerInScope {
+
+        @Test
+        @DisplayName("Given a player exists for quest, when getting player in scope, then returns the UUID")
+        void getPlayerInScope_returnsUuid_whenPlayerExists() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            UUID playerUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true);
+            when(mockResultSet.getString("player_uuid")).thenReturn(playerUUID.toString());
+
+            UUID result = SinglePlayerQuestScopeDAO.getPlayerInScope(mockConnection, questUUID);
+
+            assertEquals(playerUUID, result);
+        }
+
+        @Test
+        @DisplayName("Given no player exists for quest, when getting player in scope, then throws IllegalStateException")
+        void getPlayerInScope_throwsIllegalState_whenNoPlayerFound() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(false);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> SinglePlayerQuestScopeDAO.getPlayerInScope(mockConnection, questUUID));
+            assertTrue(exception.getMessage().contains(questUUID.toString()));
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveQuestsForPlayer")
+    class FindActiveQuestsForPlayer {
+
+        @Test
+        @DisplayName("Given multiple active quests, when finding for player, then returns all quest UUIDs")
+        void findActiveQuestsForPlayer_returnsAllUuids_whenMultipleRows() throws SQLException {
+            UUID playerUUID = UUID.randomUUID();
+            UUID quest1 = UUID.randomUUID();
+            UUID quest2 = UUID.randomUUID();
+            UUID quest3 = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(true, true, true, false);
+            when(mockResultSet.getString("quest_uuid")).thenReturn(
+                    quest1.toString(), quest2.toString(), quest3.toString());
+
+            List<UUID> result = SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(mockConnection, playerUUID);
+
+            assertEquals(3, result.size());
+            assertTrue(result.contains(quest1));
+            assertTrue(result.contains(quest2));
+            assertTrue(result.contains(quest3));
+            verify(mockStatement).setString(1, playerUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Given no active quests, when finding for player, then returns empty list")
+        void findActiveQuestsForPlayer_returnsEmptyList_whenNoRows() throws SQLException {
+            UUID playerUUID = UUID.randomUUID();
+            when(mockResultSet.next()).thenReturn(false);
+
+            List<UUID> result = SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(mockConnection, playerUUID);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given SQL exception, when finding for player, then returns empty list")
+        void findActiveQuestsForPlayer_returnsEmptyList_whenSqlException() throws SQLException {
+            UUID playerUUID = UUID.randomUUID();
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("query failed"));
+
+            List<UUID> result = SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(mockConnection, playerUUID);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("saveScope")
+    class SaveScope {
+
+        @Test
+        @DisplayName("Given a valid scope with player, when saving, then returns prepared statements with correct bindings")
+        void saveScope_returnsStatements_whenValidScope() throws SQLException {
+            UUID questUUID = UUID.randomUUID();
+            UUID playerUUID = UUID.randomUUID();
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(questUUID);
+            scope.setPlayerInScope(playerUUID);
+
+            List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(mockConnection, scope);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            verify(mockStatement).setString(1, questUUID.toString());
+            verify(mockStatement).setString(2, playerUUID.toString());
+        }
+
+        @Test
+        @DisplayName("Given an invalid scope without player, when saving, then throws QuestScopeInvalidStateException")
+        void saveScope_throwsException_whenNoPlayer() {
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+
+            assertThrows(QuestScopeInvalidStateException.class,
+                    () -> SinglePlayerQuestScopeDAO.saveScope(mockConnection, scope));
+        }
+
+        @Test
+        @DisplayName("Given SQL exception during prepare, when saving, then returns empty list")
+        void saveScope_returnsEmptyList_whenSqlException() throws SQLException {
+            when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("prepare failed"));
+
+            UUID questUUID = UUID.randomUUID();
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(questUUID);
+            scope.setPlayerInScope(UUID.randomUUID());
+
+            List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(mockConnection, scope);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/statistic/McRPGStatisticCacheManagerTest.java
+++ b/src/test/java/us/eunoians/mcrpg/statistic/McRPGStatisticCacheManagerTest.java
@@ -1,0 +1,279 @@
+package us.eunoians.mcrpg.statistic;
+
+import com.diamonddagger590.mccore.database.Database;
+import com.diamonddagger590.mccore.database.table.impl.PlayerStatisticDAO;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import com.diamonddagger590.mccore.statistic.StatisticEntry;
+import com.diamonddagger590.mccore.statistic.StatisticType;
+import com.diamonddagger590.mccore.statistic.cache.StatisticCache;
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.database.McRPGDatabaseManager;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("McRPGStatisticCacheManager")
+class McRPGStatisticCacheManagerTest extends McRPGBaseTest {
+
+    private McRPGStatisticCacheManager cacheManager;
+    private Connection mockConnection;
+    private UUID playerUUID;
+    private NamespacedKey statKey;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager = new McRPGStatisticCacheManager(mcRPG, 100, 300);
+        playerUUID = UUID.randomUUID();
+        statKey = new NamespacedKey("mcrpg", "test_stat");
+        mockConnection = mock(Connection.class);
+    }
+
+    @Nested
+    @DisplayName("getCache")
+    class GetCache {
+
+        @Test
+        @DisplayName("returns the underlying StatisticCache instance")
+        void getCache_returnsCache() {
+            StatisticCache cache = cacheManager.getCache();
+            assertNotNull(cache);
+        }
+    }
+
+    @Nested
+    @DisplayName("getOfflineStatistic")
+    class GetOfflineStatistic {
+
+        @Test
+        @DisplayName("Given a cached entry, when getting offline statistic, then returns cached value without DB call")
+        void getOfflineStatistic_returnsCachedEntry_whenCacheHit() {
+            StatisticEntry entry = new StatisticEntry(statKey, StatisticType.INT, 42);
+            cacheManager.getCache().put(playerUUID, statKey, entry);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                Optional<StatisticEntry> result = cacheManager.getOfflineStatistic(mockConnection, playerUUID, statKey);
+
+                assertTrue(result.isPresent());
+                assertSame(entry, result.get());
+                daoMock.verifyNoInteractions();
+            }
+        }
+
+        @Test
+        @DisplayName("Given no cached entry and a DB hit, when getting offline statistic, then returns DB value and populates cache")
+        void getOfflineStatistic_returnsDbEntry_whenCacheMissAndDbHit() {
+            StatisticEntry dbEntry = new StatisticEntry(statKey, StatisticType.DOUBLE, 3.14);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, statKey))
+                        .thenReturn(Optional.of(dbEntry));
+
+                Optional<StatisticEntry> result = cacheManager.getOfflineStatistic(mockConnection, playerUUID, statKey);
+
+                assertTrue(result.isPresent());
+                assertSame(dbEntry, result.get());
+
+                Optional<StatisticEntry> cachedAfter = cacheManager.getCache().get(playerUUID, statKey);
+                assertTrue(cachedAfter.isPresent());
+                assertSame(dbEntry, cachedAfter.get());
+            }
+        }
+
+        @Test
+        @DisplayName("Given no cached entry and no DB row, when getting offline statistic, then returns empty and does not populate cache")
+        void getOfflineStatistic_returnsEmpty_whenCacheMissAndDbMiss() {
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, statKey))
+                        .thenReturn(Optional.empty());
+
+                Optional<StatisticEntry> result = cacheManager.getOfflineStatistic(mockConnection, playerUUID, statKey);
+
+                assertTrue(result.isEmpty());
+
+                Optional<StatisticEntry> cachedAfter = cacheManager.getCache().get(playerUUID, statKey);
+                assertTrue(cachedAfter.isEmpty());
+            }
+        }
+
+        @Test
+        @DisplayName("Given a cached entry for one key and DB query for another, when getting second key, then only queries DB for the second key")
+        void getOfflineStatistic_queriesDbForUncachedKey_whenDifferentKeysCached() {
+            NamespacedKey cachedKey = new NamespacedKey("mcrpg", "cached_stat");
+            NamespacedKey uncachedKey = new NamespacedKey("mcrpg", "uncached_stat");
+            StatisticEntry cachedEntry = new StatisticEntry(cachedKey, StatisticType.LONG, 100L);
+            StatisticEntry dbEntry = new StatisticEntry(uncachedKey, StatisticType.INT, 5);
+
+            cacheManager.getCache().put(playerUUID, cachedKey, cachedEntry);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, uncachedKey))
+                        .thenReturn(Optional.of(dbEntry));
+
+                Optional<StatisticEntry> resultCached = cacheManager.getOfflineStatistic(mockConnection, playerUUID, cachedKey);
+                Optional<StatisticEntry> resultUncached = cacheManager.getOfflineStatistic(mockConnection, playerUUID, uncachedKey);
+
+                assertTrue(resultCached.isPresent());
+                assertSame(cachedEntry, resultCached.get());
+                assertTrue(resultUncached.isPresent());
+                assertSame(dbEntry, resultUncached.get());
+
+                daoMock.verify(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, cachedKey), never());
+                daoMock.verify(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, uncachedKey));
+            }
+        }
+
+        @Test
+        @DisplayName("Given a second call with same key after DB population, when getting offline statistic, then returns from cache without second DB call")
+        void getOfflineStatistic_returnsCachedOnSecondCall_whenFirstCallPopulatedCache() {
+            StatisticEntry dbEntry = new StatisticEntry(statKey, StatisticType.INT, 99);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, statKey))
+                        .thenReturn(Optional.of(dbEntry));
+
+                cacheManager.getOfflineStatistic(mockConnection, playerUUID, statKey);
+                Optional<StatisticEntry> secondCall = cacheManager.getOfflineStatistic(mockConnection, playerUUID, statKey);
+
+                assertTrue(secondCall.isPresent());
+                assertEquals(99, secondCall.get().value());
+
+                daoMock.verify(() -> PlayerStatisticDAO.getPlayerStatistic(mockConnection, playerUUID, statKey));
+            }
+        }
+
+        @Test
+        @DisplayName("Given different players with same stat key, when getting offline statistic, then returns correct values per player")
+        void getOfflineStatistic_returnsSeparateEntriesPerPlayer() {
+            UUID player1 = UUID.randomUUID();
+            UUID player2 = UUID.randomUUID();
+            StatisticEntry entry1 = new StatisticEntry(statKey, StatisticType.INT, 10);
+            StatisticEntry entry2 = new StatisticEntry(statKey, StatisticType.INT, 20);
+
+            cacheManager.getCache().put(player1, statKey, entry1);
+            cacheManager.getCache().put(player2, statKey, entry2);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                Optional<StatisticEntry> result1 = cacheManager.getOfflineStatistic(mockConnection, player1, statKey);
+                Optional<StatisticEntry> result2 = cacheManager.getOfflineStatistic(mockConnection, player2, statKey);
+
+                assertTrue(result1.isPresent());
+                assertEquals(10, result1.get().value());
+                assertTrue(result2.isPresent());
+                assertEquals(20, result2.get().value());
+
+                daoMock.verifyNoInteractions();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("populateAsync")
+    class PopulateAsync {
+
+        @Test
+        @DisplayName("Given a DB hit, when populating async, then cache is populated after the submitted task runs")
+        void populateAsync_populatesCache_whenDbHit() throws SQLException {
+            StatisticEntry dbEntry = new StatisticEntry(statKey, StatisticType.INT, 55);
+
+            McRPGDatabaseManager mockDatabaseManager = mock(McRPGDatabaseManager.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabaseManager.getDatabase()).thenReturn(mockDatabase);
+            when(mockDatabase.getConnection()).thenReturn(mockConnection);
+            ThreadPoolExecutor directExecutor = mock(ThreadPoolExecutor.class);
+            when(mockDatabase.getDatabaseExecutorService()).thenReturn(directExecutor);
+            RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(mockDatabaseManager);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(any(Connection.class), eq(playerUUID), eq(statKey)))
+                        .thenReturn(Optional.of(dbEntry));
+
+                cacheManager.populateAsync(playerUUID, statKey);
+
+                var runnableCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+                verify(directExecutor).submit(runnableCaptor.capture());
+                runnableCaptor.getValue().run();
+
+                Optional<StatisticEntry> cached = cacheManager.getCache().get(playerUUID, statKey);
+                assertTrue(cached.isPresent());
+                assertEquals(55, cached.get().value());
+            }
+        }
+
+        @Test
+        @DisplayName("Given a DB miss, when populating async, then cache remains empty after the submitted task runs")
+        void populateAsync_doesNotPopulateCache_whenDbMiss() throws SQLException {
+            McRPGDatabaseManager mockDatabaseManager = mock(McRPGDatabaseManager.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabaseManager.getDatabase()).thenReturn(mockDatabase);
+            when(mockDatabase.getConnection()).thenReturn(mockConnection);
+            ThreadPoolExecutor directExecutor = mock(ThreadPoolExecutor.class);
+            when(mockDatabase.getDatabaseExecutorService()).thenReturn(directExecutor);
+            RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(mockDatabaseManager);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(any(Connection.class), eq(playerUUID), eq(statKey)))
+                        .thenReturn(Optional.empty());
+
+                cacheManager.populateAsync(playerUUID, statKey);
+
+                var runnableCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+                verify(directExecutor).submit(runnableCaptor.capture());
+                runnableCaptor.getValue().run();
+
+                Optional<StatisticEntry> cached = cacheManager.getCache().get(playerUUID, statKey);
+                assertTrue(cached.isEmpty());
+            }
+        }
+
+        @Test
+        @DisplayName("Given a SQLException on connection close, when populating async, then exception is caught and cache remains empty")
+        void populateAsync_catchesException_whenSqlExceptionOnClose() throws SQLException {
+            Connection closingConnection = mock(Connection.class);
+            org.mockito.Mockito.doThrow(new SQLException("close failed")).when(closingConnection).close();
+
+            McRPGDatabaseManager mockDatabaseManager = mock(McRPGDatabaseManager.class);
+            Database mockDatabase = mock(Database.class);
+            when(mockDatabaseManager.getDatabase()).thenReturn(mockDatabase);
+            when(mockDatabase.getConnection()).thenReturn(closingConnection);
+            ThreadPoolExecutor directExecutor = mock(ThreadPoolExecutor.class);
+            when(mockDatabase.getDatabaseExecutorService()).thenReturn(directExecutor);
+            RegistryAccess.registryAccess().registry(RegistryKey.MANAGER).register(mockDatabaseManager);
+
+            try (MockedStatic<PlayerStatisticDAO> daoMock = mockStatic(PlayerStatisticDAO.class)) {
+                daoMock.when(() -> PlayerStatisticDAO.getPlayerStatistic(any(Connection.class), eq(playerUUID), eq(statKey)))
+                        .thenReturn(Optional.empty());
+
+                cacheManager.populateAsync(playerUUID, statKey);
+
+                var runnableCaptor = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+                verify(directExecutor).submit(runnableCaptor.capture());
+                runnableCaptor.getValue().run();
+
+                Optional<StatisticEntry> cached = cacheManager.getCache().get(playerUUID, statKey);
+                assertTrue(cached.isEmpty());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **New test class:** `McRPGStatisticCacheManagerTest` — 10 tests covering `getCache()`, `getOfflineStatistic()` (cache hit, DB fallback, DB miss, per-key isolation, cache population on repeat calls, per-player separation), and `populateAsync()` (DB hit populates cache, DB miss leaves cache empty, SQLException handled gracefully). Coverage goes from 0% to near-complete.
- **Expanded:** `SinglePlayerQuestScopeDAOTest` from 3 → 15 tests covering all 6 public methods
- **Expanded:** `LandQuestScopeDAOTest` from 2 → 14 tests covering all 5 public methods
- **Expanded:** `PermissionQuestScopeDAOTest` from 2 → 13 tests covering all 5 public methods

All scope DAO tests now cover `attemptCreateTable` (exists/create/exception), `updateTable` (current version/v0), query methods (found/not-found/exception), and `saveScope` (valid/exception).

## Test plan

- [x] All 4945 tests pass (`./gradlew test`)
- [x] JaCoCo report generates successfully
- [x] No regressions in existing tests
- [x] Testing audit persona reviewed changes

---
_Generated by [Claude Code](https://claude.ai/code/session_012C7Go2ra1RsMPX76BwnAdk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for quest scope database operations, including table creation, version updates, data retrieval, active quest queries, and persistence.
  * Added validation for successful results, missing data, SQL failures, and prepared-statement parameter handling.
  * Added comprehensive tests for statistic caching, including cache hits, database fallbacks, asynchronous population, player isolation, and error handling.
  * Reorganized tests into clearer, focused groups for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->