### PR TITLE
[Unit Tests] Add coverage for QuestChainStepRetryEvent and objective type processProgress

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/quest/chain/QuestChainStepRetryEventTest.java
@@ -1,0 +1,95 @@
+package us.eunoians.mcrpg.event.quest.chain;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainDefinition;
+import us.eunoians.mcrpg.quest.chain.QuestChainStep;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@DisplayName("QuestChainStepRetryEvent")
+class QuestChainStepRetryEventTest extends McRPGBaseTest {
+
+    private static QuestChainDefinition buildDefinition() {
+        NamespacedKey chainKey = new NamespacedKey("mcrpg", "test_chain");
+        NamespacedKey sourceKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey triggerKey = new NamespacedKey("mcrpg", "manual");
+        NamespacedKey questKey = new NamespacedKey("mcrpg", "example_quest");
+        List<QuestChainStep> steps = List.of(QuestChainStep.simple(questKey));
+        return new QuestChainDefinition.Builder(chainKey, sourceKey, triggerKey, steps).build();
+    }
+
+    @Test
+    @DisplayName("Constructor stores all fields and getters return them")
+    void constructor_storesAllFields() {
+        QuestChainDefinition definition = buildDefinition();
+        PlayerMock player = server.addPlayer();
+        UUID playerUUID = player.getUniqueId();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, player, playerUUID, step, 2, 5);
+
+        assertSame(definition, event.getChainDefinition());
+        assertSame(player, event.getPlayer());
+        assertEquals(playerUUID, event.getPlayerUUID());
+        assertSame(step, event.getStep());
+        assertEquals(2, event.getRetryNumber());
+        assertEquals(5, event.getMaxRetries());
+    }
+
+    @Test
+    @DisplayName("Player can be null for offline players")
+    void getPlayer_returnsNull_whenPlayerIsOffline() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID playerUUID = UUID.randomUUID();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, null, playerUUID, step, 1, 3);
+
+        assertNull(event.getPlayer());
+        assertEquals(playerUUID, event.getPlayerUUID());
+    }
+
+    @Test
+    @DisplayName("MaxRetries of -1 indicates unlimited retries")
+    void getMaxRetries_returnsNegativeOne_forUnlimited() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID playerUUID = UUID.randomUUID();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, null, playerUUID, step, 1, -1);
+
+        assertEquals(-1, event.getMaxRetries());
+    }
+
+    @Test
+    @DisplayName("getHandlerList() returns a non-null static HandlerList")
+    void getHandlerList_returnsNonNull() {
+        assertNotNull(QuestChainStepRetryEvent.getHandlerList());
+    }
+
+    @Test
+    @DisplayName("Instance getHandlers() returns the same HandlerList as the static method")
+    void getHandlers_matchesStaticHandlerList() {
+        QuestChainDefinition definition = buildDefinition();
+        UUID playerUUID = UUID.randomUUID();
+        QuestChainStep step = definition.getSteps().get(0);
+
+        QuestChainStepRetryEvent event = new QuestChainStepRetryEvent(
+                definition, null, playerUUID, step, 1, 1);
+
+        assertSame(QuestChainStepRetryEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
@@ -1,10 +1,18 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import com.diamonddagger590.mccore.util.item.CustomEntityWrapper;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.EntityTameEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.CraftingInventory;
@@ -322,6 +330,322 @@ public class ObjectiveTypeProcessProgressTest extends McRPGBaseTest {
             when(inventory.getMatrix()).thenReturn(matrix);
             CraftItemQuestContext context = new CraftItemQuestContext(event);
             assertEquals(1, type.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("ItemPickupObjectiveType processProgress")
+    class ItemPickupProcessProgress {
+
+        private final ItemPickupObjectiveType type = new ItemPickupObjectiveType();
+
+        private ItemPickupQuestContext createContext(Material material, int amount) {
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item itemEntity = mock(Item.class);
+            ItemStack itemStack = new ItemStack(material, amount);
+            when(event.getItem()).thenReturn(itemEntity);
+            when(itemEntity.getItemStack()).thenReturn(itemStack);
+            return new ItemPickupQuestContext(event);
+        }
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any item and returns stack amount")
+        public void processProgress_unconfigured_returnsStackAmount() {
+            ItemPickupQuestContext context = createContext(Material.DIAMOND, 5);
+            assertEquals(5, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns 1 for single-item pickup")
+        public void processProgress_unconfigured_returnsSingleAmount() {
+            ItemPickupQuestContext context = createContext(Material.IRON_INGOT, 1);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("ItemPickupObjectiveType parseConfig")
+    class ItemPickupParseConfig {
+
+        private final ItemPickupObjectiveType type = new ItemPickupObjectiveType();
+
+        @Test
+        @DisplayName("section without items key accepts any item")
+        public void parseConfig_noItemsKey_acceptsAnyItem() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(false);
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item itemEntity = mock(Item.class);
+            when(event.getItem()).thenReturn(itemEntity);
+            when(itemEntity.getItemStack()).thenReturn(new ItemStack(Material.GOLD_INGOT, 3));
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(3, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("section with items key filters by item type")
+        public void parseConfig_withItems_filtersCorrectly() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("DIAMOND", "EMERALD"));
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            EntityPickupItemEvent matchEvent = mock(EntityPickupItemEvent.class);
+            Item matchItem = mock(Item.class);
+            when(matchEvent.getItem()).thenReturn(matchItem);
+            when(matchItem.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND, 7));
+            assertEquals(7, configured.processProgress(mockInstance, new ItemPickupQuestContext(matchEvent)));
+
+            EntityPickupItemEvent noMatchEvent = mock(EntityPickupItemEvent.class);
+            Item noMatchItem = mock(Item.class);
+            when(noMatchEvent.getItem()).thenReturn(noMatchItem);
+            when(noMatchItem.getItemStack()).thenReturn(new ItemStack(Material.IRON_INGOT, 2));
+            assertEquals(0, configured.processProgress(mockInstance, new ItemPickupQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(false);
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+            assertEquals(ItemPickupObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("LaunchProjectileObjectiveType processProgress")
+    class LaunchProjectileProcessProgress {
+
+        private final LaunchProjectileObjectiveType type = new LaunchProjectileObjectiveType();
+
+        private LaunchProjectileQuestContext createContext(EntityType entityType) {
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(event.getEntity()).thenReturn(projectile);
+            when(projectile.getType()).thenReturn(entityType);
+            return new LaunchProjectileQuestContext(event);
+        }
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any projectile and returns 1")
+        public void processProgress_unconfigured_returnsOne() {
+            LaunchProjectileQuestContext context = createContext(EntityType.ARROW);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching projectile returns 1")
+        public void processProgress_matchingProjectile_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("ARROW", "SNOWBALL"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            LaunchProjectileQuestContext context = createContext(EntityType.ARROW);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching projectile returns 0")
+        public void processProgress_nonMatchingProjectile_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("ARROW"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            LaunchProjectileQuestContext context = createContext(EntityType.SNOWBALL);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("LaunchProjectileObjectiveType parseConfig")
+    class LaunchProjectileParseConfig {
+
+        private final LaunchProjectileObjectiveType type = new LaunchProjectileObjectiveType();
+
+        @Test
+        @DisplayName("section without projectiles key accepts any projectile")
+        public void parseConfig_noProjectilesKey_acceptsAnyProjectile() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(false);
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(event.getEntity()).thenReturn(projectile);
+            when(projectile.getType()).thenReturn(EntityType.FIREBALL);
+            assertEquals(1, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("section with projectiles key filters by entity type")
+        public void parseConfig_withProjectiles_filtersCorrectly() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("SNOWBALL", "EGG"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent matchEvent = mock(ProjectileLaunchEvent.class);
+            Projectile matchProjectile = mock(Projectile.class);
+            when(matchEvent.getEntity()).thenReturn(matchProjectile);
+            when(matchProjectile.getType()).thenReturn(EntityType.SNOWBALL);
+            assertEquals(1, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(matchEvent)));
+
+            ProjectileLaunchEvent noMatchEvent = mock(ProjectileLaunchEvent.class);
+            Projectile noMatchProjectile = mock(Projectile.class);
+            when(noMatchEvent.getEntity()).thenReturn(noMatchProjectile);
+            when(noMatchProjectile.getType()).thenReturn(EntityType.ARROW);
+            assertEquals(0, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(false);
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+            assertEquals(LaunchProjectileObjectiveType.KEY, configured.getKey());
+        }
+
+        @Test
+        @DisplayName("projectile names are parsed case-insensitively")
+        public void parseConfig_projectilesAreCaseInsensitive() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("arrow"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(event.getEntity()).thenReturn(projectile);
+            when(projectile.getType()).thenReturn(EntityType.ARROW);
+            assertEquals(1, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(event)));
+        }
+    }
+
+    @Nested
+    @DisplayName("TameAnimalObjectiveType processProgress")
+    class TameAnimalProcessProgress {
+
+        private final TameAnimalObjectiveType type = new TameAnimalObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any tamed entity and returns 1")
+        public void processProgress_unconfigured_returnsOne() {
+            EntityTameEvent tameEvent = mock(EntityTameEvent.class);
+            LivingEntity entity = mock(LivingEntity.class);
+            when(tameEvent.getEntity()).thenReturn(entity);
+            when(entity.getType()).thenReturn(EntityType.WOLF);
+            TameAnimalQuestContext context = new TameAnimalQuestContext(tameEvent);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching entity returns 1")
+        public void processProgress_matchingEntity_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("WOLF", "CAT"));
+            TameAnimalObjectiveType configured = type.parseConfig(section);
+
+            EntityTameEvent tameEvent = mock(EntityTameEvent.class);
+            LivingEntity entity = mock(LivingEntity.class);
+            when(tameEvent.getEntity()).thenReturn(entity);
+            when(entity.getType()).thenReturn(EntityType.WOLF);
+            TameAnimalQuestContext context = new TameAnimalQuestContext(tameEvent);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching entity returns 0")
+        public void processProgress_nonMatchingEntity_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("WOLF"));
+            TameAnimalObjectiveType configured = type.parseConfig(section);
+
+            EntityTameEvent tameEvent = mock(EntityTameEvent.class);
+            LivingEntity entity = mock(LivingEntity.class);
+            when(tameEvent.getEntity()).thenReturn(entity);
+            when(entity.getType()).thenReturn(EntityType.CAT);
+            TameAnimalQuestContext context = new TameAnimalQuestContext(tameEvent);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("TameAnimalObjectiveType parseConfig")
+    class TameAnimalParseConfig {
+
+        private final TameAnimalObjectiveType type = new TameAnimalObjectiveType();
+
+        @Test
+        @DisplayName("section without entities key accepts any entity")
+        public void parseConfig_noEntitiesKey_acceptsAnyEntity() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            TameAnimalObjectiveType configured = type.parseConfig(section);
+
+            EntityTameEvent tameEvent = mock(EntityTameEvent.class);
+            LivingEntity entity = mock(LivingEntity.class);
+            when(tameEvent.getEntity()).thenReturn(entity);
+            when(entity.getType()).thenReturn(EntityType.PARROT);
+            assertEquals(1, configured.processProgress(mockInstance, new TameAnimalQuestContext(tameEvent)));
+        }
+
+        @Test
+        @DisplayName("section with entities key filters by entity type")
+        public void parseConfig_withEntities_filtersCorrectly() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("CAT", "PARROT"));
+            TameAnimalObjectiveType configured = type.parseConfig(section);
+
+            EntityTameEvent matchEvent = mock(EntityTameEvent.class);
+            LivingEntity matchEntity = mock(LivingEntity.class);
+            when(matchEvent.getEntity()).thenReturn(matchEntity);
+            when(matchEntity.getType()).thenReturn(EntityType.CAT);
+            assertEquals(1, configured.processProgress(mockInstance, new TameAnimalQuestContext(matchEvent)));
+
+            EntityTameEvent noMatchEvent = mock(EntityTameEvent.class);
+            LivingEntity noMatchEntity = mock(LivingEntity.class);
+            when(noMatchEvent.getEntity()).thenReturn(noMatchEntity);
+            when(noMatchEntity.getType()).thenReturn(EntityType.WOLF);
+            assertEquals(0, configured.processProgress(mockInstance, new TameAnimalQuestContext(noMatchEvent)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            TameAnimalObjectiveType configured = type.parseConfig(section);
+            assertEquals(TameAnimalObjectiveType.KEY, configured.getKey());
         }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
@@ -368,6 +368,30 @@ public class ObjectiveTypeProcessProgressTest extends McRPGBaseTest {
             ItemPickupQuestContext context = createContext(Material.IRON_INGOT, 1);
             assertEquals(1, type.processProgress(mockInstance, context));
         }
+
+        @Test
+        @DisplayName("configured with matching item returns stack amount")
+        public void processProgress_matchingItem_returnsAmount() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("DIAMOND", "EMERALD"));
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            ItemPickupQuestContext context = createContext(Material.DIAMOND, 4);
+            assertEquals(4, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching item returns 0")
+        public void processProgress_nonMatchingItem_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("DIAMOND"));
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            ItemPickupQuestContext context = createContext(Material.IRON_INGOT, 3);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

- Add new test class `QuestChainStepRetryEventTest` covering all getters, null player (offline) path, unlimited retries sentinel (-1), and handler list identity — previously at **0% coverage**
- Expand `ObjectiveTypeProcessProgressTest` with `processProgress` and `parseConfig` tests for **ItemPickupObjectiveType**, **LaunchProjectileObjectiveType**, and **TameAnimalObjectiveType** — all three previously only had `getKey`/`getExpansionKey`/`canProcess` tests (~17-18% coverage each)

## Test plan

- [x] All new tests pass locally via `./gradlew test`
- [x] Full test suite passes with zero failures
- [x] Tests follow existing conventions: `@DisplayName`, `@Nested` grouping, `McRPGBaseTest` base class, Mockito mocks for Bukkit events

## Classes covered

| Class | Before | Tests Added |
|-------|--------|-------------|
| `QuestChainStepRetryEvent` | 0% (no test file) | 5 tests: constructor fields, null player, unlimited retries, handler list |
| `ItemPickupObjectiveType` | ~17% (4 tests) | 6 tests: processProgress (wrong context, unconfigured any-item, single amount) + parseConfig (no key, with key filtering, key preservation) |
| `LaunchProjectileObjectiveType` | ~17% (4 tests) | 8 tests: processProgress (wrong context, unconfigured, matching, non-matching) + parseConfig (no key, with key, case insensitivity, key preservation) |
| `TameAnimalObjectiveType` | ~18% (4 tests) | 7 tests: processProgress (wrong context, unconfigured, matching, non-matching) + parseConfig (no key, with key, key preservation) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMq6AytyYwevnCfAaG8bCX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for quest-chain step retry events, including retry limits, nullable player data, and event-handler consistency.
  - Added comprehensive validation for item pickup, projectile launch, and animal taming objective progress.
  - Verified matching and non-matching configurations, incorrect event contexts, unconfigured objectives, case-insensitive settings, and preservation of relevant data.
  - Confirmed accurate progress values for successful and unsuccessful objective interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->