### PR TITLE
[Unit Tests] Add coverage for StateTypeWarningLog, McRPGPlayerStat, TimeGateCondition, and QuestChainStartConditionTypeRegistry

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/combat/state/StateTypeWarningLogTest.java
+++ b/src/test/java/us/eunoians/mcrpg/combat/state/StateTypeWarningLogTest.java
@@ -1,0 +1,81 @@
+package us.eunoians.mcrpg.combat.state;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@DisplayName("StateTypeWarningLog")
+class StateTypeWarningLogTest {
+
+    private Logger mockLogger;
+    private StateTypeWarningLog warningLog;
+
+    @BeforeEach
+    void setUp() {
+        mockLogger = mock(Logger.class);
+        warningLog = new StateTypeWarningLog(mockLogger);
+    }
+
+    @Test
+    @DisplayName("warnOnce logs the first warning for a given key")
+    void warnOnce_logsFirstWarning() {
+        NamespacedKey key = new NamespacedKey("mcrpg", "test_state");
+        RuntimeException cause = new RuntimeException("boom");
+
+        warningLog.warnOnce(key, "something broke", cause);
+
+        verify(mockLogger).log(Level.WARNING, "something broke", cause);
+    }
+
+    @Test
+    @DisplayName("warnOnce suppresses duplicate warnings for the same key")
+    void warnOnce_suppressesDuplicate() {
+        NamespacedKey key = new NamespacedKey("mcrpg", "test_state");
+        RuntimeException cause = new RuntimeException("boom");
+
+        warningLog.warnOnce(key, "something broke", cause);
+        warningLog.warnOnce(key, "something broke again", cause);
+
+        verify(mockLogger, times(1)).log(Level.WARNING, "something broke", cause);
+    }
+
+    @Test
+    @DisplayName("warnOnce allows warnings for different keys independently")
+    void warnOnce_differentKeysAreIndependent() {
+        NamespacedKey keyA = new NamespacedKey("mcrpg", "state_a");
+        NamespacedKey keyB = new NamespacedKey("mcrpg", "state_b");
+        RuntimeException causeA = new RuntimeException("a broke");
+        RuntimeException causeB = new RuntimeException("b broke");
+
+        warningLog.warnOnce(keyA, "A failed", causeA);
+        warningLog.warnOnce(keyB, "B failed", causeB);
+
+        verify(mockLogger).log(Level.WARNING, "A failed", causeA);
+        verify(mockLogger).log(Level.WARNING, "B failed", causeB);
+    }
+
+    @Test
+    @DisplayName("warnOnce accepts a null cause")
+    void warnOnce_acceptsNullCause() {
+        NamespacedKey key = new NamespacedKey("mcrpg", "null_cause");
+
+        warningLog.warnOnce(key, "no cause", null);
+
+        verify(mockLogger).log(Level.WARNING, "no cause", (Throwable) null);
+    }
+
+    @Test
+    @DisplayName("no warnings are logged when warnOnce is never called")
+    void noWarnings_whenNeverCalled() {
+        verifyNoInteractions(mockLogger);
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/database/table/PlayerLoginTimeDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/PlayerLoginTimeDAOTest.java
@@ -1,5 +1,6 @@
 package us.eunoians.mcrpg.database.table;
 
+import com.diamonddagger590.mccore.database.Database;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,6 +32,34 @@ class PlayerLoginTimeDAOTest extends McRPGBaseTest {
 
     private static final UUID PLAYER_UUID = UUID.randomUUID();
     private static final Instant TEST_INSTANT = Instant.parse("2024-06-15T10:30:00Z");
+
+    @Test
+    @DisplayName("attemptCreateTable creates the table when it does not exist")
+    void attemptCreateTable_createsTable_whenAbsent() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
+        Database mockDatabase = mock(Database.class);
+        PreparedStatement mockStatement = mock(PreparedStatement.class);
+        when(mockDatabase.tableExists(mockConnection, PlayerLoginTimeDAO.TABLE_NAME)).thenReturn(false);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+        boolean created = PlayerLoginTimeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+        assertTrue(created);
+        verify(mockConnection).prepareStatement(contains("CREATE TABLE"));
+        verify(mockStatement).executeUpdate();
+    }
+
+    @Test
+    @DisplayName("attemptCreateTable returns false when the table already exists")
+    void attemptCreateTable_returnsFalse_whenAlreadyExists() {
+        Connection mockConnection = mock(Connection.class);
+        Database mockDatabase = mock(Database.class);
+        when(mockDatabase.tableExists(mockConnection, PlayerLoginTimeDAO.TABLE_NAME)).thenReturn(true);
+
+        boolean created = PlayerLoginTimeDAO.attemptCreateTable(mockConnection, mockDatabase);
+
+        assertFalse(created);
+    }
 
     @Test
     @DisplayName("hasPlayerLoggedInBefore returns true when row exists")

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/QuestChainStartConditionTypeRegistryTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/QuestChainStartConditionTypeRegistryTest.java
@@ -1,0 +1,128 @@
+package us.eunoians.mcrpg.quest.chain.condition;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("QuestChainStartConditionTypeRegistry")
+class QuestChainStartConditionTypeRegistryTest extends McRPGBaseTest {
+
+    private QuestChainStartConditionTypeRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new QuestChainStartConditionTypeRegistry();
+    }
+
+    private QuestChainStartConditionType mockType(String namespace, String key) {
+        NamespacedKey namespacedKey = new NamespacedKey(namespace, key);
+        QuestChainStartConditionType type = mock(QuestChainStartConditionType.class);
+        when(type.getKey()).thenReturn(namespacedKey);
+        return type;
+    }
+
+    @Test
+    @DisplayName("get returns empty for an unregistered key")
+    void get_returnsEmpty_whenKeyNotRegistered() {
+        NamespacedKey key = new NamespacedKey("mcrpg", "nonexistent");
+
+        Optional<QuestChainStartConditionType> result = registry.get(key);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("register then get returns the registered type")
+    void register_thenGet_returnsRegisteredType() {
+        QuestChainStartConditionType type = mockType("mcrpg", "time_gate");
+
+        registry.register(type);
+        Optional<QuestChainStartConditionType> result = registry.get(type.getKey());
+
+        assertTrue(result.isPresent());
+        assertEquals(type, result.get());
+    }
+
+    @Test
+    @DisplayName("registered returns true for a registered type")
+    void registered_returnsTrue_whenTypeRegistered() {
+        QuestChainStartConditionType type = mockType("mcrpg", "time_gate");
+
+        registry.register(type);
+
+        assertTrue(registry.registered(type));
+    }
+
+    @Test
+    @DisplayName("registered returns false for an unregistered type")
+    void registered_returnsFalse_whenTypeNotRegistered() {
+        QuestChainStartConditionType type = mockType("mcrpg", "time_gate");
+
+        assertFalse(registry.registered(type));
+    }
+
+    @Test
+    @DisplayName("register silently replaces an existing type with the same key")
+    void register_replacesExisting_whenSameKey() {
+        QuestChainStartConditionType first = mockType("mcrpg", "time_gate");
+        QuestChainStartConditionType second = mockType("mcrpg", "time_gate");
+
+        registry.register(first);
+        registry.register(second);
+
+        Optional<QuestChainStartConditionType> result = registry.get(first.getKey());
+        assertTrue(result.isPresent());
+        assertEquals(second, result.get());
+    }
+
+    @Test
+    @DisplayName("getAll returns all registered types")
+    void getAll_returnsAllRegisteredTypes() {
+        QuestChainStartConditionType typeA = mockType("mcrpg", "time_gate");
+        QuestChainStartConditionType typeB = mockType("custom", "weather_gate");
+
+        registry.register(typeA);
+        registry.register(typeB);
+
+        Collection<QuestChainStartConditionType> all = registry.getAll();
+        assertEquals(2, all.size());
+        assertTrue(all.contains(typeA));
+        assertTrue(all.contains(typeB));
+    }
+
+    @Test
+    @DisplayName("getAll returns empty collection when nothing is registered")
+    void getAll_returnsEmpty_whenNothingRegistered() {
+        Collection<QuestChainStartConditionType> all = registry.getAll();
+
+        assertNotNull(all);
+        assertTrue(all.isEmpty());
+    }
+
+    @Test
+    @DisplayName("types with different keys are independently registered")
+    void register_differentKeys_areIndependent() {
+        QuestChainStartConditionType typeA = mockType("mcrpg", "time_gate");
+        QuestChainStartConditionType typeB = mockType("mcrpg", "permission_gate");
+
+        registry.register(typeA);
+        registry.register(typeB);
+
+        assertTrue(registry.get(typeA.getKey()).isPresent());
+        assertTrue(registry.get(typeB.getKey()).isPresent());
+        assertEquals(typeA, registry.get(typeA.getKey()).get());
+        assertEquals(typeB, registry.get(typeB.getKey()).get());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
@@ -1,0 +1,116 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("TimeGateCondition")
+class TimeGateConditionTest extends McRPGBaseTest {
+
+    private static final NamespacedKey KEY = new NamespacedKey("mcrpg", "time_gate");
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    @Test
+    @DisplayName("evaluate returns false when current time is before the boundary")
+    void evaluate_returnsFalse_whenBeforeBoundary() {
+        LocalDateTime boundary = LocalDateTime.of(2025, 6, 15, 12, 0);
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, UTC);
+
+        Instant beforeBoundary = ZonedDateTime.of(2025, 6, 15, 11, 59, 59, 0, UTC).toInstant();
+
+        assertFalse(condition.evaluate(mock(Player.class), beforeBoundary));
+    }
+
+    @Test
+    @DisplayName("evaluate returns true when current time is exactly at the boundary")
+    void evaluate_returnsTrue_whenExactlyAtBoundary() {
+        LocalDateTime boundary = LocalDateTime.of(2025, 6, 15, 12, 0);
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, UTC);
+
+        Instant atBoundary = ZonedDateTime.of(2025, 6, 15, 12, 0, 0, 0, UTC).toInstant();
+
+        assertTrue(condition.evaluate(mock(Player.class), atBoundary));
+    }
+
+    @Test
+    @DisplayName("evaluate returns true when current time is after the boundary")
+    void evaluate_returnsTrue_whenAfterBoundary() {
+        LocalDateTime boundary = LocalDateTime.of(2025, 6, 15, 12, 0);
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, UTC);
+
+        Instant afterBoundary = ZonedDateTime.of(2025, 6, 16, 0, 0, 0, 0, UTC).toInstant();
+
+        assertTrue(condition.evaluate(mock(Player.class), afterBoundary));
+    }
+
+    @Test
+    @DisplayName("evaluate respects timezone offset when comparing times")
+    void evaluate_respectsTimezone_whenComparing() {
+        ZoneId tokyo = ZoneId.of("Asia/Tokyo");
+        LocalDateTime boundary = LocalDateTime.of(2025, 6, 15, 12, 0);
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, tokyo);
+
+        Instant utcTime = ZonedDateTime.of(2025, 6, 15, 2, 59, 59, 0, UTC).toInstant();
+        assertFalse(condition.evaluate(mock(Player.class), utcTime),
+                "2:59 UTC is 11:59 JST which is before 12:00 boundary");
+
+        Instant utcTimeAfter = ZonedDateTime.of(2025, 6, 15, 3, 0, 0, 0, UTC).toInstant();
+        assertTrue(condition.evaluate(mock(Player.class), utcTimeAfter),
+                "3:00 UTC is 12:00 JST which is exactly at the boundary");
+    }
+
+    @Test
+    @DisplayName("evaluate returns true when boundary is far in the past")
+    void evaluate_returnsTrue_whenBoundaryFarInPast() {
+        LocalDateTime boundary = LocalDateTime.of(2020, 1, 1, 0, 0);
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, UTC);
+
+        Instant now = ZonedDateTime.of(2025, 6, 15, 12, 0, 0, 0, UTC).toInstant();
+
+        assertTrue(condition.evaluate(mock(Player.class), now));
+    }
+
+    @Test
+    @DisplayName("evaluate returns false when boundary is far in the future")
+    void evaluate_returnsFalse_whenBoundaryFarInFuture() {
+        LocalDateTime boundary = LocalDateTime.of(2030, 12, 31, 23, 59);
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, UTC);
+
+        Instant now = ZonedDateTime.of(2025, 6, 15, 12, 0, 0, 0, UTC).toInstant();
+
+        assertFalse(condition.evaluate(mock(Player.class), now));
+    }
+
+    @Test
+    @DisplayName("getKey returns the key provided at construction")
+    void getKey_returnsConstructorKey() {
+        TimeGateCondition condition = new TimeGateCondition(KEY, LocalDateTime.now(), UTC);
+
+        assertEquals(KEY, condition.getKey());
+    }
+
+    @Test
+    @DisplayName("record accessors return constructor values")
+    void recordAccessors_returnConstructorValues() {
+        LocalDateTime boundary = LocalDateTime.of(2025, 1, 1, 0, 0);
+        ZoneId zone = ZoneId.of("America/New_York");
+        TimeGateCondition condition = new TimeGateCondition(KEY, boundary, zone);
+
+        assertEquals(KEY, condition.key());
+        assertEquals(boundary, condition.after());
+        assertEquals(zone, condition.timezone());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/stat/McRPGPlayerStatTest.java
+++ b/src/test/java/us/eunoians/mcrpg/stat/McRPGPlayerStatTest.java
@@ -1,0 +1,53 @@
+package us.eunoians.mcrpg.stat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DisplayName("McRPGPlayerStat")
+class McRPGPlayerStatTest extends McRPGBaseTest {
+
+    @ParameterizedTest
+    @EnumSource(McRPGPlayerStat.class)
+    @DisplayName("every enum value has a non-null NamespacedKey")
+    void everyValue_hasNonNullKey(McRPGPlayerStat stat) {
+        assertNotNull(stat.getKey());
+    }
+
+    @ParameterizedTest
+    @EnumSource(McRPGPlayerStat.class)
+    @DisplayName("every enum value uses the mcrpg namespace")
+    void everyValue_usesMcrpgNamespace(McRPGPlayerStat stat) {
+        assertEquals("mcrpg", stat.getKey().getNamespace());
+    }
+
+    @Test
+    @DisplayName("HEALTH key string is 'health'")
+    void health_keyStringIsHealth() {
+        assertEquals("health", McRPGPlayerStat.HEALTH.getKey().getKey());
+    }
+
+    @Test
+    @DisplayName("MANA key string is 'mana'")
+    void mana_keyStringIsMana() {
+        assertEquals("mana", McRPGPlayerStat.MANA.getKey().getKey());
+    }
+
+    @Test
+    @DisplayName("HEALTH and MANA have distinct keys")
+    void healthAndMana_haveDistinctKeys() {
+        assertNotEquals(McRPGPlayerStat.HEALTH.getKey(), McRPGPlayerStat.MANA.getKey());
+    }
+
+    @Test
+    @DisplayName("enum has exactly two values")
+    void enum_hasExactlyTwoValues() {
+        assertEquals(2, McRPGPlayerStat.values().length);
+    }
+}


### PR DESCRIPTION
## Summary

- **StateTypeWarningLogTest** (5 tests): Covers warn-once deduplication by `NamespacedKey`, independent keys logging independently, null cause handling, and no-interaction baseline. Pure Mockito — no MockBukkit needed.
- **McRPGPlayerStatTest** (6 tests): Covers every enum value having a non-null key in the `mcrpg` namespace, specific key strings for HEALTH and MANA, distinct keys, and enum cardinality. Uses `@ParameterizedTest` with `@EnumSource`.
- **TimeGateConditionTest** (8 tests): Covers time boundary evaluation — before/at/after boundary, timezone-aware comparison (UTC vs Asia/Tokyo), far-past and far-future boundaries, and record accessor verification.
- **QuestChainStartConditionTypeRegistryTest** (8 tests): Covers register/get round-trip, `registered()` true/false, silent replacement on duplicate key, `getAll()` with multiple types, empty registry, and independent key registration.
- **PlayerLoginTimeDAOTest** (+2 tests): Adds missing `attemptCreateTable` coverage — creates table when absent, returns false when already exists. Follows the established mock JDBC pattern.

Total: **29 new tests** across 4 new test files and 1 modified test file.

## Test plan

- [x] All new tests pass individually
- [x] Full `./gradlew verifiedShadowJar` passes with zero failures
- [x] Tests follow project conventions: `McRPGBaseTest`, `@DisplayName`, `action_outcome_whenCondition` naming
- [x] DAO tests use mock JDBC pattern (no real database)
- [x] No McRPG.getInstance() coupling in test targets (except PlayerLoginTimeDAO's `saveLoggedOutInSafeZone` which is already handled by the existing test via `mcRPG.getTimeProvider()`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FwUQGJ2Z9mU7otSsG2fw9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for warning-log suppression, including duplicate warnings, independent keys, null causes, and no-call scenarios.
  * Added database table creation tests for existing and missing tables.
  * Added registry tests for lookup, registration, replacement, status, and empty states.
  * Added time-gate tests covering boundaries, time zones, and record accessors.
  * Added player-stat tests validating namespaces, keys, uniqueness, and supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->