### PR TITLE
[Unit Tests] Add tests for TimeGate conditions and WindowBoundary types

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/WindowBoundaryTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/WindowBoundaryTypeTest.java
@@ -1,0 +1,244 @@
+package us.eunoians.mcrpg.quest.chain.availability.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.quest.chain.availability.WindowBoundary;
+
+import java.io.File;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WindowBoundaryTypeTest {
+
+    private final File mockFile = new File("test-chain.yml");
+    private final Logger logger = mock(Logger.class);
+
+    @Nested
+    @DisplayName("FixedWindowBoundaryType")
+    class FixedBoundaryTypeTests {
+
+        private final FixedWindowBoundaryType type = new FixedWindowBoundaryType();
+
+        @Test
+        @DisplayName("getKey returns mcrpg:fixed")
+        void getKey_returnsFixedKey() {
+            assertEquals("mcrpg", type.getKey().getNamespace());
+            assertEquals("fixed", type.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns empty for built-in type")
+        void getExpansionKey_returnsEmpty() {
+            assertTrue(type.getExpansionKey().isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse returns Fixed boundary with valid ISO-8601 date")
+        void parse_returnsFixedBoundary_whenValidDate() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("2026-06-01T00:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isPresent());
+            assertInstanceOf(WindowBoundary.Fixed.class, result.get());
+            WindowBoundary.Fixed fixed = (WindowBoundary.Fixed) result.get();
+            assertEquals(LocalDateTime.of(2026, 6, 1, 0, 0, 0), fixed.dateTime());
+        }
+
+        @Test
+        @DisplayName("parse preserves time component in date field")
+        void parse_preservesTimeComponent() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("2026-12-25T14:30:45");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Fixed fixed = (WindowBoundary.Fixed) result.get();
+            assertEquals(LocalDateTime.of(2026, 12, 25, 14, 30, 45), fixed.dateTime());
+        }
+
+        @Test
+        @DisplayName("parse returns empty when date field is missing")
+        void parse_returnsEmpty_whenDateMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn(null);
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse logs warning when date field is missing")
+        void parse_logsWarning_whenDateMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn(null);
+
+            type.parse(section, mockFile, logger);
+
+            verify(logger).warning(
+                    "[AvailabilityConfig] Fixed boundary in test-chain.yml is missing 'date' field — skipping window");
+        }
+
+        @Test
+        @DisplayName("parse returns empty when date field has invalid format")
+        void parse_returnsEmpty_whenDateInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("not-a-date");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse logs warning when date field has invalid format")
+        void parse_logsWarning_whenDateInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("bad-format");
+
+            type.parse(section, mockFile, logger);
+
+            verify(logger).warning(
+                    "[AvailabilityConfig] Invalid date 'bad-format' in test-chain.yml — expected ISO-8601 format (e.g., 2026-06-01T00:00:00)");
+        }
+    }
+
+    @Nested
+    @DisplayName("RecurringWindowBoundaryType")
+    class RecurringBoundaryTypeTests {
+
+        private final RecurringWindowBoundaryType type = new RecurringWindowBoundaryType();
+
+        @Test
+        @DisplayName("getKey returns mcrpg:recurring")
+        void getKey_returnsRecurringKey() {
+            assertEquals("mcrpg", type.getKey().getNamespace());
+            assertEquals("recurring", type.getKey().getKey());
+        }
+
+        @Test
+        @DisplayName("getExpansionKey returns empty for built-in type")
+        void getExpansionKey_returnsEmpty() {
+            assertTrue(type.getExpansionKey().isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse returns Recurring boundary with valid month-day and time")
+        void parse_returnsRecurringBoundary_whenValid() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn("00:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isPresent());
+            assertInstanceOf(WindowBoundary.Recurring.class, result.get());
+            WindowBoundary.Recurring recurring = (WindowBoundary.Recurring) result.get();
+            assertEquals(MonthDay.of(12, 1), recurring.monthDay());
+            assertEquals(LocalTime.MIDNIGHT, recurring.time());
+        }
+
+        @Test
+        @DisplayName("parse preserves time component")
+        void parse_preservesTimeComponent() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--06-15");
+            when(section.getString("time")).thenReturn("14:30:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Recurring recurring = (WindowBoundary.Recurring) result.get();
+            assertEquals(MonthDay.of(6, 15), recurring.monthDay());
+            assertEquals(LocalTime.of(14, 30, 0), recurring.time());
+        }
+
+        @Test
+        @DisplayName("parse returns empty when month-day is missing")
+        void parse_returnsEmpty_whenMonthDayMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn(null);
+            when(section.getString("time")).thenReturn("00:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse returns empty when time is missing")
+        void parse_returnsEmpty_whenTimeMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn(null);
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse returns empty when both fields are missing")
+        void parse_returnsEmpty_whenBothFieldsMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn(null);
+            when(section.getString("time")).thenReturn(null);
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse logs warning when fields are missing")
+        void parse_logsWarning_whenFieldsMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn(null);
+            when(section.getString("time")).thenReturn(null);
+
+            type.parse(section, mockFile, logger);
+
+            verify(logger).warning(
+                    "[AvailabilityConfig] Recurring boundary in test-chain.yml is missing 'month-day' or 'time' field — skipping window");
+        }
+
+        @Test
+        @DisplayName("parse returns empty when month-day has invalid format")
+        void parse_returnsEmpty_whenMonthDayInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("12-01");
+            when(section.getString("time")).thenReturn("00:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse returns empty when time has invalid format")
+        void parse_returnsEmpty_whenTimeInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn("not-a-time");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/WindowBoundaryTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/WindowBoundaryTypeTest.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -230,6 +231,19 @@ class WindowBoundaryTypeTest {
         }
 
         @Test
+        @DisplayName("parse logs warning when month-day has invalid format")
+        void parse_logsWarning_whenMonthDayInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("12-01");
+            when(section.getString("time")).thenReturn("00:00:00");
+
+            type.parse(section, mockFile, logger);
+
+            verify(logger).warning(argThat((String msg) ->
+                    msg.startsWith("[AvailabilityConfig] Invalid recurring boundary in test-chain.yml")));
+        }
+
+        @Test
         @DisplayName("parse returns empty when time has invalid format")
         void parse_returnsEmpty_whenTimeInvalid() {
             Section section = mock(Section.class);
@@ -239,6 +253,19 @@ class WindowBoundaryTypeTest {
             Optional<WindowBoundary> result = type.parse(section, mockFile, logger);
 
             assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("parse logs warning when time has invalid format")
+        void parse_logsWarning_whenTimeInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn("not-a-time");
+
+            type.parse(section, mockFile, logger);
+
+            verify(logger).warning(argThat((String msg) ->
+                    msg.startsWith("[AvailabilityConfig] Invalid recurring boundary in test-chain.yml")));
         }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateChainConditionTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateChainConditionTypeTest.java
@@ -1,0 +1,141 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.quest.chain.QuestChainStartCondition;
+
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TimeGateChainConditionTypeTest {
+
+    private final TimeGateChainConditionType type = new TimeGateChainConditionType();
+
+    @Nested
+    @DisplayName("getKey")
+    class GetKeyTests {
+
+        @Test
+        @DisplayName("getKey returns mcrpg:time_gate")
+        void getKey_returnsTimeGateKey() {
+            assertEquals("mcrpg", type.getKey().getNamespace());
+            assertEquals("time_gate", type.getKey().getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("getExpansionKey")
+    class GetExpansionKeyTests {
+
+        @Test
+        @DisplayName("getExpansionKey returns empty for built-in type")
+        void getExpansionKey_returnsEmpty() {
+            assertTrue(type.getExpansionKey().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("parse")
+    class ParseTests {
+
+        @Test
+        @DisplayName("parse returns TimeGateCondition with valid after and timezone")
+        void parse_returnsCondition_whenValidAfterAndTimezone() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn("America/New_York");
+
+            QuestChainStartCondition result = type.parse(section);
+
+            assertInstanceOf(TimeGateCondition.class, result);
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(2026, condition.after().getYear());
+            assertEquals(7, condition.after().getMonthValue());
+            assertEquals(1, condition.after().getDayOfMonth());
+            assertEquals(ZoneId.of("America/New_York"), condition.timezone());
+        }
+
+        @Test
+        @DisplayName("parse defaults to system timezone when timezone field is absent")
+        void parse_defaultsToSystemTimezone_whenTimezoneAbsent() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn(null);
+
+            QuestChainStartCondition result = type.parse(section);
+
+            assertInstanceOf(TimeGateCondition.class, result);
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(ZoneId.systemDefault(), condition.timezone());
+        }
+
+        @Test
+        @DisplayName("parse throws when after field is missing")
+        void parse_throws_whenAfterMissing() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn(null);
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> type.parse(section));
+            assertTrue(ex.getMessage().contains("'after'"));
+        }
+
+        @Test
+        @DisplayName("parse throws when after field has invalid format")
+        void parse_throws_whenAfterInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("not-a-date");
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> type.parse(section));
+            assertTrue(ex.getMessage().contains("not-a-date"));
+        }
+
+        @Test
+        @DisplayName("parse throws when timezone field has invalid value")
+        void parse_throws_whenTimezoneInvalid() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn("Invalid/Zone");
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> type.parse(section));
+            assertTrue(ex.getMessage().contains("Invalid/Zone"));
+        }
+
+        @Test
+        @DisplayName("parse preserves time component of after field")
+        void parse_preservesTimeComponent() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-12-25T14:30:45");
+            when(section.getString("timezone")).thenReturn(null);
+
+            QuestChainStartCondition result = type.parse(section);
+
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(14, condition.after().getHour());
+            assertEquals(30, condition.after().getMinute());
+            assertEquals(45, condition.after().getSecond());
+        }
+
+        @Test
+        @DisplayName("parse sets the correct key on the returned condition")
+        void parse_setsCorrectKey() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn(null);
+
+            QuestChainStartCondition result = type.parse(section);
+
+            assertEquals(TimeGateChainConditionType.KEY, result.getKey());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
@@ -1,0 +1,108 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class TimeGateConditionTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+    private static final ZoneId NEW_YORK = ZoneId.of("America/New_York");
+
+    @Nested
+    @DisplayName("TimeGateCondition")
+    class ConditionTests {
+
+        @Test
+        @DisplayName("evaluate returns true when current time is after the boundary")
+        void evaluate_returnsTrue_whenAfterBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, UTC);
+
+            Instant afterBoundary = ZonedDateTime.of(2026, 7, 15, 12, 0, 0, 0, UTC).toInstant();
+            assertTrue(condition.evaluate(mock(Player.class), afterBoundary));
+        }
+
+        @Test
+        @DisplayName("evaluate returns false when current time is before the boundary")
+        void evaluate_returnsFalse_whenBeforeBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, UTC);
+
+            Instant beforeBoundary = ZonedDateTime.of(2026, 6, 15, 12, 0, 0, 0, UTC).toInstant();
+            assertFalse(condition.evaluate(mock(Player.class), beforeBoundary));
+        }
+
+        @Test
+        @DisplayName("evaluate returns true when current time is exactly at the boundary")
+        void evaluate_returnsTrue_whenExactlyAtBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, UTC);
+
+            Instant atBoundary = ZonedDateTime.of(2026, 7, 1, 0, 0, 0, 0, UTC).toInstant();
+            assertTrue(condition.evaluate(mock(Player.class), atBoundary));
+        }
+
+        @Test
+        @DisplayName("evaluate respects the configured timezone")
+        void evaluate_respectsTimezone() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, NEW_YORK);
+
+            // 2026-07-01 03:00 UTC = 2026-06-30 23:00 ET (before boundary)
+            Instant beforeInNewYork = ZonedDateTime.of(2026, 7, 1, 3, 0, 0, 0, UTC).toInstant();
+            assertFalse(condition.evaluate(mock(Player.class), beforeInNewYork));
+
+            // 2026-07-01 05:00 UTC = 2026-07-01 01:00 ET (after boundary)
+            Instant afterInNewYork = ZonedDateTime.of(2026, 7, 1, 5, 0, 0, 0, UTC).toInstant();
+            assertTrue(condition.evaluate(mock(Player.class), afterInNewYork));
+        }
+
+        @Test
+        @DisplayName("getKey returns the time gate key")
+        void getKey_returnsTimeGateKey() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, UTC);
+
+            assertEquals(TimeGateChainConditionType.KEY, condition.getKey());
+        }
+
+        @Test
+        @DisplayName("evaluate returns true when current time is one second after boundary")
+        void evaluate_returnsTrue_whenOneSecondAfterBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 12, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, UTC);
+
+            Instant oneSecondAfter = ZonedDateTime.of(2026, 7, 1, 12, 0, 1, 0, UTC).toInstant();
+            assertTrue(condition.evaluate(mock(Player.class), oneSecondAfter));
+        }
+
+        @Test
+        @DisplayName("evaluate returns false when current time is one second before boundary")
+        void evaluate_returnsFalse_whenOneSecondBeforeBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 12, 0, 0);
+            TimeGateCondition condition = new TimeGateCondition(
+                    TimeGateChainConditionType.KEY, boundary, UTC);
+
+            Instant oneSecondBefore = ZonedDateTime.of(2026, 7, 1, 11, 59, 59, 0, UTC).toInstant();
+            assertFalse(condition.evaluate(mock(Player.class), oneSecondBefore));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `TimeGateCondition` and `TimeGateChainConditionType` (quest chain start condition system) — both previously at 0% coverage
- Add unit tests for `FixedWindowBoundaryType` and `RecurringWindowBoundaryType` (availability window boundary parsing) — both previously at 0% coverage
- All four classes are pure logic with no Bukkit dependencies, tested with plain JUnit + Mockito (mocked `Section` for YAML parsing)

## Classes covered

| Class | Lines | Key scenarios |
|-------|-------|---------------|
| `TimeGateCondition` | 5 | Boundary comparison (before/after/exact), timezone handling, edge cases |
| `TimeGateChainConditionType` | 20 | Valid parse, missing `after`, invalid date format, invalid timezone, default timezone |
| `FixedWindowBoundaryType` | 15 | Valid ISO-8601 parse, missing date, invalid format, warning log verification |
| `RecurringWindowBoundaryType` | 17 | Valid month-day+time parse, missing fields, invalid formats, warning log verification |

## Test plan

- [x] All new tests pass (`./gradlew test` — BUILD SUCCESSFUL)
- [x] Full existing test suite passes with no regressions
- [x] Testing audit persona reviewed — one nit (missing logger verification for invalid recurring formats) was addressed in a follow-up commit
- [x] No overlap with existing open PRs (#306 covers `WindowBoundary` records but not the boundary *type* parsers; #307/#328 cover chain events, not conditions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYePW1DMHxkp5NZJ6F7bB8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for fixed and recurring time-window boundaries.
  * Added validation for time-gated conditions, including date parsing, timezones, missing or invalid fields, and boundary timing.
  * Improved verification of metadata, key assignment, date/time preservation, and warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->