### PR TITLE
[Unit Tests] Add coverage for event classes: ability cooldown, quest cancel/reward, chain lifecycle

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/event/ability/AbilityPutOnCooldownEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/AbilityPutOnCooldownEventTest.java
@@ -1,0 +1,126 @@
+package us.eunoians.mcrpg.event.ability;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.impl.type.CooldownableAbility;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AbilityPutOnCooldownEvent}.
+ */
+class AbilityPutOnCooldownEventTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("Constructor")
+    class Constructor {
+
+        @Test
+        @DisplayName("Given a positive cooldown, When constructed, Then getCooldown returns that value")
+        void getCooldown_returnsValue_whenConstructedWithPositiveCooldown() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 10);
+            assertEquals(10, event.getCooldown());
+        }
+
+        @Test
+        @DisplayName("Given a negative cooldown, When constructed, Then getCooldown returns 0")
+        void getCooldown_returnsZero_whenConstructedWithNegativeCooldown() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, -5);
+            assertEquals(0, event.getCooldown());
+        }
+
+        @Test
+        @DisplayName("Given zero cooldown, When constructed, Then getCooldown returns 0")
+        void getCooldown_returnsZero_whenConstructedWithZeroCooldown() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 0);
+            assertEquals(0, event.getCooldown());
+        }
+
+        @Test
+        @DisplayName("Given a large cooldown, When constructed, Then getCooldown preserves large value")
+        void getCooldown_preservesLargeValue_whenConstructedWithLargeCooldown() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, Long.MAX_VALUE);
+            assertEquals(Long.MAX_VALUE, event.getCooldown());
+        }
+    }
+
+    @Nested
+    @DisplayName("setCooldown")
+    class SetCooldown {
+
+        @Test
+        @DisplayName("Given a positive value, When setCooldown is called, Then getCooldown returns the new value")
+        void setCooldown_updatesValue_whenGivenPositiveValue() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 10);
+            event.setCooldown(20);
+            assertEquals(20, event.getCooldown());
+        }
+
+        @Test
+        @DisplayName("Given a negative value, When setCooldown is called, Then getCooldown returns 0")
+        void setCooldown_clampsToZero_whenGivenNegativeValue() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 10);
+            event.setCooldown(-3);
+            assertEquals(0, event.getCooldown());
+        }
+
+        @Test
+        @DisplayName("Given zero, When setCooldown is called, Then getCooldown returns 0")
+        void setCooldown_returnsZero_whenGivenZero() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 10);
+            event.setCooldown(0);
+            assertEquals(0, event.getCooldown());
+        }
+    }
+
+    @Nested
+    @DisplayName("Getters")
+    class Getters {
+
+        @Test
+        @DisplayName("getAbilityHolder returns the holder passed at construction")
+        void getAbilityHolder_returnsConstructorHolder() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 5);
+            assertSame(holder, event.getAbilityHolder());
+        }
+
+        @Test
+        @DisplayName("getAbility returns a CooldownableAbility")
+        void getAbility_returnsCooldownableAbility() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 5);
+            assertSame(ability, event.getAbility());
+        }
+
+        @Test
+        @DisplayName("getHandlers returns the same list as getHandlerList")
+        void getHandlers_matchesStaticHandlerList() {
+            AbilityHolder holder = mock(AbilityHolder.class);
+            CooldownableAbility ability = mock(CooldownableAbility.class);
+            AbilityPutOnCooldownEvent event = new AbilityPutOnCooldownEvent(holder, ability, 5);
+            assertEquals(AbilityPutOnCooldownEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/QuestCancelEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/QuestCancelEventTest.java
@@ -1,0 +1,147 @@
+package us.eunoians.mcrpg.event.quest;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.QuestTestHelper;
+import us.eunoians.mcrpg.quest.definition.QuestDefinition;
+import us.eunoians.mcrpg.quest.impl.QuestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link QuestCancelEvent}.
+ */
+class QuestCancelEventTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("Three-argument constructor")
+    class ThreeArgConstructor {
+
+        @Test
+        @DisplayName("Given expiration=true, When isExpiration is called, Then returns true")
+        void isExpiration_returnsTrue_whenConstructedWithExpirationTrue() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_expire");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition, true);
+            assertTrue(event.isExpiration());
+        }
+
+        @Test
+        @DisplayName("Given expiration=false, When isExpiration is called, Then returns false")
+        void isExpiration_returnsFalse_whenConstructedWithExpirationFalse() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_manual");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition, false);
+            assertFalse(event.isExpiration());
+        }
+
+        @Test
+        @DisplayName("Given a definition, When getQuestDefinition is called, Then returns the definition")
+        void getQuestDefinition_returnsDefinition() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_def");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition, false);
+            assertSame(definition, event.getQuestDefinition());
+        }
+
+        @Test
+        @DisplayName("Given a definition, When getQuestDefinitionKey is called, Then returns the definition's key")
+        void getQuestDefinitionKey_returnsDefinitionKey() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_key");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition, false);
+            assertEquals(definition.getQuestKey(), event.getQuestDefinitionKey());
+        }
+
+        @Test
+        @DisplayName("Given a quest instance, When getQuestInstance is called, Then returns the instance")
+        void getQuestInstance_returnsInstance() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_inst");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition, false);
+            assertSame(instance, event.getQuestInstance());
+        }
+    }
+
+    @Nested
+    @DisplayName("Deprecated two-argument constructor")
+    class TwoArgConstructor {
+
+        @SuppressWarnings("deprecation")
+        @Test
+        @DisplayName("Given no expiration flag, When isExpiration is called, Then defaults to false")
+        void isExpiration_defaultsToFalse() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_dep2");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition);
+            assertFalse(event.isExpiration());
+        }
+
+        @SuppressWarnings("deprecation")
+        @Test
+        @DisplayName("Given a definition, When getQuestDefinition is called, Then returns the definition")
+        void getQuestDefinition_returnsDefinition() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_dep2_def");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition);
+            assertSame(definition, event.getQuestDefinition());
+        }
+    }
+
+    @Nested
+    @DisplayName("Deprecated single-argument constructor")
+    class SingleArgConstructor {
+
+        @SuppressWarnings("deprecation")
+        @Test
+        @DisplayName("Given no definition, When getQuestDefinition is called, Then returns null")
+        void getQuestDefinition_returnsNull() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_dep1");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance);
+            assertNull(event.getQuestDefinition());
+        }
+
+        @SuppressWarnings("deprecation")
+        @Test
+        @DisplayName("Given no definition, When isExpiration is called, Then defaults to false")
+        void isExpiration_defaultsToFalse() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_dep1_exp");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance);
+            assertFalse(event.isExpiration());
+        }
+
+        @SuppressWarnings("deprecation")
+        @Test
+        @DisplayName("Given no definition, When getQuestDefinitionKey is called, Then falls back to instance key")
+        void getQuestDefinitionKey_fallsBackToInstanceKey() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_fallback");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            NamespacedKey instanceKey = instance.getQuestKey();
+            QuestCancelEvent event = new QuestCancelEvent(instance);
+            assertEquals(instanceKey, event.getQuestDefinitionKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("Handler list")
+    class HandlerListTests {
+
+        @Test
+        @DisplayName("getHandlers returns the shared QuestEvent handler list")
+        void getHandlers_returnsSharedHandlerList() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("cancel_hl");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            QuestCancelEvent event = new QuestCancelEvent(instance, definition, false);
+            assertSame(QuestEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/QuestRewardGrantEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/QuestRewardGrantEventTest.java
@@ -1,0 +1,193 @@
+package us.eunoians.mcrpg.event.quest;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.QuestTestHelper;
+import us.eunoians.mcrpg.quest.definition.QuestDefinition;
+import us.eunoians.mcrpg.quest.impl.QuestInstance;
+import us.eunoians.mcrpg.quest.reward.MockQuestRewardType;
+import us.eunoians.mcrpg.quest.reward.QuestRewardType;
+import us.eunoians.mcrpg.quest.reward.RewardGrantContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link QuestRewardGrantEvent}.
+ */
+class QuestRewardGrantEventTest extends McRPGBaseTest {
+
+    private static final NamespacedKey QUEST_KEY = new NamespacedKey("mcrpg", "reward_quest");
+
+    @Nested
+    @DisplayName("Constructor and getters")
+    class ConstructorAndGetters {
+
+        @Test
+        @DisplayName("Given all parameters, When getters are called, Then they return the values passed to the constructor")
+        void getters_returnConstructorValues() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("rge_getters");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(QuestTestHelper.mockRewardType("test_reward"));
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    instance, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertSame(instance, event.getQuestInstance());
+            assertEquals(QUEST_KEY, event.getQuestKey());
+            assertEquals(playerUUID, event.getPlayerUUID());
+            assertSame(rewards, event.getRewards());
+            assertEquals(RewardGrantContext.INLINE, event.getContext());
+        }
+
+        @Test
+        @DisplayName("Given null quest instance, When getQuestInstance is called, Then returns null")
+        void getQuestInstance_returnsNull_whenConstructedWithNull() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.PENDING);
+
+            assertNull(event.getQuestInstance());
+        }
+
+        @Test
+        @DisplayName("Given DISTRIBUTION context, When getContext is called, Then returns DISTRIBUTION")
+        void getContext_returnsDistribution() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.DISTRIBUTION);
+
+            assertEquals(RewardGrantContext.DISTRIBUTION, event.getContext());
+        }
+    }
+
+    @Nested
+    @DisplayName("Cancellation")
+    class Cancellation {
+
+        @Test
+        @DisplayName("Given a new event, When isCancelled is called, Then returns false")
+        void isCancelled_returnsFalse_byDefault() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("Given setCancelled(true), When isCancelled is called, Then returns true")
+        void isCancelled_returnsTrue_afterSetCancelledTrue() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+            event.setCancelled(true);
+
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("Given setCancelled(true) then setCancelled(false), When isCancelled is called, Then returns false")
+        void isCancelled_returnsFalse_afterReenabling() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+            event.setCancelled(true);
+            event.setCancelled(false);
+
+            assertFalse(event.isCancelled());
+        }
+    }
+
+    @Nested
+    @DisplayName("Mutable reward list")
+    class MutableRewardList {
+
+        @Test
+        @DisplayName("Given a mutable reward list, When a reward is added, Then getRewards reflects the addition")
+        void getRewards_reflectsAddition() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            MockQuestRewardType reward = QuestTestHelper.mockRewardType("added_reward");
+            event.getRewards().add(reward);
+
+            assertEquals(1, event.getRewards().size());
+            assertSame(reward, event.getRewards().get(0));
+        }
+
+        @Test
+        @DisplayName("Given a mutable reward list, When a reward is removed, Then getRewards reflects the removal")
+        void getRewards_reflectsRemoval() {
+            UUID playerUUID = UUID.randomUUID();
+            MockQuestRewardType reward = QuestTestHelper.mockRewardType("removable");
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(reward);
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            event.getRewards().remove(0);
+
+            assertTrue(event.getRewards().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given a mutable reward list, When cleared, Then getRewards returns empty list")
+        void getRewards_returnsEmpty_afterClear() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(QuestTestHelper.mockRewardType("r1"));
+            rewards.add(QuestTestHelper.mockRewardType("r2"));
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            event.getRewards().clear();
+
+            assertTrue(event.getRewards().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Handler list")
+    class HandlerListTests {
+
+        @Test
+        @DisplayName("getHandlers returns the static handler list")
+        void getHandlers_matchesStaticHandlerList() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantEvent event = new QuestRewardGrantEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertSame(QuestRewardGrantEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/QuestRewardGrantedEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/QuestRewardGrantedEventTest.java
@@ -1,0 +1,174 @@
+package us.eunoians.mcrpg.event.quest;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.QuestTestHelper;
+import us.eunoians.mcrpg.quest.definition.QuestDefinition;
+import us.eunoians.mcrpg.quest.impl.QuestInstance;
+import us.eunoians.mcrpg.quest.reward.QuestRewardType;
+import us.eunoians.mcrpg.quest.reward.RewardGrantContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link QuestRewardGrantedEvent}.
+ */
+class QuestRewardGrantedEventTest extends McRPGBaseTest {
+
+    private static final NamespacedKey QUEST_KEY = new NamespacedKey("mcrpg", "granted_quest");
+
+    @Nested
+    @DisplayName("Constructor and getters")
+    class ConstructorAndGetters {
+
+        @Test
+        @DisplayName("Given all parameters, When getters are called, Then they return the values passed to the constructor")
+        void getters_returnConstructorValues() {
+            QuestDefinition definition = QuestTestHelper.singlePhaseQuest("rged_getters");
+            QuestInstance instance = QuestTestHelper.startedQuestInstance(definition);
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(QuestTestHelper.mockRewardType("granted_reward"));
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    instance, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertSame(instance, event.getQuestInstance());
+            assertEquals(QUEST_KEY, event.getQuestKey());
+            assertEquals(playerUUID, event.getPlayerUUID());
+            assertEquals(RewardGrantContext.INLINE, event.getContext());
+        }
+
+        @Test
+        @DisplayName("Given null quest instance, When getQuestInstance is called, Then returns null")
+        void getQuestInstance_returnsNull_whenConstructedWithNull() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.PENDING);
+
+            assertNull(event.getQuestInstance());
+        }
+
+        @Test
+        @DisplayName("Given PENDING context, When getContext is called, Then returns PENDING")
+        void getContext_returnsPending() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.PENDING);
+
+            assertEquals(RewardGrantContext.PENDING, event.getContext());
+        }
+    }
+
+    @Nested
+    @DisplayName("Immutability")
+    class Immutability {
+
+        @Test
+        @DisplayName("Given a reward list, When getGrantedRewards is called, Then the list is immutable")
+        void getGrantedRewards_returnsImmutableList() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(QuestTestHelper.mockRewardType("immutable_reward"));
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertThrows(UnsupportedOperationException.class,
+                    () -> event.getGrantedRewards().add(QuestTestHelper.mockRewardType("extra")));
+        }
+
+        @Test
+        @DisplayName("Given a reward list, When the original list is modified after construction, Then getGrantedRewards is unaffected")
+        void getGrantedRewards_isDefensivelyCopied() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(QuestTestHelper.mockRewardType("copied_reward"));
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            rewards.clear();
+
+            assertEquals(1, event.getGrantedRewards().size());
+        }
+
+        @Test
+        @DisplayName("Given a reward list, When getGrantedRewards is called, Then it contains the original rewards")
+        void getGrantedRewards_containsOriginalRewards() {
+            UUID playerUUID = UUID.randomUUID();
+            QuestRewardType reward1 = QuestTestHelper.mockRewardType("r1");
+            QuestRewardType reward2 = QuestTestHelper.mockRewardType("r2");
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(reward1);
+            rewards.add(reward2);
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.DISTRIBUTION);
+
+            assertEquals(2, event.getGrantedRewards().size());
+            assertSame(reward1, event.getGrantedRewards().get(0));
+            assertSame(reward2, event.getGrantedRewards().get(1));
+        }
+
+        @Test
+        @DisplayName("Given an empty reward list, When getGrantedRewards is called, Then returns empty immutable list")
+        void getGrantedRewards_returnsEmptyImmutableList_whenNoRewards() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertTrue(event.getGrantedRewards().isEmpty());
+            assertThrows(UnsupportedOperationException.class,
+                    () -> event.getGrantedRewards().add(QuestTestHelper.mockRewardType("sneaky")));
+        }
+
+        @Test
+        @DisplayName("Given a reward list, When remove is called on getGrantedRewards, Then UnsupportedOperationException is thrown")
+        void getGrantedRewards_throwsOnRemove() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+            rewards.add(QuestTestHelper.mockRewardType("no_remove"));
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertThrows(UnsupportedOperationException.class,
+                    () -> event.getGrantedRewards().remove(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("Handler list")
+    class HandlerListTests {
+
+        @Test
+        @DisplayName("getHandlers returns the static handler list")
+        void getHandlers_matchesStaticHandlerList() {
+            UUID playerUUID = UUID.randomUUID();
+            List<QuestRewardType> rewards = new ArrayList<>();
+
+            QuestRewardGrantedEvent event = new QuestRewardGrantedEvent(
+                    null, QUEST_KEY, playerUUID, rewards, RewardGrantContext.INLINE);
+
+            assertSame(QuestRewardGrantedEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainExpireEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainExpireEventTest.java
@@ -1,0 +1,132 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link QuestChainExpireEvent}.
+ */
+class QuestChainExpireEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition(String key) {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", key);
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", key + "_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Nested
+    @DisplayName("Constructor and getters")
+    class ConstructorAndGetters {
+
+        @Test
+        @DisplayName("Given all parameters with online player, When getters are called, Then they return the constructor values")
+        void getters_returnConstructorValues_withOnlinePlayer() {
+            QuestChainDefinition definition = buildDefinition("expire_online");
+            PlayerMock player = server.addPlayer();
+            UUID playerUUID = player.getUniqueId();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, player);
+
+            assertSame(definition, event.getChainDefinition());
+            assertEquals(playerUUID, event.getPlayerUUID());
+            assertTrue(event.getPlayer().isPresent());
+            assertSame(player, event.getPlayer().get());
+        }
+
+        @Test
+        @DisplayName("Given null player, When getPlayer is called, Then returns empty Optional")
+        void getPlayer_returnsEmpty_whenPlayerIsNull() {
+            QuestChainDefinition definition = buildDefinition("expire_offline");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, null);
+
+            assertTrue(event.getPlayer().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Given null player, When getPlayerUUID is called, Then still returns the UUID")
+        void getPlayerUUID_returnsUUID_evenWhenPlayerIsNull() {
+            QuestChainDefinition definition = buildDefinition("expire_uuid");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, null);
+
+            assertEquals(playerUUID, event.getPlayerUUID());
+        }
+    }
+
+    @Nested
+    @DisplayName("Cancellation")
+    class Cancellation {
+
+        @Test
+        @DisplayName("Given a new event, When isCancelled is called, Then returns false")
+        void isCancelled_returnsFalse_byDefault() {
+            QuestChainDefinition definition = buildDefinition("expire_cancel_def");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, null);
+
+            assertFalse(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("Given setCancelled(true), When isCancelled is called, Then returns true")
+        void isCancelled_returnsTrue_afterSetCancelledTrue() {
+            QuestChainDefinition definition = buildDefinition("expire_cancel_set");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, null);
+            event.setCancelled(true);
+
+            assertTrue(event.isCancelled());
+        }
+
+        @Test
+        @DisplayName("Given setCancelled toggled, When isCancelled is called, Then reflects the latest state")
+        void isCancelled_reflectsLatestState_afterToggle() {
+            QuestChainDefinition definition = buildDefinition("expire_cancel_toggle");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, null);
+            event.setCancelled(true);
+            event.setCancelled(false);
+
+            assertFalse(event.isCancelled());
+        }
+    }
+
+    @Nested
+    @DisplayName("Handler list")
+    class HandlerListTests {
+
+        @Test
+        @DisplayName("getHandlers returns the static handler list")
+        void getHandlers_matchesStaticHandlerList() {
+            QuestChainDefinition definition = buildDefinition("expire_hl");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainExpireEvent event = new QuestChainExpireEvent(definition, playerUUID, null);
+
+            assertSame(QuestChainExpireEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainRestartEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainRestartEventTest.java
@@ -1,0 +1,114 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainRestartEvent}.
+ */
+class QuestChainRestartEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition(String key) {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", key);
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", key + "_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Nested
+    @DisplayName("Constructor and getters")
+    class ConstructorAndGetters {
+
+        @Test
+        @DisplayName("Given all parameters with online player, When getters are called, Then they return the constructor values")
+        void getters_returnConstructorValues_withOnlinePlayer() {
+            QuestChainDefinition definition = buildDefinition("restart_online");
+            PlayerMock player = server.addPlayer();
+            UUID playerUUID = player.getUniqueId();
+
+            QuestChainRestartEvent event = new QuestChainRestartEvent(
+                    definition, player, playerUUID, QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+            assertSame(definition, event.getChainDefinition());
+            assertSame(player, event.getPlayer());
+            assertEquals(playerUUID, event.getPlayerUUID());
+            assertEquals(QuestChainRestartEvent.RestartReason.REPEAT_MODE, event.getReason());
+        }
+
+        @Test
+        @DisplayName("Given null player, When getPlayer is called, Then returns null")
+        void getPlayer_returnsNull_whenPlayerIsNull() {
+            QuestChainDefinition definition = buildDefinition("restart_offline");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainRestartEvent event = new QuestChainRestartEvent(
+                    definition, null, playerUUID, QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+            assertNull(event.getPlayer());
+        }
+
+        @Test
+        @DisplayName("Given null player, When getPlayerUUID is called, Then still returns the UUID")
+        void getPlayerUUID_returnsUUID_evenWhenPlayerIsNull() {
+            QuestChainDefinition definition = buildDefinition("restart_uuid");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainRestartEvent event = new QuestChainRestartEvent(
+                    definition, null, playerUUID, QuestChainRestartEvent.RestartReason.QUEST_EXPIRE_RESTART_CHAIN);
+
+            assertEquals(playerUUID, event.getPlayerUUID());
+        }
+    }
+
+    @Nested
+    @DisplayName("RestartReason")
+    class RestartReasonTests {
+
+        @ParameterizedTest
+        @EnumSource(QuestChainRestartEvent.RestartReason.class)
+        @DisplayName("Given each RestartReason, When getReason is called, Then returns the matching reason")
+        void getReason_returnsMatchingReason(QuestChainRestartEvent.RestartReason reason) {
+            QuestChainDefinition definition = buildDefinition("restart_reason_" + reason.name().toLowerCase());
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainRestartEvent event = new QuestChainRestartEvent(
+                    definition, null, playerUUID, reason);
+
+            assertEquals(reason, event.getReason());
+        }
+    }
+
+    @Nested
+    @DisplayName("Handler list")
+    class HandlerListTests {
+
+        @Test
+        @DisplayName("getHandlers returns the static handler list")
+        void getHandlers_matchesStaticHandlerList() {
+            QuestChainDefinition definition = buildDefinition("restart_hl");
+            UUID playerUUID = UUID.randomUUID();
+
+            QuestChainRestartEvent event = new QuestChainRestartEvent(
+                    definition, null, playerUUID, QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+            assertSame(QuestChainRestartEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
@@ -1,0 +1,173 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainStepRetryEvent}.
+ */
+class QuestChainStepRetryEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition(String key) {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", key);
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", key + "_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    private static QuestChainStep buildStep(String key) {
+        return QuestChainStep.simple(new NamespacedKey("mcrpg", key));
+    }
+
+    @Nested
+    @DisplayName("Constructor and getters")
+    class ConstructorAndGetters {
+
+        @Test
+        @DisplayName("Given all parameters with online player, When getters are called, Then they return the constructor values")
+        void getters_returnConstructorValues_withOnlinePlayer() {
+            QuestChainDefinition definition = buildDefinition("retry_online");
+            PlayerMock player = server.addPlayer();
+            UUID playerUUID = player.getUniqueId();
+            QuestChainStep step = buildStep("retry_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, player, playerUUID, step, 1, 3);
+
+            assertSame(definition, event.getChainDefinition());
+            assertSame(player, event.getPlayer());
+            assertEquals(playerUUID, event.getPlayerUUID());
+            assertSame(step, event.getStep());
+            assertEquals(1, event.getRetryNumber());
+            assertEquals(3, event.getMaxRetries());
+        }
+
+        @Test
+        @DisplayName("Given null player, When getPlayer is called, Then returns null")
+        void getPlayer_returnsNull_whenPlayerIsNull() {
+            QuestChainDefinition definition = buildDefinition("retry_offline");
+            UUID playerUUID = UUID.randomUUID();
+            QuestChainStep step = buildStep("retry_offline_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, playerUUID, step, 2, 5);
+
+            assertNull(event.getPlayer());
+        }
+
+        @Test
+        @DisplayName("Given null player, When getPlayerUUID is called, Then still returns the UUID")
+        void getPlayerUUID_returnsUUID_evenWhenPlayerIsNull() {
+            QuestChainDefinition definition = buildDefinition("retry_uuid");
+            UUID playerUUID = UUID.randomUUID();
+            QuestChainStep step = buildStep("retry_uuid_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, playerUUID, step, 1, 3);
+
+            assertEquals(playerUUID, event.getPlayerUUID());
+        }
+    }
+
+    @Nested
+    @DisplayName("Retry number")
+    class RetryNumberTests {
+
+        @Test
+        @DisplayName("Given retryNumber=1, When getRetryNumber is called, Then returns 1")
+        void getRetryNumber_returnsOne_forFirstRetry() {
+            QuestChainDefinition definition = buildDefinition("retry_first");
+            QuestChainStep step = buildStep("retry_first_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, UUID.randomUUID(), step, 1, 5);
+
+            assertEquals(1, event.getRetryNumber());
+        }
+
+        @Test
+        @DisplayName("Given retryNumber equal to maxRetries, When getRetryNumber is called, Then returns the max value")
+        void getRetryNumber_returnsMax_whenAtLimit() {
+            QuestChainDefinition definition = buildDefinition("retry_at_max");
+            QuestChainStep step = buildStep("retry_at_max_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, UUID.randomUUID(), step, 5, 5);
+
+            assertEquals(5, event.getRetryNumber());
+        }
+    }
+
+    @Nested
+    @DisplayName("Max retries")
+    class MaxRetriesTests {
+
+        @Test
+        @DisplayName("Given maxRetries=-1, When getMaxRetries is called, Then returns -1 for unlimited")
+        void getMaxRetries_returnsNegativeOne_forUnlimited() {
+            QuestChainDefinition definition = buildDefinition("retry_unlimited");
+            QuestChainStep step = buildStep("retry_unlimited_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, UUID.randomUUID(), step, 3, -1);
+
+            assertEquals(-1, event.getMaxRetries());
+        }
+
+        @Test
+        @DisplayName("Given maxRetries=0, When getMaxRetries is called, Then returns 0")
+        void getMaxRetries_returnsZero() {
+            QuestChainDefinition definition = buildDefinition("retry_zero_max");
+            QuestChainStep step = buildStep("retry_zero_max_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, UUID.randomUUID(), step, 1, 0);
+
+            assertEquals(0, event.getMaxRetries());
+        }
+
+        @Test
+        @DisplayName("Given a positive maxRetries, When getMaxRetries is called, Then returns the positive value")
+        void getMaxRetries_returnsPositiveValue() {
+            QuestChainDefinition definition = buildDefinition("retry_positive_max");
+            QuestChainStep step = buildStep("retry_positive_max_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, UUID.randomUUID(), step, 1, 10);
+
+            assertEquals(10, event.getMaxRetries());
+        }
+    }
+
+    @Nested
+    @DisplayName("Handler list")
+    class HandlerListTests {
+
+        @Test
+        @DisplayName("getHandlers returns the static handler list")
+        void getHandlers_matchesStaticHandlerList() {
+            QuestChainDefinition definition = buildDefinition("retry_hl");
+            QuestChainStep step = buildStep("retry_hl_step");
+
+            QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                    definition, null, UUID.randomUUID(), step, 1, 3);
+
+            assertSame(QuestChainStepRetryEvent.getHandlerList(), event.getHandlers());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for 7 event classes that previously had 0% test coverage
- All tests pass (`./gradlew test` — zero failures across the full suite)
- Testing audit persona (`persona-testing.mdc`) run against changes with no blocking concerns

## Classes Covered

| Class | Key behaviors tested |
|-------|---------------------|
| `AbilityPutOnCooldownEvent` | Cooldown clamping (`Math.max(0, cooldown)`) in constructor and `setCooldown()`, large values (`Long.MAX_VALUE`), getters for holder/ability |
| `QuestCancelEvent` | 3-arg constructor (expiration flag), deprecated 2-arg and 1-arg constructors, `getQuestDefinitionKey()` fallback to instance key when definition is null |
| `QuestRewardGrantEvent` | Cancellation state (default false, set/toggle), mutable reward list (add/remove/clear), `RewardGrantContext` values, nullable `QuestInstance` |
| `QuestRewardGrantedEvent` | Immutable reward list via `List.copyOf()` (throws `UnsupportedOperationException` on add/remove), defensive copy independence from original list, `RewardGrantContext` values |
| `QuestChainExpireEvent` | Cancellation state, nullable `Player` wrapped in `Optional.ofNullable()`, UUID always available even with null player |
| `QuestChainRestartEvent` | `RestartReason` enum (parameterized test over all values), nullable player (raw null), handler list |
| `QuestChainStepRetryEvent` | Retry number (1-based), max retries (-1 for unlimited, 0, positive), `QuestChainStep` getter, nullable player |

## Test plan

- [x] All 7 new test files compile and pass
- [x] Full test suite passes (`./gradlew test` — zero failures)
- [x] Testing audit persona reviewed — no blocking concerns
- [x] Tests follow `action_outcome_whenCondition` naming convention with `@DisplayName` annotations
- [x] Tests extend `McRPGBaseTest` and use `server.addPlayer()` for `PlayerMock` where needed
- [x] Edge cases covered: zero values, negative values, null parameters, enum variants, boundary values

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnEnfiJSL4odu54xz2KCzG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for ability cooldown events.
  * Added tests for quest cancellation, reward granting, and reward completion behavior.
  * Added coverage for quest-chain expiration, restarting, and step retry scenarios.
  * Verified constructor handling, getters, nullable values, state transitions, boundary conditions, reward mutability, and event handler consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->