### PR TITLE
[Unit Tests] Expand scope DAO and QuestChainPlayerData coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/PermissionQuestScopeDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/PermissionQuestScopeDAOTest.java
@@ -1,18 +1,25 @@
 package us.eunoians.mcrpg.database.table.quest.scope;
 
+import com.diamonddagger590.mccore.database.Database;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.impl.scope.impl.PermissionQuestScope;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -20,31 +27,232 @@ import static org.mockito.Mockito.when;
 
 public class PermissionQuestScopeDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given a valid permission scope, when saving, then prepared statements are returned")
-    @Test
-    public void saveScope_validScope_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("saveScope")
+    class SaveScope {
 
-        UUID questUUID = UUID.randomUUID();
-        PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.some.permission");
+        @DisplayName("Given a valid permission scope, when saving, then prepared statements are returned")
+        @Test
+        void saveScope_returnsPreparedStatements_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
 
-        List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(conn, scope);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.some.permission");
+
+            List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(conn, scope);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+        }
+
+        @DisplayName("Given a valid permission scope, when saving, then connection is used to prepare a statement")
+        @Test
+        void saveScope_usesConnection_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.some.permission");
+
+            PermissionQuestScopeDAO.saveScope(conn, scope);
+            verify(conn).prepareStatement(anyString());
+        }
+
+        @DisplayName("Given a valid scope, when saving, then quest UUID and permission node are bound to the statement")
+        @Test
+        void saveScope_bindsParameters_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID questUUID = UUID.randomUUID();
+            String permissionNode = "mcrpg.quest.vip";
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, permissionNode);
+
+            PermissionQuestScopeDAO.saveScope(conn, scope);
+
+            verify(mockPs).setString(1, questUUID.toString());
+            verify(mockPs).setString(2, permissionNode);
+        }
+
+        @DisplayName("Given a SQL exception on prepareStatement, when saving, then an empty list is returned")
+        @Test
+        void saveScope_returnsEmptyList_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.quest.test");
+
+            List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(conn, scope);
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given a valid scope, when saving, then exactly one prepared statement is returned")
+        @Test
+        void saveScope_returnsExactlyOneStatement_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.quest.test");
+
+            List<PreparedStatement> result = PermissionQuestScopeDAO.saveScope(conn, scope);
+            assertEquals(1, result.size());
+        }
     }
 
-    @DisplayName("Given a valid permission scope, when saving, then connection is used")
-    @Test
-    public void saveScope_usesConnection() throws SQLException {
-        Connection conn = mock(Connection.class);
-        PreparedStatement mockPs = mock(PreparedStatement.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+    @Nested
+    @DisplayName("getPermissionNode")
+    class GetPermissionNode {
 
-        UUID questUUID = UUID.randomUUID();
-        PermissionQuestScope scope = new PermissionQuestScope(questUUID, "mcrpg.some.permission");
+        @DisplayName("Given a matching row in the database, when getting permission node, then the node is returned")
+        @Test
+        void getPermissionNode_returnsNode_whenRowExists() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true);
+            when(rs.getString("permission_node")).thenReturn("mcrpg.quest.elite");
 
-        PermissionQuestScopeDAO.saveScope(conn, scope);
-        verify(conn).prepareStatement(anyString());
+            UUID questUUID = UUID.randomUUID();
+            String result = PermissionQuestScopeDAO.getPermissionNode(conn, questUUID);
+
+            assertEquals("mcrpg.quest.elite", result);
+        }
+
+        @DisplayName("Given a matching row, when getting permission node, then the quest UUID is bound to the query")
+        @Test
+        void getPermissionNode_bindsQuestUUID_whenQuerying() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true);
+            when(rs.getString("permission_node")).thenReturn("mcrpg.quest.test");
+
+            UUID questUUID = UUID.randomUUID();
+            PermissionQuestScopeDAO.getPermissionNode(conn, questUUID);
+
+            verify(ps).setString(1, questUUID.toString());
+        }
+
+        @DisplayName("Given no matching row, when getting permission node, then IllegalStateException is thrown")
+        @Test
+        void getPermissionNode_throwsIllegalState_whenNoRowExists() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+
+            UUID questUUID = UUID.randomUUID();
+
+            assertThrows(IllegalStateException.class,
+                    () -> PermissionQuestScopeDAO.getPermissionNode(conn, questUUID));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllActivePermissionQuests")
+    class FindAllActivePermissionQuests {
+
+        @DisplayName("Given active permission quests, when finding all, then a map of UUID to permission node is returned")
+        @Test
+        void findAllActivePermissionQuests_returnsMap_whenRowsExist() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+
+            UUID questUUID1 = UUID.randomUUID();
+            UUID questUUID2 = UUID.randomUUID();
+            when(rs.next()).thenReturn(true, true, false);
+            when(rs.getString("quest_uuid")).thenReturn(questUUID1.toString(), questUUID2.toString());
+            when(rs.getString("permission_node")).thenReturn("mcrpg.quest.vip", "mcrpg.quest.admin");
+
+            Map<UUID, String> result = PermissionQuestScopeDAO.findAllActivePermissionQuests(conn);
+
+            assertEquals(2, result.size());
+            assertEquals("mcrpg.quest.vip", result.get(questUUID1));
+            assertEquals("mcrpg.quest.admin", result.get(questUUID2));
+        }
+
+        @DisplayName("Given no active permission quests, when finding all, then an empty map is returned")
+        @Test
+        void findAllActivePermissionQuests_returnsEmptyMap_whenNoRowsExist() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+
+            Map<UUID, String> result = PermissionQuestScopeDAO.findAllActivePermissionQuests(conn);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given a SQL exception, when finding all active quests, then an empty map is returned")
+        @Test
+        void findAllActivePermissionQuests_returnsEmptyMap_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            Map<UUID, String> result = PermissionQuestScopeDAO.findAllActivePermissionQuests(conn);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @DisplayName("Given the table already exists, when attempting to create, then false is returned")
+        @Test
+        void attemptCreateTable_returnsFalse_whenTableAlreadyExists() {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, "mcrpg_permission_quest_scope")).thenReturn(true);
+
+            boolean result = PermissionQuestScopeDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Given the table does not exist, when attempting to create, then a CREATE TABLE statement is executed")
+        @Test
+        void attemptCreateTable_executesCreateStatement_whenTableDoesNotExist() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            when(database.tableExists(conn, "mcrpg_permission_quest_scope")).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+
+            boolean result = PermissionQuestScopeDAO.attemptCreateTable(conn, database);
+
+            assertTrue(result);
+            verify(ps).executeUpdate();
+        }
+
+        @DisplayName("Given a SQL exception during creation, when attempting to create, then false is returned")
+        @Test
+        void attemptCreateTable_returnsFalse_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, "mcrpg_permission_quest_scope")).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            boolean result = PermissionQuestScopeDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/SinglePlayerQuestScopeDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/quest/scope/SinglePlayerQuestScopeDAOTest.java
@@ -1,6 +1,8 @@
 package us.eunoians.mcrpg.database.table.quest.scope;
 
+import com.diamonddagger590.mccore.database.Database;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.exception.quest.QuestScopeInvalidStateException;
@@ -8,53 +10,336 @@ import us.eunoians.mcrpg.quest.impl.scope.impl.SinglePlayerQuestScope;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SinglePlayerQuestScopeDAOTest extends McRPGBaseTest {
 
-    @DisplayName("Given a valid single player scope, when saving, then prepared statements are returned")
-    @Test
-    public void saveScope_validScope_returnsPreparedStatements() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("saveScope")
+    class SaveScope {
 
-        SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
-        scope.setPlayerInScope(UUID.randomUUID());
+        @DisplayName("Given a valid single player scope, when saving, then prepared statements are returned")
+        @Test
+        void saveScope_returnsPreparedStatements_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
 
-        List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(conn, scope);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+            scope.setPlayerInScope(UUID.randomUUID());
+
+            List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(conn, scope);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+        }
+
+        @DisplayName("Given an invalid scope without player, when saving, then QuestScopeInvalidStateException is thrown")
+        @Test
+        void saveScope_throwsException_whenScopeIsInvalid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+
+            assertThrows(QuestScopeInvalidStateException.class,
+                    () -> SinglePlayerQuestScopeDAO.saveScope(conn, scope));
+        }
+
+        @DisplayName("Given a valid scope, when saving, then connection is used to prepare a statement")
+        @Test
+        void saveScope_usesConnection_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+            scope.setPlayerInScope(UUID.randomUUID());
+
+            SinglePlayerQuestScopeDAO.saveScope(conn, scope);
+            verify(conn).prepareStatement(anyString());
+        }
+
+        @DisplayName("Given a valid scope, when saving, then quest UUID and player UUID are bound to the statement")
+        @Test
+        void saveScope_bindsParameters_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement mockPs = mock(PreparedStatement.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+
+            UUID questUUID = UUID.randomUUID();
+            UUID playerUUID = UUID.randomUUID();
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(questUUID);
+            scope.setPlayerInScope(playerUUID);
+
+            SinglePlayerQuestScopeDAO.saveScope(conn, scope);
+
+            verify(mockPs).setString(1, questUUID.toString());
+            verify(mockPs).setString(2, playerUUID.toString());
+        }
+
+        @DisplayName("Given a valid scope, when saving, then exactly one prepared statement is returned")
+        @Test
+        void saveScope_returnsExactlyOneStatement_whenScopeIsValid() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+            scope.setPlayerInScope(UUID.randomUUID());
+
+            List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(conn, scope);
+            assertEquals(1, result.size());
+        }
+
+        @DisplayName("Given a SQL exception on prepareStatement, when saving a valid scope, then an empty list is returned")
+        @Test
+        void saveScope_returnsEmptyList_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+            scope.setPlayerInScope(UUID.randomUUID());
+
+            List<PreparedStatement> result = SinglePlayerQuestScopeDAO.saveScope(conn, scope);
+            assertTrue(result.isEmpty());
+        }
     }
 
-    @DisplayName("Given an invalid scope without player, when saving, then exception is thrown")
-    @Test
-    public void saveScope_invalidScope_throwsException() throws SQLException {
-        Connection conn = mock(Connection.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mock(PreparedStatement.class));
+    @Nested
+    @DisplayName("findPlayerUuidForQuest")
+    class FindPlayerUuidForQuest {
 
-        SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
+        @DisplayName("Given a matching row in the database, when finding player UUID, then the UUID is returned")
+        @Test
+        void findPlayerUuidForQuest_returnsUuid_whenRowExists() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true);
 
-        assertThrows(QuestScopeInvalidStateException.class,
-                () -> SinglePlayerQuestScopeDAO.saveScope(conn, scope));
+            UUID playerUUID = UUID.randomUUID();
+            when(rs.getString("player_uuid")).thenReturn(playerUUID.toString());
+
+            UUID questUUID = UUID.randomUUID();
+            Optional<UUID> result = SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(conn, questUUID);
+
+            assertTrue(result.isPresent());
+            assertEquals(playerUUID, result.orElseThrow());
+        }
+
+        @DisplayName("Given no matching row, when finding player UUID, then empty Optional is returned")
+        @Test
+        void findPlayerUuidForQuest_returnsEmpty_whenNoRowExists() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+
+            UUID questUUID = UUID.randomUUID();
+            Optional<UUID> result = SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(conn, questUUID);
+
+            assertFalse(result.isPresent());
+        }
+
+        @DisplayName("Given a matching row, when finding player UUID, then quest UUID is bound to the query")
+        @Test
+        void findPlayerUuidForQuest_bindsQuestUuid_whenQuerying() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true);
+            when(rs.getString("player_uuid")).thenReturn(UUID.randomUUID().toString());
+
+            UUID questUUID = UUID.randomUUID();
+            SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(conn, questUUID);
+
+            verify(ps).setString(1, questUUID.toString());
+        }
+
+        @DisplayName("Given a SQL exception, when finding player UUID, then RuntimeException is thrown")
+        @Test
+        void findPlayerUuidForQuest_throwsRuntimeException_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            UUID questUUID = UUID.randomUUID();
+
+            assertThrows(RuntimeException.class,
+                    () -> SinglePlayerQuestScopeDAO.findPlayerUuidForQuest(conn, questUUID));
+        }
     }
 
-    @DisplayName("Given a valid single player scope, when saving, then connection is used")
-    @Test
-    public void saveScope_usesConnection() throws SQLException {
-        Connection conn = mock(Connection.class);
-        PreparedStatement mockPs = mock(PreparedStatement.class);
-        when(conn.prepareStatement(anyString())).thenReturn(mockPs);
+    @Nested
+    @DisplayName("getPlayerInScope")
+    class GetPlayerInScope {
 
-        SinglePlayerQuestScope scope = new SinglePlayerQuestScope(UUID.randomUUID());
-        scope.setPlayerInScope(UUID.randomUUID());
+        @DisplayName("Given a matching row, when getting player in scope, then the UUID is returned")
+        @Test
+        void getPlayerInScope_returnsUuid_whenRowExists() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true);
 
-        SinglePlayerQuestScopeDAO.saveScope(conn, scope);
-        verify(conn).prepareStatement(anyString());
+            UUID playerUUID = UUID.randomUUID();
+            when(rs.getString("player_uuid")).thenReturn(playerUUID.toString());
+
+            UUID questUUID = UUID.randomUUID();
+            UUID result = SinglePlayerQuestScopeDAO.getPlayerInScope(conn, questUUID);
+
+            assertEquals(playerUUID, result);
+        }
+
+        @DisplayName("Given no matching row, when getting player in scope, then IllegalStateException is thrown")
+        @Test
+        void getPlayerInScope_throwsIllegalState_whenNoRowExists() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+
+            UUID questUUID = UUID.randomUUID();
+
+            assertThrows(IllegalStateException.class,
+                    () -> SinglePlayerQuestScopeDAO.getPlayerInScope(conn, questUUID));
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveQuestsForPlayer")
+    class FindActiveQuestsForPlayer {
+
+        @DisplayName("Given active quests for a player, when finding all, then a list of quest UUIDs is returned")
+        @Test
+        void findActiveQuestsForPlayer_returnsList_whenRowsExist() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+
+            UUID questUUID1 = UUID.randomUUID();
+            UUID questUUID2 = UUID.randomUUID();
+            when(rs.next()).thenReturn(true, true, false);
+            when(rs.getString("quest_uuid")).thenReturn(questUUID1.toString(), questUUID2.toString());
+
+            UUID playerUUID = UUID.randomUUID();
+            List<UUID> result = SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(conn, playerUUID);
+
+            assertEquals(2, result.size());
+            assertEquals(questUUID1, result.get(0));
+            assertEquals(questUUID2, result.get(1));
+        }
+
+        @DisplayName("Given no active quests for a player, when finding all, then an empty list is returned")
+        @Test
+        void findActiveQuestsForPlayer_returnsEmptyList_whenNoRowsExist() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+
+            UUID playerUUID = UUID.randomUUID();
+            List<UUID> result = SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(conn, playerUUID);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @DisplayName("Given active quests, when finding all, then player UUID is bound to the query")
+        @Test
+        void findActiveQuestsForPlayer_bindsPlayerUuid_whenQuerying() throws SQLException {
+            Connection conn = mock(Connection.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+            when(ps.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+
+            UUID playerUUID = UUID.randomUUID();
+            SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(conn, playerUUID);
+
+            verify(ps).setString(1, playerUUID.toString());
+        }
+
+        @DisplayName("Given a SQL exception, when finding active quests, then an empty list is returned")
+        @Test
+        void findActiveQuestsForPlayer_returnsEmptyList_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            UUID playerUUID = UUID.randomUUID();
+            List<UUID> result = SinglePlayerQuestScopeDAO.findActiveQuestsForPlayer(conn, playerUUID);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("attemptCreateTable")
+    class AttemptCreateTable {
+
+        @DisplayName("Given the table already exists, when attempting to create, then false is returned")
+        @Test
+        void attemptCreateTable_returnsFalse_whenTableAlreadyExists() {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, "mcrpg_single_player_quest_scope")).thenReturn(true);
+
+            boolean result = SinglePlayerQuestScopeDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Given the table does not exist, when attempting to create, then a CREATE TABLE statement is executed")
+        @Test
+        void attemptCreateTable_executesCreateStatement_whenTableDoesNotExist() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            PreparedStatement ps = mock(PreparedStatement.class);
+            when(database.tableExists(conn, "mcrpg_single_player_quest_scope")).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenReturn(ps);
+
+            boolean result = SinglePlayerQuestScopeDAO.attemptCreateTable(conn, database);
+
+            assertTrue(result);
+            verify(ps).executeUpdate();
+        }
+
+        @DisplayName("Given a SQL exception during creation, when attempting to create, then false is returned")
+        @Test
+        void attemptCreateTable_returnsFalse_whenSqlExceptionOccurs() throws SQLException {
+            Connection conn = mock(Connection.class);
+            Database database = mock(Database.class);
+            when(database.tableExists(conn, "mcrpg_single_player_quest_scope")).thenReturn(false);
+            when(conn.prepareStatement(anyString())).thenThrow(new SQLException("test error"));
+
+            boolean result = SinglePlayerQuestScopeDAO.attemptCreateTable(conn, database);
+
+            assertFalse(result);
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/QuestChainPlayerDataTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/QuestChainPlayerDataTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
 import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,7 +38,7 @@ public class QuestChainPlayerDataTest extends McRPGBaseTest {
         data.putChainState(state);
 
         assertTrue(data.getChainState(chainKeyA).isPresent());
-        assertEquals(state, data.getChainState(chainKeyA).get());
+        assertEquals(state, data.getChainState(chainKeyA).orElseThrow());
     }
 
     @Test
@@ -91,7 +93,7 @@ public class QuestChainPlayerDataTest extends McRPGBaseTest {
         data.putChainState(QuestChainPlayerState.newActive(chainKeyA, questKeyA));
 
         assertTrue(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
-        assertEquals(chainKeyA, data.getChainKeyForCurrentQuest(questKeyA).get());
+        assertEquals(chainKeyA, data.getChainKeyForCurrentQuest(questKeyA).orElseThrow());
     }
 
     @Test
@@ -136,5 +138,119 @@ public class QuestChainPlayerDataTest extends McRPGBaseTest {
 
         assertFalse(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
         assertEquals(chainKeyA, data.getChainKeyForCurrentQuest(questKeyB).orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Given multiple states, When putChainStateBatch is called, Then all states are retrievable")
+    public void putChainStateBatch_addsAllStates() {
+        var stateA = QuestChainPlayerState.newActive(chainKeyA, questKeyA);
+        var stateB = QuestChainPlayerState.newActive(chainKeyB, questKeyB);
+
+        data.putChainStateBatch(List.of(stateA, stateB));
+
+        assertTrue(data.getChainState(chainKeyA).isPresent());
+        assertTrue(data.getChainState(chainKeyB).isPresent());
+    }
+
+    @Test
+    @DisplayName("Given active states in batch, When putChainStateBatch is called, Then quest key index is rebuilt")
+    public void putChainStateBatch_rebuildsQuestKeyIndex() {
+        var stateA = QuestChainPlayerState.newActive(chainKeyA, questKeyA);
+        var stateB = QuestChainPlayerState.newActive(chainKeyB, questKeyB);
+
+        data.putChainStateBatch(List.of(stateA, stateB));
+
+        assertEquals(chainKeyA, data.getChainKeyForCurrentQuest(questKeyA).orElseThrow());
+        assertEquals(chainKeyB, data.getChainKeyForCurrentQuest(questKeyB).orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Given an empty list, When putChainStateBatch is called, Then no states are added")
+    public void putChainStateBatch_addsNothing_whenListIsEmpty() {
+        data.putChainStateBatch(List.of());
+
+        assertTrue(data.getAllStates().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Given populated data, When getAllStates is called, Then all states are returned")
+    public void getAllStates_returnsAllStates() {
+        var stateA = QuestChainPlayerState.newActive(chainKeyA, questKeyA);
+        var completed = QuestChainPlayerState.newActive(chainKeyB, questKeyB);
+        completed.complete(Instant.ofEpochMilli(1000L));
+
+        data.putChainState(stateA);
+        data.putChainState(completed);
+
+        Collection<QuestChainPlayerState> allStates = data.getAllStates();
+        assertEquals(2, allStates.size());
+    }
+
+    @Test
+    @DisplayName("Given empty data, When getAllStates is called, Then an empty collection is returned")
+    public void getAllStates_returnsEmptyCollection_whenNoStates() {
+        assertTrue(data.getAllStates().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Given an active state, When updateQuestKeyIndex is called directly, Then the index is updated")
+    public void updateQuestKeyIndex_updatesIndex_forActiveState() {
+        var state = QuestChainPlayerState.newActive(chainKeyA, questKeyA);
+        data.putChainState(state);
+
+        state.advance(questKeyB);
+        data.updateQuestKeyIndex(state);
+
+        assertFalse(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
+        assertEquals(chainKeyA, data.getChainKeyForCurrentQuest(questKeyB).orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Given a completed state, When updateQuestKeyIndex is called, Then the quest key is removed from the index")
+    public void updateQuestKeyIndex_removesFromIndex_forTerminalState() {
+        var state = QuestChainPlayerState.newActive(chainKeyA, questKeyA);
+        data.putChainState(state);
+        assertTrue(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
+
+        state.complete(Instant.ofEpochMilli(1000L));
+        data.updateQuestKeyIndex(state);
+
+        assertFalse(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
+    }
+
+    @Test
+    @DisplayName("Given an existing state, When putChainState overwrites with new state, Then old state is replaced")
+    public void putChainState_overwritesExistingState() {
+        var oldState = QuestChainPlayerState.newActive(chainKeyA, questKeyA);
+        data.putChainState(oldState);
+
+        var newState = QuestChainPlayerState.newActive(chainKeyA, questKeyB);
+        data.putChainState(newState);
+
+        assertEquals(newState, data.getChainState(chainKeyA).orElseThrow());
+        assertEquals(questKeyB, data.getChainState(chainKeyA).orElseThrow().getCurrentQuestKey().orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Given an overwritten state, When putChainState replaces, Then quest key index reflects new quest key")
+    public void putChainState_updatesIndex_whenOverwriting() {
+        data.putChainState(QuestChainPlayerState.newActive(chainKeyA, questKeyA));
+        assertTrue(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
+
+        data.putChainState(QuestChainPlayerState.newActive(chainKeyA, questKeyB));
+
+        assertFalse(data.getChainKeyForCurrentQuest(questKeyA).isPresent());
+        assertEquals(chainKeyA, data.getChainKeyForCurrentQuest(questKeyB).orElseThrow());
+    }
+
+    @Test
+    @DisplayName("Given a non-existent chain key, When removeChainState is called, Then nothing changes")
+    public void removeChainState_doesNothing_whenKeyNotFound() {
+        data.putChainState(QuestChainPlayerState.newActive(chainKeyA, questKeyA));
+
+        data.removeChainState(chainKeyB);
+
+        assertTrue(data.getChainState(chainKeyA).isPresent());
+        assertEquals(1, data.getAllStates().size());
     }
 }


### PR DESCRIPTION
## Summary

- **PermissionQuestScopeDAOTest**: Expanded from 2 → 14 tests across 4 `@Nested` groups (`SaveScope`, `GetPermissionNode`, `FindAllActivePermissionQuests`, `AttemptCreateTable`). Adds parameter binding verification, SQL exception error paths, and return value assertions.
- **SinglePlayerQuestScopeDAOTest**: Expanded from 3 → 19 tests across 5 `@Nested` groups (`SaveScope`, `FindPlayerUuidForQuest`, `GetPlayerInScope`, `FindActiveQuestsForPlayer`, `AttemptCreateTable`). Covers the `RuntimeException` propagation path in `findPlayerUuidForQuest`, `IllegalStateException` in `getPlayerInScope`, and SQL exception handling in `findActiveQuestsForPlayer`.
- **QuestChainPlayerDataTest**: Expanded from 10 → 20 tests. Adds coverage for `putChainStateBatch` (bulk insert + index rebuild), `getAllStates`, direct `updateQuestKeyIndex` calls, state overwrite behavior, and `removeChainState` no-op when key is absent.

Total: 15 existing tests → 53 tests (+38 net new).

## Test plan

- [x] All 53 tests pass locally via `./gradlew test`
- [x] Full test suite passes (no regressions)
- [x] Tests follow CLAUDE.md conventions: `McRPGBaseTest`, `@Nested`/`@DisplayName` grouping, `action_outcome_whenCondition` naming, JDBC mock pattern for DAOs

---
_Generated by [Claude Code](https://claude.ai/code/session_019A2euQNPDdoEyZRhg3bX8k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for permission-based and single-player quest scope database operations.
  * Added validation for saving, retrieving, updating, and removing quest states, including empty, missing, and error scenarios.
  * Added coverage for batch state insertion, collection retrieval, index maintenance, state replacement, and terminal states.
  * Improved test organization and assertion clarity across quest data and database components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->