### PR TITLE
[Unit Tests] Add mining ability event and quest chain condition tests

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/event/ability/mining/ExtraOreActivateEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/mining/ExtraOreActivateEventTest.java
@@ -1,0 +1,135 @@
+package us.eunoians.mcrpg.event.ability.mining;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.impl.mining.ExtraOre;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExtraOreActivateEventTest extends McRPGBaseTest {
+
+    @BeforeEach
+    void setUp() {
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER)
+                .register(mock(ReloadableContentManager.class));
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        ExtraOre mockExtraOre = mock(ExtraOre.class);
+        when(mockExtraOre.getAbilityKey()).thenReturn(ExtraOre.EXTRA_ORE_KEY);
+        when(mockExtraOre.getSkillKey()).thenReturn(Mining.MINING_KEY);
+        when(mockExtraOre.getReloadableContent()).thenReturn(Set.of());
+        abilityRegistry.register(mockExtraOre);
+    }
+
+    @Test
+    @DisplayName("Negative drop multiplier clamped to 1 at construction")
+    void getDropMultiplier_returnsOne_whenConstructedWithNegativeValue() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, -3);
+        assertEquals(1, event.getDropMultiplier());
+    }
+
+    @Test
+    @DisplayName("Zero drop multiplier clamped to 1 at construction")
+    void getDropMultiplier_returnsOne_whenConstructedWithZeroValue() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 0);
+        assertEquals(1, event.getDropMultiplier());
+    }
+
+    @Test
+    @DisplayName("Positive drop multiplier preserved at construction")
+    void getDropMultiplier_returnsValue_whenConstructedWithPositiveValue() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 5);
+        assertEquals(5, event.getDropMultiplier());
+    }
+
+    @Test
+    @DisplayName("setDropMultiplier clamps negative to 1")
+    void setDropMultiplier_clampsToOne_whenGivenNegativeValue() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 3);
+        event.setDropMultiplier(-2);
+        assertEquals(1, event.getDropMultiplier());
+    }
+
+    @Test
+    @DisplayName("setDropMultiplier clamps zero to 1")
+    void setDropMultiplier_clampsToOne_whenGivenZeroValue() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 3);
+        event.setDropMultiplier(0);
+        assertEquals(1, event.getDropMultiplier());
+    }
+
+    @Test
+    @DisplayName("setDropMultiplier preserves positive value")
+    void setDropMultiplier_preservesValue_whenGivenPositiveValue() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+        event.setDropMultiplier(7);
+        assertEquals(7, event.getDropMultiplier());
+    }
+
+    @Test
+    @DisplayName("getAbility returns ExtraOre instance")
+    void getAbility_returnsExtraOreInstance() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+        assertInstanceOf(ExtraOre.class, event.getAbility());
+    }
+
+    @Test
+    @DisplayName("Event is not cancelled by default")
+    void isCancelled_returnsFalse_byDefault() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(true) makes event cancelled")
+    void setCancelled_makesEventCancelled() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(false) restores non-cancelled state")
+    void setCancelled_restoresNonCancelledState() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+        event.setCancelled(true);
+        event.setCancelled(false);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("getAbilityHolder returns the holder passed at construction")
+    void getAbilityHolder_returnsConstructorHolder() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ExtraOreActivateEvent event = new ExtraOreActivateEvent(holder, 2);
+        assertSame(holder, event.getAbilityHolder());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/ability/mining/ItsATripleActivateEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/mining/ItsATripleActivateEventTest.java
@@ -1,0 +1,69 @@
+package us.eunoians.mcrpg.event.ability.mining;
+
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.impl.mining.ItsATriple;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class ItsATripleActivateEventTest extends McRPGBaseTest {
+
+    @BeforeEach
+    void setUp() {
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+        abilityRegistry.register(new ItsATriple(mcRPG));
+    }
+
+    @Test
+    @DisplayName("getAbility returns ItsATriple instance")
+    void getAbility_returnsItsATripleInstance() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+        assertInstanceOf(ItsATriple.class, event.getAbility());
+    }
+
+    @Test
+    @DisplayName("Event is not cancelled by default")
+    void isCancelled_returnsFalse_byDefault() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(true) makes event cancelled")
+    void setCancelled_makesEventCancelled() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(false) restores non-cancelled state")
+    void setCancelled_restoresNonCancelledState() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+        event.setCancelled(true);
+        event.setCancelled(false);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("getAbilityHolder returns the holder passed at construction")
+    void getAbilityHolder_returnsConstructorHolder() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        ItsATripleActivateEvent event = new ItsATripleActivateEvent(holder);
+        assertSame(holder, event.getAbilityHolder());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/ability/mining/OreScannerActivateEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/mining/OreScannerActivateEventTest.java
@@ -1,0 +1,171 @@
+package us.eunoians.mcrpg.event.ability.mining;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.impl.mining.OreScanner;
+import us.eunoians.mcrpg.ability.impl.mining.orescanner.OreScannerBlockType;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("deprecation")
+class OreScannerActivateEventTest extends McRPGBaseTest {
+
+    @BeforeEach
+    void setUp() {
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER)
+                .register(mock(ReloadableContentManager.class));
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        OreScanner mockOreScanner = mock(OreScanner.class);
+        when(mockOreScanner.getAbilityKey()).thenReturn(OreScanner.ORE_SCANNER_KEY);
+        when(mockOreScanner.getSkillKey()).thenReturn(Mining.MINING_KEY);
+        when(mockOreScanner.getReloadableContent()).thenReturn(Set.of());
+        abilityRegistry.register(mockOreScanner);
+    }
+
+    @Test
+    @DisplayName("getInstancesOfBlocks returns defensive copy that is unaffected by original mutation")
+    void getInstancesOfBlocks_returnsDefensiveCopy() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        OreScannerBlockType blockType = new OreScannerBlockType(
+                Set.of(Material.DIAMOND_ORE), "Diamond", ChatColor.AQUA, 10);
+        Location loc = new Location(world, 1, 2, 3);
+        Map<OreScannerBlockType, Set<Location>> blocks = new HashMap<>();
+        blocks.put(blockType, Set.of(loc));
+
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, blocks);
+        Map<OreScannerBlockType, Set<Location>> returned = event.getInstancesOfBlocks();
+        assertEquals(1, returned.size());
+        assertTrue(returned.containsKey(blockType));
+
+        blocks.clear();
+        assertEquals(1, returned.size(), "Returned map should be unaffected by original map mutation");
+    }
+
+    @Test
+    @DisplayName("getInstancesOfBlocks returns empty map when constructed with empty map")
+    void getInstancesOfBlocks_returnsEmptyMap_whenConstructedEmpty() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        assertTrue(event.getInstancesOfBlocks().isEmpty());
+    }
+
+    @Test
+    @DisplayName("getLocationsOfBlockType returns locations for a known block type")
+    void getLocationsOfBlockType_returnsLocations_whenBlockTypePresent() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        OreScannerBlockType blockType = new OreScannerBlockType(
+                Set.of(Material.IRON_ORE), "Iron", ChatColor.WHITE, 5);
+        Location loc1 = new Location(world, 10, 20, 30);
+        Location loc2 = new Location(world, 40, 50, 60);
+        Map<OreScannerBlockType, Set<Location>> blocks = new HashMap<>();
+        blocks.put(blockType, Set.of(loc1, loc2));
+
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, blocks);
+        Set<Location> result = event.getLocationsOfBlockType(blockType);
+        assertEquals(2, result.size());
+        assertTrue(result.contains(loc1));
+        assertTrue(result.contains(loc2));
+    }
+
+    @Test
+    @DisplayName("getLocationsOfBlockType returns empty set for unknown block type")
+    void getLocationsOfBlockType_returnsEmptySet_whenBlockTypeNotPresent() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerBlockType unknownType = new OreScannerBlockType(
+                Set.of(Material.GOLD_ORE), "Gold", ChatColor.GOLD, 8);
+
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        Set<Location> result = event.getLocationsOfBlockType(unknownType);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getAbility returns OreScanner instance")
+    void getAbility_returnsOreScannerInstance() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        assertInstanceOf(OreScanner.class, event.getAbility());
+    }
+
+    @Test
+    @DisplayName("Event is not cancelled by default")
+    void isCancelled_returnsFalse_byDefault() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(true) makes event cancelled")
+    void setCancelled_makesEventCancelled() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(false) restores non-cancelled state")
+    void setCancelled_restoresNonCancelledState() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        event.setCancelled(true);
+        event.setCancelled(false);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("getAbilityHolder returns the holder passed at construction")
+    void getAbilityHolder_returnsConstructorHolder() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, Map.of());
+        assertSame(holder, event.getAbilityHolder());
+    }
+
+    @Test
+    @DisplayName("Multiple block types are all returned")
+    void getInstancesOfBlocks_returnsAllTypes_whenMultipleBlockTypesPresent() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        OreScannerBlockType diamondType = new OreScannerBlockType(
+                Set.of(Material.DIAMOND_ORE), "Diamond", ChatColor.AQUA, 10);
+        OreScannerBlockType ironType = new OreScannerBlockType(
+                Set.of(Material.IRON_ORE), "Iron", ChatColor.WHITE, 5);
+        Map<OreScannerBlockType, Set<Location>> blocks = new HashMap<>();
+        blocks.put(diamondType, Set.of(new Location(world, 1, 2, 3)));
+        blocks.put(ironType, Set.of(new Location(world, 4, 5, 6)));
+
+        OreScannerActivateEvent event = new OreScannerActivateEvent(holder, blocks);
+        Map<OreScannerBlockType, Set<Location>> returned = event.getInstancesOfBlocks();
+        assertEquals(2, returned.size());
+        assertTrue(returned.containsKey(diamondType));
+        assertTrue(returned.containsKey(ironType));
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/event/ability/mining/RemoteTransferActivateEventTest.java
+++ b/src/test/java/us/eunoians/mcrpg/event/ability/mining/RemoteTransferActivateEventTest.java
@@ -1,0 +1,136 @@
+package us.eunoians.mcrpg.event.ability.mining;
+
+import com.diamonddagger590.mccore.configuration.ReloadableContentManager;
+import com.diamonddagger590.mccore.registry.RegistryAccess;
+import com.diamonddagger590.mccore.registry.RegistryKey;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import dev.dejvokep.boostedyaml.route.Route;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.ability.AbilityRegistry;
+import us.eunoians.mcrpg.ability.impl.mining.RemoteTransfer;
+import us.eunoians.mcrpg.configuration.FileManager;
+import us.eunoians.mcrpg.configuration.FileType;
+import us.eunoians.mcrpg.entity.holder.AbilityHolder;
+import us.eunoians.mcrpg.registry.manager.McRPGManagerKey;
+import us.eunoians.mcrpg.skill.impl.mining.Mining;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteTransferActivateEventTest extends McRPGBaseTest {
+
+    @BeforeEach
+    void setUp() {
+        // Stub FileManager BEFORE any reference to RemoteTransfer triggers its static
+        // ReloadableRemoteTransferMap initializer, which calls getFile(MINING_CONFIG)
+        FileManager fileManager = RegistryAccess.registryAccess().registry(RegistryKey.MANAGER)
+                .manager(McRPGManagerKey.FILE);
+        YamlDocument mockDocument = mock(YamlDocument.class);
+        when(fileManager.getFile(FileType.MINING_CONFIG)).thenReturn(mockDocument);
+        Section mockSection = mock(Section.class);
+        when(mockDocument.getSection(any(Route.class))).thenReturn(mockSection);
+        when(mockSection.getRoutesAsStrings(false)).thenReturn(Set.of());
+
+        RegistryAccess.registryAccess().registry(RegistryKey.MANAGER)
+                .register(mock(ReloadableContentManager.class));
+
+        AbilityRegistry abilityRegistry = new AbilityRegistry(mcRPG);
+        RegistryAccess.registryAccess().register(abilityRegistry);
+
+        RemoteTransfer mockRemoteTransfer = mock(RemoteTransfer.class);
+        when(mockRemoteTransfer.getAbilityKey()).thenReturn(RemoteTransfer.REMOTE_TRANSFER_KEY);
+        when(mockRemoteTransfer.getSkillKey()).thenReturn(Mining.MINING_KEY);
+        when(mockRemoteTransfer.getReloadableContent()).thenReturn(Set.of());
+        abilityRegistry.register(mockRemoteTransfer);
+    }
+
+    @Test
+    @DisplayName("getRemoteTransferDestination returns the location passed at construction")
+    void getRemoteTransferDestination_returnsConstructorLocation() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 10, 64, -20);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        assertSame(destination, event.getRemoteTransferDestination());
+    }
+
+    @Test
+    @DisplayName("getRemoteTransferDestination preserves coordinates")
+    void getRemoteTransferDestination_preservesCoordinates() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 100.5, 200.0, -300.25);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        Location returned = event.getRemoteTransferDestination();
+        assertEquals(100.5, returned.getX());
+        assertEquals(200.0, returned.getY());
+        assertEquals(-300.25, returned.getZ());
+    }
+
+    @Test
+    @DisplayName("getAbility returns RemoteTransfer instance")
+    void getAbility_returnsRemoteTransferInstance() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 0, 0, 0);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        assertInstanceOf(RemoteTransfer.class, event.getAbility());
+    }
+
+    @Test
+    @DisplayName("Event is not cancelled by default")
+    void isCancelled_returnsFalse_byDefault() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 0, 0, 0);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(true) makes event cancelled")
+    void setCancelled_makesEventCancelled() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 0, 0, 0);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("setCancelled(false) restores non-cancelled state")
+    void setCancelled_restoresNonCancelledState() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 0, 0, 0);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        event.setCancelled(true);
+        event.setCancelled(false);
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    @DisplayName("getAbilityHolder returns the holder passed at construction")
+    void getAbilityHolder_returnsConstructorHolder() {
+        AbilityHolder holder = mock(AbilityHolder.class);
+        World world = mock(World.class);
+        Location destination = new Location(world, 0, 0, 0);
+        RemoteTransferActivateEvent event = new RemoteTransferActivateEvent(holder, destination);
+        assertSame(holder, event.getAbilityHolder());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateChainConditionTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateChainConditionTypeTest.java
@@ -1,0 +1,154 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainStartCondition;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TimeGateChainConditionTypeTest extends McRPGBaseTest {
+
+    private final TimeGateChainConditionType conditionType = new TimeGateChainConditionType();
+
+    @Nested
+    @DisplayName("getKey")
+    class GetKey {
+
+        @Test
+        @DisplayName("Returns the time_gate key")
+        void getKey_returnsTimeGateKey() {
+            assertEquals(TimeGateChainConditionType.KEY, conditionType.getKey());
+        }
+
+        @Test
+        @DisplayName("Key namespace is mcrpg")
+        void getKey_namespacedCorrectly() {
+            assertEquals("mcrpg", conditionType.getKey().getNamespace());
+            assertEquals("time_gate", conditionType.getKey().getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("getExpansionKey")
+    class GetExpansionKey {
+
+        @Test
+        @DisplayName("Returns empty — built-in type")
+        void getExpansionKey_returnsEmpty() {
+            Optional<org.bukkit.NamespacedKey> result = conditionType.getExpansionKey();
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("parse")
+    class Parse {
+
+        @Test
+        @DisplayName("Parses valid ISO-8601 after with default timezone")
+        void parse_validAfterNoTimezone_returnsConditionWithSystemDefault() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn(null);
+
+            QuestChainStartCondition result = conditionType.parse(section);
+            assertInstanceOf(TimeGateCondition.class, result);
+
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(LocalDateTime.of(2026, 7, 1, 0, 0, 0), condition.after());
+            assertEquals(ZoneId.systemDefault(), condition.timezone());
+            assertEquals(TimeGateChainConditionType.KEY, condition.key());
+        }
+
+        @Test
+        @DisplayName("Parses valid after with explicit timezone")
+        void parse_validAfterWithTimezone_returnsConditionWithSpecifiedZone() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-12-25T10:30:00");
+            when(section.getString("timezone")).thenReturn("America/New_York");
+
+            QuestChainStartCondition result = conditionType.parse(section);
+            assertInstanceOf(TimeGateCondition.class, result);
+
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(LocalDateTime.of(2026, 12, 25, 10, 30, 0), condition.after());
+            assertEquals(ZoneId.of("America/New_York"), condition.timezone());
+        }
+
+        @Test
+        @DisplayName("Throws when 'after' field is missing")
+        void parse_missingAfter_throwsIllegalArgument() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn(null);
+
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> conditionType.parse(section));
+            assertTrue(exception.getMessage().contains("'after'"));
+        }
+
+        @Test
+        @DisplayName("Throws when 'after' field is not valid ISO-8601")
+        void parse_invalidAfterFormat_throwsIllegalArgument() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("not-a-date");
+
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> conditionType.parse(section));
+            assertTrue(exception.getMessage().contains("not-a-date"));
+            assertTrue(exception.getMessage().contains("ISO-8601"));
+        }
+
+        @Test
+        @DisplayName("Throws when 'timezone' field is not a valid IANA zone")
+        void parse_invalidTimezone_throwsIllegalArgument() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn("Invalid/Zone");
+
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> conditionType.parse(section));
+            assertTrue(exception.getMessage().contains("Invalid/Zone"));
+            assertTrue(exception.getMessage().contains("IANA"));
+        }
+
+        @Test
+        @DisplayName("Parses date-time without seconds")
+        void parse_afterWithoutSeconds_parsesSuccessfully() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T14:30");
+            when(section.getString("timezone")).thenReturn(null);
+
+            QuestChainStartCondition result = conditionType.parse(section);
+            assertInstanceOf(TimeGateCondition.class, result);
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(LocalDateTime.of(2026, 7, 1, 14, 30, 0), condition.after());
+        }
+
+        @Test
+        @DisplayName("Parses with UTC timezone string")
+        void parse_utcTimezone_parsesSuccessfully() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-01-01T00:00:00");
+            when(section.getString("timezone")).thenReturn("UTC");
+
+            QuestChainStartCondition result = conditionType.parse(section);
+            TimeGateCondition condition = (TimeGateCondition) result;
+            assertEquals(ZoneId.of("UTC"), condition.timezone());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
@@ -1,0 +1,138 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class TimeGateConditionTest extends McRPGBaseTest {
+
+    @Nested
+    @DisplayName("evaluate")
+    class Evaluate {
+
+        @Test
+        @DisplayName("Returns true when current time is after the boundary")
+        void evaluate_returnsTrue_whenNowIsAfterBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            Instant nowAfter = ZonedDateTime.of(2026, 7, 2, 12, 0, 0, 0, zone).toInstant();
+            Player player = mock(Player.class);
+
+            assertTrue(condition.evaluate(player, nowAfter));
+        }
+
+        @Test
+        @DisplayName("Returns true when current time is exactly at the boundary")
+        void evaluate_returnsTrue_whenNowIsExactlyAtBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            Instant nowExact = ZonedDateTime.of(2026, 7, 1, 0, 0, 0, 0, zone).toInstant();
+            Player player = mock(Player.class);
+
+            assertTrue(condition.evaluate(player, nowExact));
+        }
+
+        @Test
+        @DisplayName("Returns false when current time is before the boundary")
+        void evaluate_returnsFalse_whenNowIsBeforeBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            Instant nowBefore = ZonedDateTime.of(2026, 6, 30, 23, 59, 59, 0, zone).toInstant();
+            Player player = mock(Player.class);
+
+            assertFalse(condition.evaluate(player, nowBefore));
+        }
+
+        @Test
+        @DisplayName("Respects timezone when evaluating — same instant, different local time")
+        void evaluate_respectsTimezone() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+            ZoneId newYork = ZoneId.of("America/New_York");
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, newYork);
+
+            Instant utcMidnight = ZonedDateTime.of(2026, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
+
+            assertFalse(condition.evaluate(mock(Player.class), utcMidnight));
+
+            Instant nyMidnight = ZonedDateTime.of(2026, 7, 1, 0, 0, 0, 0, newYork).toInstant();
+            assertTrue(condition.evaluate(mock(Player.class), nyMidnight));
+        }
+
+        @Test
+        @DisplayName("Far-future instant passes a near-term boundary")
+        void evaluate_returnsTrue_whenFarFutureInstant() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 1, 1, 0, 0, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            Instant farFuture = ZonedDateTime.of(2030, 12, 31, 23, 59, 59, 0, zone).toInstant();
+            assertTrue(condition.evaluate(mock(Player.class), farFuture));
+        }
+
+        @Test
+        @DisplayName("Far-past instant fails a near-term boundary")
+        void evaluate_returnsFalse_whenFarPastInstant() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 1, 1, 0, 0, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            Instant farPast = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, zone).toInstant();
+            assertFalse(condition.evaluate(mock(Player.class), farPast));
+        }
+    }
+
+    @Nested
+    @DisplayName("record accessors")
+    class RecordAccessors {
+
+        @Test
+        @DisplayName("getKey returns the condition type key")
+        void getKey_returnsConditionTypeKey() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            assertEquals(TimeGateChainConditionType.KEY, condition.getKey());
+        }
+
+        @Test
+        @DisplayName("after returns the configured boundary")
+        void after_returnsConfiguredBoundary() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 8, 15, 14, 30, 0);
+            ZoneId zone = ZoneOffset.UTC;
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            assertEquals(boundary, condition.after());
+        }
+
+        @Test
+        @DisplayName("timezone returns the configured zone")
+        void timezone_returnsConfiguredZone() {
+            LocalDateTime boundary = LocalDateTime.of(2026, 1, 1, 0, 0, 0);
+            ZoneId zone = ZoneId.of("Europe/London");
+            TimeGateCondition condition = new TimeGateCondition(TimeGateChainConditionType.KEY, boundary, zone);
+
+            assertSame(zone, condition.timezone());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for 4 mining ability activation events: `ExtraOreActivateEvent`, `ItsATripleActivateEvent`, `OreScannerActivateEvent`, `RemoteTransferActivateEvent`
- Add unit tests for 2 quest chain condition types: `TimeGateCondition`, `TimeGateChainConditionType`
- Total of 6 new test classes covering getters, cancellation state, ability holder returns, defensive copy verification, drop multiplier clamping, time-based condition evaluation, and YAML section parsing

## Details

**Mining event tests** verify:
- Event DTO getters return constructor values
- `Cancellable` contract (default false, set true/false toggles)
- `getAbilityHolder()` identity
- `getAbility()` returns correct ability type
- `ExtraOreActivateEvent`: drop multiplier clamping (negative/zero → 1, positive preserved) for both constructor and setter
- `OreScannerActivateEvent`: defensive copy semantics (mutating original map doesn't affect returned map), multi-block-type support, empty set for unknown block types
- `RemoteTransferActivateEvent`: coordinate preservation

**Quest chain condition tests** verify:
- `TimeGateCondition.evaluate()`: before/after/exact boundary, timezone respect, far-future/far-past instants
- `TimeGateChainConditionType.parse()`: valid ISO-8601 with/without timezone, missing `after` field, invalid date format, invalid IANA timezone, date-time without seconds, UTC timezone

**Testing challenges solved:**
- `ExtraOre`, `OreScanner`, `RemoteTransfer` abilities have complex constructors requiring file manager and config access — solved by mocking abilities and registering a mock `ReloadableContentManager`
- `RemoteTransfer` has a `private static final ReloadableRemoteTransferMap` that triggers on class load — solved by stubbing the `FileManager` mock to return a mock `YamlDocument` with an empty `Section` before any `RemoteTransfer` class reference

## Test plan

- [x] All 6 new test classes pass
- [x] Full test suite passes (`./gradlew verifiedShadowJar`)
- [x] Testing audit persona reviewed — fixed defensive copy test to verify mutation isolation

---
_Generated by [Claude Code](https://claude.ai/code/session_01Feu9UCoJyCwFXgJozkz1wc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for mining ability activation events, including state changes, accessors, cancellation, destinations, and block handling.
  * Added validation for time-based quest conditions, including timezone-aware parsing, boundary comparisons, invalid configurations, and record properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->