### PR TITLE
[Unit Tests] Add coverage for woodcutting abilities and quest chain events

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/ability/impl/woodcutting/DryadsGiftTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/woodcutting/DryadsGiftTest.java
@@ -1,0 +1,275 @@
+package us.eunoians.mcrpg.ability.impl.woodcutting;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.WoodcuttingConfigFile;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.woodcutting.WoodCutting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DryadsGift} configuration value resolution and metadata accessors.
+ */
+class DryadsGiftTest extends McRPGBaseTest {
+
+    private YamlDocument woodcuttingConfig;
+    private DryadsGift dryadsGift;
+
+    @BeforeEach
+    void setUp() {
+        woodcuttingConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.WOODCUTTING_CONFIG)).thenReturn(woodcuttingConfig);
+
+        when(woodcuttingConfig.getStringList(WoodcuttingConfigFile.DRYADS_GIFT_VALID_BLOCKS))
+                .thenReturn(List.of("OAK_LOG", "BIRCH_LOG", "DARK_OAK_LOG"));
+
+        dryadsGift = new DryadsGift(mcRPG);
+    }
+
+    @Nested
+    @DisplayName("getActivationChance")
+    class GetActivationChance {
+
+        @Test
+        @DisplayName("evaluates formula with tier variable")
+        void getActivationChance_evaluatesFormulaWithTier() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "activation-chance");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "activation-chance");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*2");
+
+            assertEquals(6.0, dryadsGift.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("returns literal value when given plain number")
+        void getActivationChance_returnsLiteral() {
+            int tier = 1;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "activation-chance");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "activation-chance");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("3");
+
+            assertEquals(3.0, dryadsGift.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("prefers tier-specific route over all-tiers")
+        void getActivationChance_prefersTierSpecific() {
+            int tier = 4;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "activation-chance");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "activation-chance");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(true);
+            when(woodcuttingConfig.getString(tierRoute)).thenReturn("7.5");
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*2");
+
+            assertEquals(7.5, dryadsGift.getActivationChance(tier), 0.001);
+        }
+    }
+
+    @Nested
+    @DisplayName("getExperienceToDrop")
+    class GetExperienceToDrop {
+
+        @Test
+        @DisplayName("evaluates formula with tier variable")
+        void getExperienceToDrop_evaluatesFormulaWithTier() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "experience-to-drop");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "experience-to-drop");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*5");
+
+            assertEquals(15, dryadsGift.getExperienceToDrop(tier));
+        }
+
+        @Test
+        @DisplayName("returns literal value when given plain number")
+        void getExperienceToDrop_returnsLiteral() {
+            int tier = 1;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "experience-to-drop");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "experience-to-drop");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("5");
+
+            assertEquals(5, dryadsGift.getExperienceToDrop(tier));
+        }
+
+        @Test
+        @DisplayName("prefers tier-specific route over all-tiers")
+        void getExperienceToDrop_prefersTierSpecific() {
+            int tier = 5;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "experience-to-drop");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "experience-to-drop");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(true);
+            when(woodcuttingConfig.getString(tierRoute)).thenReturn("22");
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*5");
+
+            assertEquals(22, dryadsGift.getExperienceToDrop(tier));
+        }
+
+        @Test
+        @DisplayName("truncates fractional values to integer")
+        void getExperienceToDrop_truncatesFractionalValue() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "tier-" + tier),
+                    "experience-to-drop");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, "all-tiers"),
+                    "experience-to-drop");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*3.7");
+
+            assertEquals(11, dryadsGift.getExperienceToDrop(tier));
+        }
+    }
+
+    @Nested
+    @DisplayName("isBlockValid")
+    class IsBlockValid {
+
+        @Test
+        @DisplayName("returns true for block type in valid set")
+        void isBlockValid_returnsTrue_whenBlockInValidSet() {
+            Block block = mock(Block.class);
+            when(block.getType()).thenReturn(Material.OAK_LOG);
+
+            assertTrue(dryadsGift.isBlockValid(block));
+        }
+
+        @Test
+        @DisplayName("returns false for block type not in valid set")
+        void isBlockValid_returnsFalse_whenBlockNotInValidSet() {
+            Block block = mock(Block.class);
+            when(block.getType()).thenReturn(Material.DIAMOND_ORE);
+
+            assertFalse(dryadsGift.isBlockValid(block));
+        }
+
+        @Test
+        @DisplayName("returns true for all configured valid blocks")
+        void isBlockValid_returnsTrue_forAllConfiguredBlocks() {
+            for (Material material : List.of(Material.OAK_LOG, Material.BIRCH_LOG, Material.DARK_OAK_LOG)) {
+                Block block = mock(Block.class);
+                when(block.getType()).thenReturn(material);
+                assertTrue(dryadsGift.isBlockValid(block), material + " should be valid");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("getAbilityKey returns DRYADS_GIFT_KEY")
+        void getAbilityKey_returnsDryadsGiftKey() {
+            assertEquals(DryadsGift.DRYADS_GIFT_KEY, dryadsGift.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns WOODCUTTING_KEY")
+        void getSkillKey_returnsWoodcuttingKey() {
+            assertEquals(WoodCutting.WOODCUTTING_KEY, dryadsGift.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("getDatabaseName returns dryads_gift")
+        void getDatabaseName_returnsDryadsGift() {
+            assertEquals("dryads_gift", dryadsGift.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("getMaxTier reads from config")
+        void getMaxTier_readsFromConfig() {
+            when(woodcuttingConfig.getInt(WoodcuttingConfigFile.DRYADS_GIFT_AMOUNT_OF_TIERS)).thenReturn(5);
+
+            assertEquals(5, dryadsGift.getMaxTier());
+        }
+
+        @Test
+        @DisplayName("getAbilityEnabledRoute returns correct route")
+        void getAbilityEnabledRoute_returnsCorrectRoute() {
+            assertEquals(WoodcuttingConfigFile.DRYADS_GIFT_ENABLED, dryadsGift.getAbilityEnabledRoute());
+        }
+
+        @Test
+        @DisplayName("getAbilityTierConfigurationRoute returns correct route")
+        void getAbilityTierConfigurationRoute_returnsCorrectRoute() {
+            assertEquals(WoodcuttingConfigFile.DRYADS_GIFT_CONFIGURATION_HEADER, dryadsGift.getAbilityTierConfigurationRoute());
+        }
+
+        @Test
+        @DisplayName("getYamlDocument returns non-null")
+        void getYamlDocument_returnsNonNull() {
+            assertNotNull(dryadsGift.getYamlDocument());
+        }
+
+        @Test
+        @DisplayName("getApplicableAttributes returns non-null set")
+        void getApplicableAttributes_returnsNonNull() {
+            assertNotNull(dryadsGift.getApplicableAttributes());
+        }
+
+        @Test
+        @DisplayName("getReloadableContent returns non-empty set")
+        void getReloadableContent_returnsNonEmptySet() {
+            assertFalse(dryadsGift.getReloadableContent().isEmpty());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/woodcutting/HeavySwingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/woodcutting/HeavySwingTest.java
@@ -1,0 +1,275 @@
+package us.eunoians.mcrpg.ability.impl.woodcutting;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.WoodcuttingConfigFile;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.woodcutting.WoodCutting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link HeavySwing} configuration value resolution and metadata accessors.
+ */
+class HeavySwingTest extends McRPGBaseTest {
+
+    private YamlDocument woodcuttingConfig;
+    private HeavySwing heavySwing;
+
+    @BeforeEach
+    void setUp() {
+        woodcuttingConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.WOODCUTTING_CONFIG)).thenReturn(woodcuttingConfig);
+
+        when(woodcuttingConfig.getStringList(WoodcuttingConfigFile.HEAVY_SWING_VALID_BLOCKS))
+                .thenReturn(List.of("OAK_LOG", "BIRCH_LOG", "SPRUCE_LOG"));
+
+        heavySwing = new HeavySwing(mcRPG);
+    }
+
+    @Nested
+    @DisplayName("getActivationChance")
+    class GetActivationChance {
+
+        @Test
+        @DisplayName("evaluates formula with tier variable")
+        void getActivationChance_evaluatesFormulaWithTier() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "activation-chance");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "activation-chance");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*2.5");
+
+            assertEquals(7.5, heavySwing.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("returns literal value when given plain number")
+        void getActivationChance_returnsLiteral() {
+            int tier = 1;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "activation-chance");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "activation-chance");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("5");
+
+            assertEquals(5.0, heavySwing.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("prefers tier-specific route over all-tiers")
+        void getActivationChance_prefersTierSpecific() {
+            int tier = 2;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "activation-chance");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "activation-chance");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(true);
+            when(woodcuttingConfig.getString(tierRoute)).thenReturn("15");
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*2");
+
+            assertEquals(15.0, heavySwing.getActivationChance(tier), 0.001);
+        }
+    }
+
+    @Nested
+    @DisplayName("getRadius")
+    class GetRadius {
+
+        @Test
+        @DisplayName("evaluates formula with tier variable")
+        void getRadius_evaluatesFormulaWithTier() {
+            int tier = 4;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "radius");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "radius");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier");
+
+            assertEquals(4, heavySwing.getRadius(tier));
+        }
+
+        @Test
+        @DisplayName("returns literal value when given plain number")
+        void getRadius_returnsLiteral() {
+            int tier = 1;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "radius");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "radius");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("1");
+
+            assertEquals(1, heavySwing.getRadius(tier));
+        }
+
+        @Test
+        @DisplayName("prefers tier-specific route over all-tiers")
+        void getRadius_prefersTierSpecific() {
+            int tier = 5;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "radius");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "radius");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(true);
+            when(woodcuttingConfig.getString(tierRoute)).thenReturn("3");
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier");
+
+            assertEquals(3, heavySwing.getRadius(tier));
+        }
+
+        @Test
+        @DisplayName("truncates fractional values to integer")
+        void getRadius_truncatesFractionalValue() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "tier-" + tier),
+                    "radius");
+            Route allTiersRoute = Route.addTo(
+                    Route.addTo(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, "all-tiers"),
+                    "radius");
+
+            when(woodcuttingConfig.contains(tierRoute)).thenReturn(false);
+            when(woodcuttingConfig.getString(allTiersRoute)).thenReturn("tier*0.6");
+
+            assertEquals(1, heavySwing.getRadius(tier));
+        }
+    }
+
+    @Nested
+    @DisplayName("isBlockValid")
+    class IsBlockValid {
+
+        @Test
+        @DisplayName("returns true for block type in valid set")
+        void isBlockValid_returnsTrue_whenBlockInValidSet() {
+            Block block = mock(Block.class);
+            when(block.getType()).thenReturn(Material.OAK_LOG);
+
+            assertTrue(heavySwing.isBlockValid(block));
+        }
+
+        @Test
+        @DisplayName("returns false for block type not in valid set")
+        void isBlockValid_returnsFalse_whenBlockNotInValidSet() {
+            Block block = mock(Block.class);
+            when(block.getType()).thenReturn(Material.STONE);
+
+            assertFalse(heavySwing.isBlockValid(block));
+        }
+
+        @Test
+        @DisplayName("returns true for all configured valid blocks")
+        void isBlockValid_returnsTrue_forAllConfiguredBlocks() {
+            for (Material material : List.of(Material.OAK_LOG, Material.BIRCH_LOG, Material.SPRUCE_LOG)) {
+                Block block = mock(Block.class);
+                when(block.getType()).thenReturn(material);
+                assertTrue(heavySwing.isBlockValid(block), material + " should be valid");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("getAbilityKey returns HEAVY_SWING_KEY")
+        void getAbilityKey_returnsHeavySwingKey() {
+            assertEquals(HeavySwing.HEAVY_SWING_KEY, heavySwing.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns WOODCUTTING_KEY")
+        void getSkillKey_returnsWoodcuttingKey() {
+            assertEquals(WoodCutting.WOODCUTTING_KEY, heavySwing.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("getDatabaseName returns heavy_swing")
+        void getDatabaseName_returnsHeavySwing() {
+            assertEquals("heavy_swing", heavySwing.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("getMaxTier reads from config")
+        void getMaxTier_readsFromConfig() {
+            when(woodcuttingConfig.getInt(WoodcuttingConfigFile.HEAVY_SWING_AMOUNT_OF_TIERS)).thenReturn(5);
+
+            assertEquals(5, heavySwing.getMaxTier());
+        }
+
+        @Test
+        @DisplayName("getAbilityEnabledRoute returns correct route")
+        void getAbilityEnabledRoute_returnsCorrectRoute() {
+            assertEquals(WoodcuttingConfigFile.HEAVY_SWING_ENABLED, heavySwing.getAbilityEnabledRoute());
+        }
+
+        @Test
+        @DisplayName("getAbilityTierConfigurationRoute returns correct route")
+        void getAbilityTierConfigurationRoute_returnsCorrectRoute() {
+            assertEquals(WoodcuttingConfigFile.HEAVY_SWING_CONFIGURATION_HEADER, heavySwing.getAbilityTierConfigurationRoute());
+        }
+
+        @Test
+        @DisplayName("getYamlDocument returns non-null")
+        void getYamlDocument_returnsNonNull() {
+            assertNotNull(heavySwing.getYamlDocument());
+        }
+
+        @Test
+        @DisplayName("getApplicableAttributes returns non-null set")
+        void getApplicableAttributes_returnsNonNull() {
+            assertNotNull(heavySwing.getApplicableAttributes());
+        }
+
+        @Test
+        @DisplayName("getReloadableContent returns non-empty set")
+        void getReloadableContent_returnsNonEmptySet() {
+            assertFalse(heavySwing.getReloadableContent().isEmpty());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainExpireEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainExpireEventTest.java
@@ -1,0 +1,111 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link QuestChainExpireEvent}.
+ */
+class QuestChainExpireEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "expire_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", "expire_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("Given an online player, When getters are called, Then they return the values passed to the constructor")
+    void event_getters_returnConstructorValues() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(
+                definition, player.getUniqueId(), player);
+
+        assertSame(definition, event.getChainDefinition());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+        assertTrue(event.getPlayer().isPresent());
+        assertSame(player, event.getPlayer().orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Given an offline player, When getPlayer() is called, Then it returns empty Optional")
+    void event_getPlayer_returnsEmpty_whenOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(
+                definition, offlineUUID, null);
+
+        assertTrue(event.getPlayer().isEmpty());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("Given a new event, When isCancelled() is called, Then it defaults to false")
+    void event_isCancelled_defaultsFalse() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(
+                definition, player.getUniqueId(), player);
+
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("Given an event, When setCancelled(true) is called, Then isCancelled() returns true")
+    void event_setCancelled_updatesState() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(
+                definition, player.getUniqueId(), player);
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("Given a cancelled event, When setCancelled(false) is called, Then isCancelled() returns false")
+    void event_setCancelledFalse_revertsState() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(
+                definition, player.getUniqueId(), player);
+        event.setCancelled(true);
+        event.setCancelled(false);
+
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("Given an expire event, When getHandlers() is called, Then a HandlerList is returned")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainExpireEvent event = new QuestChainExpireEvent(
+                definition, player.getUniqueId(), player);
+
+        assertEquals(QuestChainExpireEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainRestartEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainRestartEventTest.java
@@ -1,0 +1,89 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainRestartEvent}.
+ */
+class QuestChainRestartEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "restart_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", "restart_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("Given an online player with REPEAT_MODE reason, When getters are called, Then they return constructor values")
+    void event_getters_returnConstructorValues_repeatMode() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, player, player.getUniqueId(),
+                QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+        assertEquals(QuestChainRestartEvent.RestartReason.REPEAT_MODE, event.getReason());
+    }
+
+    @Test
+    @DisplayName("Given an offline player, When getPlayer() is called, Then it returns null")
+    void event_getPlayer_returnsNull_whenOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, null, offlineUUID,
+                QuestChainRestartEvent.RestartReason.QUEST_EXPIRE_RESTART_CHAIN);
+
+        assertNull(event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @ParameterizedTest
+    @EnumSource(QuestChainRestartEvent.RestartReason.class)
+    @DisplayName("Given each RestartReason variant, When getReason() is called, Then it returns the expected value")
+    void event_getReason_returnsExpectedValue(QuestChainRestartEvent.RestartReason reason) {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, player, player.getUniqueId(), reason);
+
+        assertEquals(reason, event.getReason());
+    }
+
+    @Test
+    @DisplayName("Given a restart event, When getHandlers() is called, Then a HandlerList is returned")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+
+        QuestChainRestartEvent event = new QuestChainRestartEvent(
+                definition, player, player.getUniqueId(),
+                QuestChainRestartEvent.RestartReason.REPEAT_MODE);
+
+        assertEquals(QuestChainRestartEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
@@ -1,0 +1,89 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link QuestChainStepRetryEvent}.
+ */
+class QuestChainStepRetryEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", "retry_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("Given an online player, When getters are called, Then they return the values passed to the constructor")
+    void event_getters_returnConstructorValues() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 2, 5);
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(player.getUniqueId(), event.getPlayerUUID());
+        assertSame(step, event.getStep());
+        assertEquals(2, event.getRetryNumber());
+        assertEquals(5, event.getMaxRetries());
+    }
+
+    @Test
+    @DisplayName("Given an offline player, When getPlayer() is called, Then it returns null")
+    void event_getPlayer_returnsNull_whenOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        QuestChainStep step = definition.getSteps().get(0);
+        UUID offlineUUID = UUID.randomUUID();
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, null, offlineUUID, step, 1, 3);
+
+        assertNull(event.getPlayer());
+        assertEquals(offlineUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("Given unlimited retries, When getMaxRetries() is called, Then it returns -1")
+    void event_getMaxRetries_returnsNegativeOne_whenUnlimited() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 1, -1);
+
+        assertEquals(-1, event.getMaxRetries());
+    }
+
+    @Test
+    @DisplayName("Given a step retry event, When getHandlers() is called, Then a HandlerList is returned")
+    void event_getHandlers_returnsHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, player.getUniqueId(), step, 1, 3);
+
+        assertEquals(QuestChainStepRetryEvent.getHandlerList(), event.getHandlers());
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `HeavySwing` and `DryadsGift` woodcutting abilities (activation chance, radius/XP drop with Parser formula evaluation, block validation, metadata accessors)
- Add unit tests for three previously-untested quest chain events: `QuestChainExpireEvent`, `QuestChainRestartEvent`, `QuestChainStepRetryEvent`
- Tests cover online/offline player paths, cancellable behavior, parameterized enum variants, handler list access, and tier-specific vs all-tiers config fallback

## New test files (5)

| File | Tests | What's covered |
|------|-------|----------------|
| `HeavySwingTest` | 14 | `getActivationChance`, `getRadius`, `isBlockValid`, metadata |
| `DryadsGiftTest` | 14 | `getActivationChance`, `getExperienceToDrop`, `isBlockValid`, metadata |
| `QuestChainExpireEventTest` | 6 | Getters, offline Optional, cancel toggle, handler list |
| `QuestChainRestartEventTest` | 4 | Getters, offline null, parameterized RestartReason, handler list |
| `QuestChainStepRetryEventTest` | 4 | Getters, offline null, unlimited retries, handler list |

## Test plan

- [x] All 5 new test files compile and pass
- [x] Full test suite passes (`./gradlew test` — zero failures)
- [x] Testing audit persona reviewed changes (one nit fixed: fully-qualified UUID reference)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLr2saz77skR2gjcbTBh5V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for woodcutting ability activation, experience calculations, tier overrides, formulas, valid blocks, and metadata.
  * Added coverage for quest chain expiration, restarting, and step retry events.
  * Verified event cancellation, handler access, player resolution, restart reasons, and unlimited retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->