### PR TITLE
[Unit Tests] Add coverage for mining and herbalism ability configs

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/ability/impl/herbalism/TooManyPlantsTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/herbalism/TooManyPlantsTest.java
@@ -1,0 +1,136 @@
+package us.eunoians.mcrpg.ability.impl.herbalism;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.HerbalismConfigFile;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.herbalism.Herbalism;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TooManyPlantsTest extends McRPGBaseTest {
+
+    private YamlDocument herbalismConfig;
+    private TooManyPlants tooManyPlants;
+
+    @BeforeEach
+    void setUp() {
+        herbalismConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.HERBALISM_CONFIG)).thenReturn(herbalismConfig);
+
+        when(herbalismConfig.getStringList(HerbalismConfigFile.TOO_MANY_PLANTS_VALID_DROPS))
+                .thenReturn(List.of("WHEAT", "CARROTS"));
+
+        tooManyPlants = new TooManyPlants(mcRPG);
+    }
+
+    @Nested
+    @DisplayName("getActivationChance")
+    class GetActivationChance {
+
+        @Test
+        @DisplayName("evaluates formula with herbalism_level variable")
+        void getActivationChance_evaluatesFormulaWithHerbalismLevel() {
+            int level = 10;
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            SkillHolder.SkillHolderData skillHolderData = mock(SkillHolder.SkillHolderData.class);
+            when(skillHolder.getSkillHolderData(Herbalism.HERBALISM_KEY)).thenReturn(Optional.of(skillHolderData));
+            when(skillHolderData.getCurrentLevel()).thenReturn(level);
+            when(herbalismConfig.getString(HerbalismConfigFile.TOO_MANY_PLANTS_ACTIVATION_EQUATION)).thenReturn("herbalism_level*3");
+
+            assertEquals(30.0, tooManyPlants.getActivationChance(skillHolder), 0.001);
+        }
+
+        @Test
+        @DisplayName("returns literal value when given plain number")
+        void getActivationChance_returnsLiteral() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            SkillHolder.SkillHolderData skillHolderData = mock(SkillHolder.SkillHolderData.class);
+            when(skillHolder.getSkillHolderData(Herbalism.HERBALISM_KEY)).thenReturn(Optional.of(skillHolderData));
+            when(skillHolderData.getCurrentLevel()).thenReturn(5);
+            when(herbalismConfig.getString(HerbalismConfigFile.TOO_MANY_PLANTS_ACTIVATION_EQUATION)).thenReturn("25");
+
+            assertEquals(25.0, tooManyPlants.getActivationChance(skillHolder), 0.001);
+        }
+
+        @Test
+        @DisplayName("returns zero when holder has no herbalism skill data")
+        void getActivationChance_returnsZero_whenNoHerbalismData() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            when(skillHolder.getSkillHolderData(Herbalism.HERBALISM_KEY)).thenReturn(Optional.empty());
+
+            assertEquals(0.0, tooManyPlants.getActivationChance(skillHolder), 0.001);
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("getAbilityKey returns TOO_MANY_PLANTS_KEY")
+        void getAbilityKey_returnsTooManyPlantsKey() {
+            assertEquals(TooManyPlants.TOO_MANY_PLANTS_KEY, tooManyPlants.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns HERBALISM_KEY")
+        void getSkillKey_returnsHerbalismKey() {
+            assertEquals(Herbalism.HERBALISM_KEY, tooManyPlants.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("getDatabaseName returns too_many_plants")
+        void getDatabaseName_returnsTooManyPlants() {
+            assertEquals("too_many_plants", tooManyPlants.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("getAbilityEnabledRoute returns correct route")
+        void getAbilityEnabledRoute_returnsCorrectRoute() {
+            assertEquals(HerbalismConfigFile.TOO_MANY_PLANTS_ENABLED, tooManyPlants.getAbilityEnabledRoute());
+        }
+
+        @Test
+        @DisplayName("getYamlDocument returns non-null")
+        void getYamlDocument_returnsNonNull() {
+            assertNotNull(tooManyPlants.getYamlDocument());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMultiplierMap")
+    class GetMultiplierMap {
+
+        @Test
+        @DisplayName("returns non-null map")
+        void getMultiplierMap_returnsNonNull() {
+            assertNotNull(tooManyPlants.getMultiplierMap());
+        }
+
+        @Test
+        @DisplayName("returns empty map initially")
+        void getMultiplierMap_returnsEmptyInitially() {
+            assertTrue(tooManyPlants.getMultiplierMap().isEmpty());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ExtraOreTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ExtraOreTest.java
@@ -1,0 +1,137 @@
+package us.eunoians.mcrpg.ability.impl.mining;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.MiningConfigFile;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.entity.holder.SkillHolder;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExtraOreTest extends McRPGBaseTest {
+
+    private YamlDocument miningConfig;
+    private ExtraOre extraOre;
+
+    @BeforeEach
+    void setUp() {
+        miningConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.MINING_CONFIG)).thenReturn(miningConfig);
+
+        when(miningConfig.getStringList(MiningConfigFile.EXTRA_ORE_VALID_DROPS))
+                .thenReturn(List.of("DIAMOND_ORE", "IRON_ORE"));
+
+        extraOre = new ExtraOre(mcRPG);
+    }
+
+    @Nested
+    @DisplayName("getActivationChance")
+    class GetActivationChance {
+
+        @Test
+        @DisplayName("evaluates formula with mining_level variable")
+        void getActivationChance_evaluatesFormulaWithMiningLevel() {
+            int level = 10;
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            SkillHolder.SkillHolderData skillHolderData = mock(SkillHolder.SkillHolderData.class);
+            when(skillHolder.getSkillHolderData(Mining.MINING_KEY)).thenReturn(Optional.of(skillHolderData));
+            when(skillHolderData.getCurrentLevel()).thenReturn(level);
+            when(miningConfig.getString(MiningConfigFile.EXTRA_ORE_ACTIVATION_EQUATION)).thenReturn("mining_level*2");
+
+            assertEquals(20.0, extraOre.getActivationChance(skillHolder), 0.001);
+        }
+
+        @Test
+        @DisplayName("returns literal value when given plain number")
+        void getActivationChance_returnsLiteral() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            SkillHolder.SkillHolderData skillHolderData = mock(SkillHolder.SkillHolderData.class);
+            when(skillHolder.getSkillHolderData(Mining.MINING_KEY)).thenReturn(Optional.of(skillHolderData));
+            when(skillHolderData.getCurrentLevel()).thenReturn(5);
+            when(miningConfig.getString(MiningConfigFile.EXTRA_ORE_ACTIVATION_EQUATION)).thenReturn("30");
+
+            assertEquals(30.0, extraOre.getActivationChance(skillHolder), 0.001);
+        }
+
+        @Test
+        @DisplayName("returns zero when holder has no mining skill data")
+        void getActivationChance_returnsZero_whenNoMiningData() {
+            SkillHolder skillHolder = mock(SkillHolder.class);
+            when(skillHolder.getSkillHolderData(Mining.MINING_KEY)).thenReturn(Optional.empty());
+
+            assertEquals(0.0, extraOre.getActivationChance(skillHolder), 0.001);
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("getAbilityKey returns EXTRA_ORE_KEY")
+        void getAbilityKey_returnsExtraOreKey() {
+            assertEquals(ExtraOre.EXTRA_ORE_KEY, extraOre.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns MINING_KEY")
+        void getSkillKey_returnsMiningKey() {
+            assertEquals(Mining.MINING_KEY, extraOre.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("getDatabaseName returns extra_ore")
+        void getDatabaseName_returnsExtraOre() {
+            assertEquals("extra_ore", extraOre.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("getAbilityEnabledRoute returns correct route")
+        void getAbilityEnabledRoute_returnsCorrectRoute() {
+            assertEquals(MiningConfigFile.EXTRA_ORE_ENABLED, extraOre.getAbilityEnabledRoute());
+        }
+
+        @Test
+        @DisplayName("getYamlDocument returns non-null")
+        void getYamlDocument_returnsNonNull() {
+            assertNotNull(extraOre.getYamlDocument());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMultiplierMap")
+    class GetMultiplierMap {
+
+        @Test
+        @DisplayName("returns non-null map")
+        void getMultiplierMap_returnsNonNull() {
+            assertNotNull(extraOre.getMultiplierMap());
+        }
+
+        @Test
+        @DisplayName("returns empty map initially")
+        void getMultiplierMap_returnsEmptyInitially() {
+            assertTrue(extraOre.getMultiplierMap().isEmpty());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ExtraOreTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ExtraOreTest.java
@@ -11,7 +11,6 @@ import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.configuration.FileManager;
 import us.eunoians.mcrpg.configuration.FileType;
 import us.eunoians.mcrpg.configuration.file.skill.MiningConfigFile;
-import us.eunoians.mcrpg.entity.holder.AbilityHolder;
 import us.eunoians.mcrpg.entity.holder.SkillHolder;
 import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
 import us.eunoians.mcrpg.skill.impl.mining.Mining;

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ItsATripleTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ItsATripleTest.java
@@ -17,7 +17,6 @@ import us.eunoians.mcrpg.skill.impl.mining.Mining;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,6 +63,19 @@ class ItsATripleTest extends McRPGBaseTest {
             when(miningConfig.getString(tierRoute)).thenReturn("50");
 
             assertEquals(50.0, itsATriple.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("resolves tier-1 route correctly")
+        void getActivationChance_resolvesTierOne() {
+            int tier = 1;
+            Route tierRoute = Route.addTo(itsATriple.getRouteForTier(tier), "activation-chance");
+            Route allTiersRoute = Route.addTo(itsATriple.getRouteForAllTiers(), "activation-chance");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("tier*10");
+
+            assertEquals(10.0, itsATriple.getActivationChance(tier), 0.001);
         }
 
         @Test

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ItsATripleTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/mining/ItsATripleTest.java
@@ -1,0 +1,136 @@
+package us.eunoians.mcrpg.ability.impl.mining;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.MiningConfigFile;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ItsATripleTest extends McRPGBaseTest {
+
+    private YamlDocument miningConfig;
+    private ItsATriple itsATriple;
+
+    @BeforeEach
+    void setUp() {
+        miningConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.MINING_CONFIG)).thenReturn(miningConfig);
+
+        itsATriple = new ItsATriple(mcRPG);
+    }
+
+    @Nested
+    @DisplayName("getActivationChance")
+    class GetActivationChance {
+
+        @Test
+        @DisplayName("uses all-tiers route when tier-specific route is absent")
+        void getActivationChance_usesAllTiersRoute_whenTierRouteAbsent() {
+            int tier = 2;
+            Route tierRoute = Route.addTo(itsATriple.getRouteForTier(tier), "activation-chance");
+            Route allTiersRoute = Route.addTo(itsATriple.getRouteForAllTiers(), "activation-chance");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("tier*10");
+
+            assertEquals(20.0, itsATriple.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("uses tier-specific route when present")
+        void getActivationChance_usesTierRoute_whenPresent() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(itsATriple.getRouteForTier(tier), "activation-chance");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(true);
+            when(miningConfig.getString(tierRoute)).thenReturn("50");
+
+            assertEquals(50.0, itsATriple.getActivationChance(tier), 0.001);
+        }
+
+        @Test
+        @DisplayName("sets tier variable in formula")
+        void getActivationChance_setsTierVariable() {
+            int tier = 5;
+            Route tierRoute = Route.addTo(itsATriple.getRouteForTier(tier), "activation-chance");
+            Route allTiersRoute = Route.addTo(itsATriple.getRouteForAllTiers(), "activation-chance");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("tier*5+10");
+
+            assertEquals(35.0, itsATriple.getActivationChance(tier), 0.001);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMaxTier")
+    class GetMaxTier {
+
+        @Test
+        @DisplayName("returns value from config")
+        void getMaxTier_returnsConfigValue() {
+            when(miningConfig.getInt(MiningConfigFile.ITS_A_TRIPLE_AMOUNT_OF_TIERS)).thenReturn(5);
+
+            assertEquals(5, itsATriple.getMaxTier());
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("getAbilityKey returns ITS_A_TRIPLE_KEY")
+        void getAbilityKey_returnsItsATripleKey() {
+            assertEquals(ItsATriple.ITS_A_TRIPLE_KEY, itsATriple.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns MINING_KEY")
+        void getSkillKey_returnsMiningKey() {
+            assertEquals(Mining.MINING_KEY, itsATriple.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("getDatabaseName returns its_a_triple")
+        void getDatabaseName_returnsItsATriple() {
+            assertEquals("its_a_triple", itsATriple.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("getAbilityEnabledRoute returns correct route")
+        void getAbilityEnabledRoute_returnsCorrectRoute() {
+            assertEquals(MiningConfigFile.ITS_A_TRIPLE_ENABLED, itsATriple.getAbilityEnabledRoute());
+        }
+
+        @Test
+        @DisplayName("getAbilityTierConfigurationRoute returns correct route")
+        void getAbilityTierConfigurationRoute_returnsCorrectRoute() {
+            assertEquals(MiningConfigFile.ITS_A_TRIPLE_CONFIGURATION_HEADER, itsATriple.getAbilityTierConfigurationRoute());
+        }
+
+        @Test
+        @DisplayName("getYamlDocument returns non-null")
+        void getYamlDocument_returnsNonNull() {
+            assertNotNull(itsATriple.getYamlDocument());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/mining/OreScannerConfigTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/mining/OreScannerConfigTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("deprecation")
-class OresScannerConfigTest extends McRPGBaseTest {
+class OreScannerConfigTest extends McRPGBaseTest {
 
     private YamlDocument miningConfig;
     private OreScanner oreScanner;
@@ -77,6 +77,19 @@ class OresScannerConfigTest extends McRPGBaseTest {
             when(miningConfig.getString(tierRoute)).thenReturn("20");
 
             assertEquals(20, oreScanner.getRange(tier));
+        }
+
+        @Test
+        @DisplayName("resolves tier-1 route correctly")
+        void getRange_resolvesTierOne() {
+            int tier = 1;
+            Route tierRoute = Route.addTo(oreScanner.getRouteForTier(tier), "range");
+            Route allTiersRoute = Route.addTo(oreScanner.getRouteForAllTiers(), "range");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("tier*5");
+
+            assertEquals(5, oreScanner.getRange(tier));
         }
 
         @Test

--- a/src/test/java/us/eunoians/mcrpg/ability/impl/mining/OresScannerConfigTest.java
+++ b/src/test/java/us/eunoians/mcrpg/ability/impl/mining/OresScannerConfigTest.java
@@ -1,0 +1,217 @@
+package us.eunoians.mcrpg.ability.impl.mining;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.impl.mining.orescanner.OreScannerBlockType;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.configuration.file.skill.MiningConfigFile;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("deprecation")
+class OresScannerConfigTest extends McRPGBaseTest {
+
+    private YamlDocument miningConfig;
+    private OreScanner oreScanner;
+
+    @BeforeEach
+    void setUp() {
+        miningConfig = mock(YamlDocument.class);
+        FileManager fileManager = RegistryAccess.registryAccess()
+                .registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        when(fileManager.getFile(FileType.MINING_CONFIG)).thenReturn(miningConfig);
+
+        Section emptySection = mock(Section.class);
+        when(emptySection.getRoutesAsStrings(false)).thenReturn(Set.of());
+        when(miningConfig.getSection(any(Route.class))).thenReturn(emptySection);
+
+        oreScanner = new OreScanner(mcRPG);
+    }
+
+    @Nested
+    @DisplayName("getRange")
+    class GetRange {
+
+        @Test
+        @DisplayName("uses all-tiers route when tier-specific route is absent")
+        void getRange_usesAllTiersRoute_whenTierRouteAbsent() {
+            int tier = 2;
+            Route tierRoute = Route.addTo(oreScanner.getRouteForTier(tier), "range");
+            Route allTiersRoute = Route.addTo(oreScanner.getRouteForAllTiers(), "range");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("tier*5");
+
+            assertEquals(10, oreScanner.getRange(tier));
+        }
+
+        @Test
+        @DisplayName("uses tier-specific route when present")
+        void getRange_usesTierRoute_whenPresent() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(oreScanner.getRouteForTier(tier), "range");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(true);
+            when(miningConfig.getString(tierRoute)).thenReturn("20");
+
+            assertEquals(20, oreScanner.getRange(tier));
+        }
+
+        @Test
+        @DisplayName("sets tier variable in formula")
+        void getRange_setsTierVariable() {
+            int tier = 4;
+            Route tierRoute = Route.addTo(oreScanner.getRouteForTier(tier), "range");
+            Route allTiersRoute = Route.addTo(oreScanner.getRouteForAllTiers(), "range");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("5+tier*3");
+
+            assertEquals(17, oreScanner.getRange(tier));
+        }
+
+        @Test
+        @DisplayName("truncates fractional result to int")
+        void getRange_truncatesFractionalResult() {
+            int tier = 3;
+            Route tierRoute = Route.addTo(oreScanner.getRouteForTier(tier), "range");
+            Route allTiersRoute = Route.addTo(oreScanner.getRouteForAllTiers(), "range");
+
+            when(miningConfig.contains(tierRoute)).thenReturn(false);
+            when(miningConfig.getString(allTiersRoute)).thenReturn("tier*2.5");
+
+            assertEquals(7, oreScanner.getRange(tier));
+        }
+    }
+
+    @Nested
+    @DisplayName("getHighestWeightedScanType")
+    class GetHighestWeightedScanType {
+
+        @Test
+        @DisplayName("returns empty for empty set")
+        void getHighestWeightedScanType_returnsEmpty_whenSetEmpty() {
+            Optional<OreScannerBlockType> result = oreScanner.getHighestWeightedScanType(Set.of());
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns single type from singleton set")
+        void getHighestWeightedScanType_returnsSingleType() {
+            OreScannerBlockType type = new OreScannerBlockType(
+                    Set.of(Material.DIAMOND_ORE), "Diamond", ChatColor.AQUA, 10);
+
+            Optional<OreScannerBlockType> result = oreScanner.getHighestWeightedScanType(Set.of(type));
+
+            assertTrue(result.isPresent());
+            assertEquals(type, result.get());
+        }
+
+        @Test
+        @DisplayName("returns highest weighted type from multiple types")
+        void getHighestWeightedScanType_returnsHighest() {
+            OreScannerBlockType low = new OreScannerBlockType(
+                    Set.of(Material.COAL_ORE), "Coal", ChatColor.DARK_GRAY, 1);
+            OreScannerBlockType mid = new OreScannerBlockType(
+                    Set.of(Material.IRON_ORE), "Iron", ChatColor.WHITE, 5);
+            OreScannerBlockType high = new OreScannerBlockType(
+                    Set.of(Material.DIAMOND_ORE), "Diamond", ChatColor.AQUA, 10);
+
+            Optional<OreScannerBlockType> result = oreScanner.getHighestWeightedScanType(Set.of(low, mid, high));
+
+            assertTrue(result.isPresent());
+            assertEquals(high, result.get());
+        }
+
+        @Test
+        @DisplayName("handles types with equal weight")
+        void getHighestWeightedScanType_handlesEqualWeight() {
+            OreScannerBlockType first = new OreScannerBlockType(
+                    Set.of(Material.GOLD_ORE), "Gold", ChatColor.GOLD, 5);
+            OreScannerBlockType second = new OreScannerBlockType(
+                    Set.of(Material.IRON_ORE), "Iron", ChatColor.WHITE, 5);
+
+            Optional<OreScannerBlockType> result = oreScanner.getHighestWeightedScanType(Set.of(first, second));
+
+            assertTrue(result.isPresent());
+            assertEquals(5, result.get().weight());
+        }
+    }
+
+    @Nested
+    @DisplayName("getMaxTier")
+    class GetMaxTier {
+
+        @Test
+        @DisplayName("returns value from config")
+        void getMaxTier_returnsConfigValue() {
+            when(miningConfig.getInt(MiningConfigFile.ORE_SCANNER_AMOUNT_OF_TIERS)).thenReturn(5);
+
+            assertEquals(5, oreScanner.getMaxTier());
+        }
+    }
+
+    @Nested
+    @DisplayName("Metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("getAbilityKey returns ORE_SCANNER_KEY")
+        void getAbilityKey_returnsOreScannerKey() {
+            assertEquals(OreScanner.ORE_SCANNER_KEY, oreScanner.getAbilityKey());
+        }
+
+        @Test
+        @DisplayName("getSkillKey returns MINING_KEY")
+        void getSkillKey_returnsMiningKey() {
+            assertEquals(Mining.MINING_KEY, oreScanner.getSkillKey());
+        }
+
+        @Test
+        @DisplayName("getDatabaseName returns ore_scanner")
+        void getDatabaseName_returnsOreScanner() {
+            assertEquals("ore_scanner", oreScanner.getDatabaseName());
+        }
+
+        @Test
+        @DisplayName("getAbilityEnabledRoute returns correct route")
+        void getAbilityEnabledRoute_returnsCorrectRoute() {
+            assertEquals(MiningConfigFile.ORE_SCANNER_ENABLED, oreScanner.getAbilityEnabledRoute());
+        }
+
+        @Test
+        @DisplayName("getAbilityTierConfigurationRoute returns correct route")
+        void getAbilityTierConfigurationRoute_returnsCorrectRoute() {
+            assertEquals(MiningConfigFile.ORE_SCANNER_CONFIGURATION_HEADER, oreScanner.getAbilityTierConfigurationRoute());
+        }
+
+        @Test
+        @DisplayName("getYamlDocument returns non-null")
+        void getYamlDocument_returnsNonNull() {
+            assertNotNull(oreScanner.getYamlDocument());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `ExtraOre`, `ItsATriple`, `OreScanner` (mining), and `TooManyPlants` (herbalism) ability config/metadata methods
- All four classes previously had 0% or near-0% test coverage on their non-Bukkit logic
- Tests cover Parser formula evaluation with skill-level and tier variables, tier-specific vs all-tiers config routing, metadata accessors, and `getHighestWeightedScanType` selection logic

## New test files

| File | Class under test | Tests |
|------|-----------------|-------|
| `ExtraOreTest` | `ExtraOre` | `getActivationChance` (formula with `mining_level`, literal, zero when no data), metadata, multiplier map |
| `ItsATripleTest` | `ItsATriple` | `getActivationChance` (all-tiers fallback, tier-specific override, tier-1 boundary, tier variable), `getMaxTier`, metadata |
| `OreScannerConfigTest` | `OreScanner` | `getRange` (all-tiers fallback, tier-specific, tier-1 boundary, tier variable, fractional truncation), `getHighestWeightedScanType` (empty, singleton, multiple, equal weight), `getMaxTier`, metadata |
| `TooManyPlantsTest` | `TooManyPlants` | `getActivationChance` (formula with `herbalism_level`, literal, zero when no data), metadata, multiplier map |

## Test plan

- [x] All new tests pass (`./gradlew test` — BUILD SUCCESSFUL)
- [x] Full test suite passes with zero regressions
- [x] Testing audit persona reviewed and all findings addressed (class rename, unused imports, tier-1 boundary tests added)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViwhAA5UvsysKmRYNMjFhz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for herbalism and mining abilities.
  * Verified activation chances, fallback behavior, configuration handling, tier and multiplier calculations, metadata, and YAML access.
  * Added coverage for weighted ore scanning and configurable scan ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->