### PR TITLE
[Unit Tests] Add tests for window boundary types, time gate condition, and objective type processProgress

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/FixedWindowBoundaryTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/FixedWindowBoundaryTypeTest.java
@@ -1,0 +1,130 @@
+package us.eunoians.mcrpg.quest.chain.availability.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.availability.WindowBoundary;
+
+import java.io.File;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("FixedWindowBoundaryType")
+public class FixedWindowBoundaryTypeTest extends McRPGBaseTest {
+
+    private FixedWindowBoundaryType type;
+    private File mockFile;
+    private Logger mockLogger;
+
+    @BeforeEach
+    public void setup() {
+        type = new FixedWindowBoundaryType();
+        mockFile = mock(File.class);
+        when(mockFile.getName()).thenReturn("test-chain.yml");
+        mockLogger = mock(Logger.class);
+    }
+
+    @Nested
+    @DisplayName("getKey")
+    class GetKey {
+
+        @Test
+        @DisplayName("returns the fixed boundary key")
+        public void getKey_returnsFixedKey() {
+            assertEquals(FixedWindowBoundaryType.KEY, type.getKey());
+            assertEquals("mcrpg", type.getKey().getNamespace());
+            assertEquals("fixed", type.getKey().getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("getExpansionKey")
+    class GetExpansionKey {
+
+        @Test
+        @DisplayName("returns empty for built-in type")
+        public void getExpansionKey_returnsEmpty() {
+            assertTrue(type.getExpansionKey().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("parse")
+    class Parse {
+
+        @Test
+        @DisplayName("valid ISO-8601 date returns Fixed boundary")
+        public void parse_validDate_returnsFixedBoundary() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("2026-06-01T00:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Fixed fixed = assertInstanceOf(WindowBoundary.Fixed.class, result.get());
+            assertEquals(LocalDateTime.of(2026, 6, 1, 0, 0, 0), fixed.dateTime());
+        }
+
+        @Test
+        @DisplayName("date with time component parses correctly")
+        public void parse_dateWithTime_parsesCorrectly() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("2025-12-25T14:30:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Fixed fixed = assertInstanceOf(WindowBoundary.Fixed.class, result.get());
+            assertEquals(LocalDateTime.of(2025, 12, 25, 14, 30, 0), fixed.dateTime());
+        }
+
+        @Test
+        @DisplayName("null date field returns empty and logs warning")
+        public void parse_nullDate_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn(null);
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning("[AvailabilityConfig] Fixed boundary in test-chain.yml is missing 'date' field — skipping window");
+        }
+
+        @Test
+        @DisplayName("invalid date format returns empty and logs warning")
+        public void parse_invalidDateFormat_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("not-a-date");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning("[AvailabilityConfig] Invalid date 'not-a-date' in test-chain.yml — expected ISO-8601 format (e.g., 2026-06-01T00:00:00)");
+        }
+
+        @Test
+        @DisplayName("date without explicit time component parses as midnight")
+        public void parse_dateWithoutTime_parsesAsMidnight() {
+            Section section = mock(Section.class);
+            when(section.getString("date")).thenReturn("2026-06-01T00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Fixed fixed = assertInstanceOf(WindowBoundary.Fixed.class, result.get());
+            assertEquals(LocalDateTime.of(2026, 6, 1, 0, 0, 0), fixed.dateTime());
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/RecurringWindowBoundaryTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/availability/builtin/RecurringWindowBoundaryTypeTest.java
@@ -1,0 +1,163 @@
+package us.eunoians.mcrpg.quest.chain.availability.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.availability.WindowBoundary;
+
+import java.io.File;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("RecurringWindowBoundaryType")
+public class RecurringWindowBoundaryTypeTest extends McRPGBaseTest {
+
+    private RecurringWindowBoundaryType type;
+    private File mockFile;
+    private Logger mockLogger;
+
+    @BeforeEach
+    public void setup() {
+        type = new RecurringWindowBoundaryType();
+        mockFile = mock(File.class);
+        when(mockFile.getName()).thenReturn("test-chain.yml");
+        mockLogger = mock(Logger.class);
+    }
+
+    @Nested
+    @DisplayName("getKey")
+    class GetKey {
+
+        @Test
+        @DisplayName("returns the recurring boundary key")
+        public void getKey_returnsRecurringKey() {
+            assertEquals(RecurringWindowBoundaryType.KEY, type.getKey());
+            assertEquals("mcrpg", type.getKey().getNamespace());
+            assertEquals("recurring", type.getKey().getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("getExpansionKey")
+    class GetExpansionKey {
+
+        @Test
+        @DisplayName("returns empty for built-in type")
+        public void getExpansionKey_returnsEmpty() {
+            assertTrue(type.getExpansionKey().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("parse")
+    class Parse {
+
+        @Test
+        @DisplayName("valid month-day and time returns Recurring boundary")
+        public void parse_validInputs_returnsRecurringBoundary() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn("00:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Recurring recurring = assertInstanceOf(WindowBoundary.Recurring.class, result.get());
+            assertEquals(MonthDay.of(12, 1), recurring.monthDay());
+            assertEquals(LocalTime.MIDNIGHT, recurring.time());
+        }
+
+        @Test
+        @DisplayName("month-day with specific time parses correctly")
+        public void parse_specificTime_parsesCorrectly() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--06-15");
+            when(section.getString("time")).thenReturn("14:30:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertTrue(result.isPresent());
+            WindowBoundary.Recurring recurring = assertInstanceOf(WindowBoundary.Recurring.class, result.get());
+            assertEquals(MonthDay.of(6, 15), recurring.monthDay());
+            assertEquals(LocalTime.of(14, 30, 0), recurring.time());
+        }
+
+        @Test
+        @DisplayName("null month-day returns empty and logs warning")
+        public void parse_nullMonthDay_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn(null);
+            when(section.getString("time")).thenReturn("12:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning("[AvailabilityConfig] Recurring boundary in test-chain.yml is missing 'month-day' or 'time' field — skipping window");
+        }
+
+        @Test
+        @DisplayName("null time returns empty and logs warning")
+        public void parse_nullTime_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn(null);
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning("[AvailabilityConfig] Recurring boundary in test-chain.yml is missing 'month-day' or 'time' field — skipping window");
+        }
+
+        @Test
+        @DisplayName("both fields null returns empty and logs warning")
+        public void parse_bothNull_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn(null);
+            when(section.getString("time")).thenReturn(null);
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning("[AvailabilityConfig] Recurring boundary in test-chain.yml is missing 'month-day' or 'time' field — skipping window");
+        }
+
+        @Test
+        @DisplayName("invalid month-day format returns empty and logs warning")
+        public void parse_invalidMonthDay_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("invalid");
+            when(section.getString("time")).thenReturn("12:00:00");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning(org.mockito.ArgumentMatchers.startsWith("[AvailabilityConfig] Invalid recurring boundary in test-chain.yml:"));
+        }
+
+        @Test
+        @DisplayName("invalid time format returns empty and logs warning")
+        public void parse_invalidTime_returnsEmptyAndLogsWarning() {
+            Section section = mock(Section.class);
+            when(section.getString("month-day")).thenReturn("--12-01");
+            when(section.getString("time")).thenReturn("not-a-time");
+
+            Optional<WindowBoundary> result = type.parse(section, mockFile, mockLogger);
+
+            assertFalse(result.isPresent());
+            verify(mockLogger).warning(org.mockito.ArgumentMatchers.startsWith("[AvailabilityConfig] Invalid recurring boundary in test-chain.yml:"));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateChainConditionTypeTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateChainConditionTypeTest.java
@@ -1,0 +1,138 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.chain.QuestChainStartCondition;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TimeGateChainConditionType")
+public class TimeGateChainConditionTypeTest extends McRPGBaseTest {
+
+    private TimeGateChainConditionType type;
+
+    @BeforeEach
+    public void setup() {
+        type = new TimeGateChainConditionType();
+    }
+
+    @Nested
+    @DisplayName("getKey")
+    class GetKey {
+
+        @Test
+        @DisplayName("returns the time_gate key")
+        public void getKey_returnsTimeGateKey() {
+            assertEquals(TimeGateChainConditionType.KEY, type.getKey());
+            assertEquals("mcrpg", type.getKey().getNamespace());
+            assertEquals("time_gate", type.getKey().getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("getExpansionKey")
+    class GetExpansionKey {
+
+        @Test
+        @DisplayName("returns empty for built-in type")
+        public void getExpansionKey_returnsEmpty() {
+            assertTrue(type.getExpansionKey().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("parse")
+    class Parse {
+
+        @Test
+        @DisplayName("valid after and timezone returns TimeGateCondition")
+        public void parse_validAfterAndTimezone_returnsCondition() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn("America/New_York");
+
+            QuestChainStartCondition result = type.parse(section);
+
+            TimeGateCondition condition = assertInstanceOf(TimeGateCondition.class, result);
+            assertEquals(LocalDateTime.of(2026, 7, 1, 0, 0, 0), condition.after());
+            assertEquals(ZoneId.of("America/New_York"), condition.timezone());
+            assertEquals(TimeGateChainConditionType.KEY, condition.getKey());
+        }
+
+        @Test
+        @DisplayName("valid after without timezone uses system default")
+        public void parse_validAfterNoTimezone_usesSystemDefault() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-01-15T08:30:00");
+            when(section.getString("timezone")).thenReturn(null);
+
+            QuestChainStartCondition result = type.parse(section);
+
+            TimeGateCondition condition = assertInstanceOf(TimeGateCondition.class, result);
+            assertEquals(LocalDateTime.of(2026, 1, 15, 8, 30, 0), condition.after());
+            assertEquals(ZoneId.systemDefault(), condition.timezone());
+        }
+
+        @Test
+        @DisplayName("UTC timezone parses correctly")
+        public void parse_utcTimezone_parsesCorrectly() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2025-03-01T12:00:00");
+            when(section.getString("timezone")).thenReturn("UTC");
+
+            QuestChainStartCondition result = type.parse(section);
+
+            TimeGateCondition condition = assertInstanceOf(TimeGateCondition.class, result);
+            assertEquals(ZoneId.of("UTC"), condition.timezone());
+        }
+
+        @Test
+        @DisplayName("missing after field throws IllegalArgumentException")
+        public void parse_missingAfter_throwsIllegalArgument() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn(null);
+
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> type.parse(section));
+            assertEquals("TimeGateChainConditionType requires an 'after' field", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("invalid after format throws IllegalArgumentException")
+        public void parse_invalidAfterFormat_throwsIllegalArgument() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("not-a-date");
+            when(section.getString("timezone")).thenReturn(null);
+
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> type.parse(section));
+            assertTrue(exception.getMessage().contains("Invalid 'after' value 'not-a-date'"));
+            assertTrue(exception.getMessage().contains("expected ISO-8601 format"));
+        }
+
+        @Test
+        @DisplayName("invalid timezone throws IllegalArgumentException")
+        public void parse_invalidTimezone_throwsIllegalArgument() {
+            Section section = mock(Section.class);
+            when(section.getString("after")).thenReturn("2026-07-01T00:00:00");
+            when(section.getString("timezone")).thenReturn("Invalid/Timezone");
+
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                    () -> type.parse(section));
+            assertTrue(exception.getMessage().contains("Invalid 'timezone' value 'Invalid/Timezone'"));
+            assertTrue(exception.getMessage().contains("expected a valid IANA timezone ID"));
+        }
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/chain/condition/builtin/TimeGateConditionTest.java
@@ -1,0 +1,81 @@
+package us.eunoians.mcrpg.quest.chain.condition.builtin;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("TimeGateCondition")
+public class TimeGateConditionTest extends McRPGBaseTest {
+
+    private final Player mockPlayer = mock(Player.class);
+
+    @Test
+    @DisplayName("returns false when current time is before the boundary")
+    public void evaluate_beforeBoundary_returnsFalse() {
+        LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+        TimeGateCondition condition = new TimeGateCondition(
+                TimeGateChainConditionType.KEY, boundary, ZoneOffset.UTC);
+
+        Instant beforeBoundary = ZonedDateTime.of(2026, 6, 30, 23, 59, 59, 0, ZoneOffset.UTC).toInstant();
+        assertFalse(condition.evaluate(mockPlayer, beforeBoundary));
+    }
+
+    @Test
+    @DisplayName("returns true when current time is exactly at the boundary")
+    public void evaluate_exactlyAtBoundary_returnsTrue() {
+        LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+        TimeGateCondition condition = new TimeGateCondition(
+                TimeGateChainConditionType.KEY, boundary, ZoneOffset.UTC);
+
+        Instant atBoundary = ZonedDateTime.of(2026, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
+        assertTrue(condition.evaluate(mockPlayer, atBoundary));
+    }
+
+    @Test
+    @DisplayName("returns true when current time is after the boundary")
+    public void evaluate_afterBoundary_returnsTrue() {
+        LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+        TimeGateCondition condition = new TimeGateCondition(
+                TimeGateChainConditionType.KEY, boundary, ZoneOffset.UTC);
+
+        Instant afterBoundary = ZonedDateTime.of(2026, 7, 1, 0, 0, 1, 0, ZoneOffset.UTC).toInstant();
+        assertTrue(condition.evaluate(mockPlayer, afterBoundary));
+    }
+
+    @Test
+    @DisplayName("cross-timezone: UTC time before boundary but local time after boundary returns true")
+    public void evaluate_crossTimezone_localTimeAfterBoundary_returnsTrue() {
+        LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 0, 0, 0);
+        ZoneId tokyoZone = ZoneId.of("Asia/Tokyo");
+        TimeGateCondition condition = new TimeGateCondition(
+                TimeGateChainConditionType.KEY, boundary, tokyoZone);
+
+        // 2026-06-30T20:00:00 UTC = 2026-07-01T05:00:00 Asia/Tokyo (after boundary in Tokyo)
+        Instant utcTime = ZonedDateTime.of(2026, 6, 30, 20, 0, 0, 0, ZoneOffset.UTC).toInstant();
+        assertTrue(condition.evaluate(mockPlayer, utcTime));
+    }
+
+    @Test
+    @DisplayName("cross-timezone: UTC time after boundary but local time before boundary returns false")
+    public void evaluate_crossTimezone_localTimeBeforeBoundary_returnsFalse() {
+        LocalDateTime boundary = LocalDateTime.of(2026, 7, 1, 12, 0, 0);
+        ZoneId newYorkZone = ZoneId.of("America/New_York");
+        TimeGateCondition condition = new TimeGateCondition(
+                TimeGateChainConditionType.KEY, boundary, newYorkZone);
+
+        // 2026-07-01T14:00:00 UTC = 2026-07-01T10:00:00 America/New_York (before 12:00 boundary)
+        Instant utcTime = ZonedDateTime.of(2026, 7, 1, 14, 0, 0, 0, ZoneOffset.UTC).toInstant();
+        assertFalse(condition.evaluate(mockPlayer, utcTime));
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/objective/type/builtin/ObjectiveTypeProcessProgressTest.java
@@ -1,14 +1,25 @@
 package us.eunoians.mcrpg.quest.objective.type.builtin;
 
+import com.diamonddagger590.mccore.util.item.CustomEntityWrapper;
+import com.diamonddagger590.mccore.util.item.CustomItemWrapper;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
+import io.papermc.paper.event.player.PlayerTradeEvent;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
 import org.bukkit.inventory.Recipe;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -322,6 +333,384 @@ public class ObjectiveTypeProcessProgressTest extends McRPGBaseTest {
             when(inventory.getMatrix()).thenReturn(matrix);
             CraftItemQuestContext context = new CraftItemQuestContext(event);
             assertEquals(1, type.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("ItemPickupObjectiveType processProgress")
+    class ItemPickupProcessProgress {
+
+        private final ItemPickupObjectiveType type = new ItemPickupObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns stack amount")
+        public void processProgress_unconfigured_returnsStackAmount() {
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND, 5));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(5, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns 1 for single item")
+        public void processProgress_unconfigured_returnsSingleAmount() {
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.IRON_SWORD, 1));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching item returns stack amount")
+        public void processProgress_matchingItem_returnsStackAmount() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("DIAMOND"));
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.DIAMOND, 3));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(3, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching item returns 0")
+        public void processProgress_nonMatchingItem_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("DIAMOND"));
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.GOLD_INGOT, 10));
+            when(event.getItem()).thenReturn(item);
+            ItemPickupQuestContext context = new ItemPickupQuestContext(event);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("ItemPickupObjectiveType parseConfig")
+    class ItemPickupParseConfig {
+
+        private final ItemPickupObjectiveType type = new ItemPickupObjectiveType();
+
+        @Test
+        @DisplayName("section without items key accepts any item")
+        public void parseConfig_noItemsKey_acceptsAnyItem() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(false);
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+
+            EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+            Item item = mock(Item.class);
+            when(item.getItemStack()).thenReturn(new ItemStack(Material.EMERALD, 2));
+            when(event.getItem()).thenReturn(item);
+            assertEquals(2, configured.processProgress(mockInstance, new ItemPickupQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(false);
+            ItemPickupObjectiveType configured = type.parseConfig(section);
+            assertEquals(ItemPickupObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("LaunchProjectileObjectiveType processProgress")
+    class LaunchProjectileProcessProgress {
+
+        private final LaunchProjectileObjectiveType type = new LaunchProjectileObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any projectile")
+        public void processProgress_unconfigured_returnsOne() {
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(projectile.getType()).thenReturn(EntityType.ARROW);
+            when(event.getEntity()).thenReturn(projectile);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching projectile returns 1")
+        public void processProgress_matchingProjectile_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("ARROW", "SNOWBALL"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(projectile.getType()).thenReturn(EntityType.ARROW);
+            when(event.getEntity()).thenReturn(projectile);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching projectile returns 0")
+        public void processProgress_nonMatchingProjectile_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("ARROW"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(projectile.getType()).thenReturn(EntityType.SNOWBALL);
+            when(event.getEntity()).thenReturn(projectile);
+            LaunchProjectileQuestContext context = new LaunchProjectileQuestContext(event);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("LaunchProjectileObjectiveType parseConfig")
+    class LaunchProjectileParseConfig {
+
+        private final LaunchProjectileObjectiveType type = new LaunchProjectileObjectiveType();
+
+        @Test
+        @DisplayName("section without projectiles key accepts any projectile")
+        public void parseConfig_noProjectilesKey_acceptsAnyProjectile() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(false);
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(projectile.getType()).thenReturn(EntityType.FIREBALL);
+            when(event.getEntity()).thenReturn(projectile);
+            assertEquals(1, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("projectiles are parsed case-insensitively")
+        public void parseConfig_projectilesAreCaseInsensitive() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(true);
+            when(section.getStringList("projectiles")).thenReturn(List.of("arrow"));
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+
+            ProjectileLaunchEvent event = mock(ProjectileLaunchEvent.class);
+            Projectile projectile = mock(Projectile.class);
+            when(projectile.getType()).thenReturn(EntityType.ARROW);
+            when(event.getEntity()).thenReturn(projectile);
+            assertEquals(1, configured.processProgress(mockInstance, new LaunchProjectileQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("projectiles")).thenReturn(false);
+            LaunchProjectileObjectiveType configured = type.parseConfig(section);
+            assertEquals(LaunchProjectileObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("VillagerTradeObjectiveType processProgress")
+    class VillagerTradeProcessProgress {
+
+        private final VillagerTradeObjectiveType type = new VillagerTradeObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns trade result amount")
+        public void processProgress_unconfigured_returnsResultAmount() {
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.EMERALD, 3));
+            when(event.getTrade()).thenReturn(recipe);
+            VillagerTradeQuestContext context = new VillagerTradeQuestContext(event);
+            assertEquals(3, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("unconfigured returns 1 for single result item")
+        public void processProgress_unconfigured_returnsSingleAmount() {
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.DIAMOND_SWORD, 1));
+            when(event.getTrade()).thenReturn(recipe);
+            VillagerTradeQuestContext context = new VillagerTradeQuestContext(event);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching item returns result amount")
+        public void processProgress_matchingItem_returnsResultAmount() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("EMERALD"));
+            VillagerTradeObjectiveType configured = type.parseConfig(section);
+
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.EMERALD, 5));
+            when(event.getTrade()).thenReturn(recipe);
+            VillagerTradeQuestContext context = new VillagerTradeQuestContext(event);
+            assertEquals(5, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching item returns 0")
+        public void processProgress_nonMatchingItem_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(true);
+            when(section.getStringList("items")).thenReturn(List.of("EMERALD"));
+            VillagerTradeObjectiveType configured = type.parseConfig(section);
+
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.DIAMOND, 1));
+            when(event.getTrade()).thenReturn(recipe);
+            VillagerTradeQuestContext context = new VillagerTradeQuestContext(event);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("VillagerTradeObjectiveType parseConfig")
+    class VillagerTradeParseConfig {
+
+        private final VillagerTradeObjectiveType type = new VillagerTradeObjectiveType();
+
+        @Test
+        @DisplayName("section without items key accepts any trade")
+        public void parseConfig_noItemsKey_acceptsAnyTrade() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(false);
+            VillagerTradeObjectiveType configured = type.parseConfig(section);
+
+            PlayerTradeEvent event = mock(PlayerTradeEvent.class);
+            MerchantRecipe recipe = mock(MerchantRecipe.class);
+            when(recipe.getResult()).thenReturn(new ItemStack(Material.GOLDEN_APPLE, 1));
+            when(event.getTrade()).thenReturn(recipe);
+            assertEquals(1, configured.processProgress(mockInstance, new VillagerTradeQuestContext(event)));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("items")).thenReturn(false);
+            VillagerTradeObjectiveType configured = type.parseConfig(section);
+            assertEquals(VillagerTradeObjectiveType.KEY, configured.getKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("ShearEntityObjectiveType processProgress")
+    class ShearEntityProcessProgress {
+
+        private final ShearEntityObjectiveType type = new ShearEntityObjectiveType();
+
+        @Test
+        @DisplayName("wrong context type returns 0")
+        public void processProgress_wrongContextType_returnsZero() {
+            QuestObjectiveProgressContext wrongContext = mock(QuestObjectiveProgressContext.class);
+            assertEquals(0, type.processProgress(mockInstance, wrongContext));
+        }
+
+        @Test
+        @DisplayName("unconfigured accepts any entity")
+        public void processProgress_unconfigured_returnsOne() {
+            ShearEntityQuestContext context = mock(ShearEntityQuestContext.class);
+            CustomEntityWrapper wrapper = mock(CustomEntityWrapper.class);
+            when(context.getEntityWrapper()).thenReturn(wrapper);
+            assertEquals(1, type.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with matching entity returns 1")
+        public void processProgress_matchingEntity_returnsOne() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("SHEEP"));
+            ShearEntityObjectiveType configured = type.parseConfig(section);
+
+            ShearEntityQuestContext context = mock(ShearEntityQuestContext.class);
+            CustomEntityWrapper wrapper = new CustomEntityWrapper("SHEEP");
+            when(context.getEntityWrapper()).thenReturn(wrapper);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("configured with non-matching entity returns 0")
+        public void processProgress_nonMatchingEntity_returnsZero() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(true);
+            when(section.getStringList("entities")).thenReturn(List.of("SHEEP"));
+            ShearEntityObjectiveType configured = type.parseConfig(section);
+
+            ShearEntityQuestContext context = mock(ShearEntityQuestContext.class);
+            CustomEntityWrapper wrapper = new CustomEntityWrapper("MOOSHROOM");
+            when(context.getEntityWrapper()).thenReturn(wrapper);
+            assertEquals(0, configured.processProgress(mockInstance, context));
+        }
+    }
+
+    @Nested
+    @DisplayName("ShearEntityObjectiveType parseConfig")
+    class ShearEntityParseConfig {
+
+        private final ShearEntityObjectiveType type = new ShearEntityObjectiveType();
+
+        @Test
+        @DisplayName("section without entities key accepts any entity")
+        public void parseConfig_noEntitiesKey_acceptsAnyEntity() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            ShearEntityObjectiveType configured = type.parseConfig(section);
+
+            ShearEntityQuestContext context = mock(ShearEntityQuestContext.class);
+            CustomEntityWrapper wrapper = mock(CustomEntityWrapper.class);
+            when(context.getEntityWrapper()).thenReturn(wrapper);
+            assertEquals(1, configured.processProgress(mockInstance, context));
+        }
+
+        @Test
+        @DisplayName("parsed instance preserves key")
+        public void parseConfig_preservesKey() {
+            Section section = mock(Section.class);
+            when(section.contains("entities")).thenReturn(false);
+            ShearEntityObjectiveType configured = type.parseConfig(section);
+            assertEquals(ShearEntityObjectiveType.KEY, configured.getKey());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add new test files for `FixedWindowBoundaryType`, `RecurringWindowBoundaryType`, and `TimeGateChainConditionType` (all at 0% coverage previously)
- Expand `ObjectiveTypeProcessProgressTest` with `processProgress` and `parseConfig` coverage for `ItemPickupObjectiveType`, `LaunchProjectileObjectiveType`, `VillagerTradeObjectiveType`, and `ShearEntityObjectiveType` (all at ~17% coverage previously — only metadata tests existed)

## New Test Files

| File | Tests | Covers |
|------|-------|--------|
| `FixedWindowBoundaryTypeTest` | 7 | parse valid/invalid dates, null field, key/expansion metadata |
| `RecurringWindowBoundaryTypeTest` | 9 | parse valid/invalid month-day+time, null fields, key/expansion metadata |
| `TimeGateChainConditionTypeTest` | 7 | parse with/without timezone, missing/invalid after, invalid timezone, key/expansion metadata |

## Extended Tests (ObjectiveTypeProcessProgressTest)

| Nested Class | Tests | Covers |
|-------------|-------|--------|
| `ItemPickupProcessProgress` | 5 | wrong context, unconfigured (stack amount), configured match/non-match |
| `ItemPickupParseConfig` | 2 | no items key, key preservation |
| `LaunchProjectileProcessProgress` | 4 | wrong context, unconfigured, configured match/non-match |
| `LaunchProjectileParseConfig` | 3 | no projectiles key, case-insensitive parsing, key preservation |
| `VillagerTradeProcessProgress` | 5 | wrong context, unconfigured (result amount), configured match/non-match |
| `VillagerTradeParseConfig` | 2 | no items key, key preservation |
| `ShearEntityProcessProgress` | 4 | wrong context, unconfigured, configured match/non-match |
| `ShearEntityParseConfig` | 2 | no entities key, key preservation |

## Test plan

- [x] All 5126+ tests pass via `./gradlew test`
- [x] No regressions in existing tests
- [x] Tests follow CLAUDE.md naming conventions (`@DisplayName`, `@Nested` grouping, `action_outcome_whenCondition` methods)
- [x] Tests extend `McRPGBaseTest` where MockBukkit setup is needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNTkqKXjtRccJoUBgK2FiF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for fixed and recurring time-window boundaries.
  * Added validation tests for timestamps, time zones, missing fields, invalid values, and warning messages.
  * Expanded objective progress tests for item pickup, projectile launching, villager trading, and entity shearing.
  * Added coverage for matching filters, configuration handling, returned quantities, and preserved objective keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->