### PR TITLE
[Unit Tests] Add coverage for DisableTutorialSetting and quest board template records

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/ObjectiveSelectionConfigTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/ObjectiveSelectionConfigTest.java
@@ -1,0 +1,78 @@
+package us.eunoians.mcrpg.quest.board.template;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.quest.board.template.ObjectiveSelectionConfig.ObjectiveSelectionMode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("ObjectiveSelectionConfig")
+public class ObjectiveSelectionConfigTest {
+
+    @DisplayName("Valid config stores mode, minCount, and maxCount")
+    @Test
+    void constructor_validValues_storesFields() {
+        var config = new ObjectiveSelectionConfig(ObjectiveSelectionMode.WEIGHTED_RANDOM, 2, 5);
+        assertEquals(ObjectiveSelectionMode.WEIGHTED_RANDOM, config.mode());
+        assertEquals(2, config.minCount());
+        assertEquals(5, config.maxCount());
+    }
+
+    @DisplayName("ALL mode accepted with valid counts")
+    @Test
+    void constructor_allMode_storesCorrectly() {
+        var config = new ObjectiveSelectionConfig(ObjectiveSelectionMode.ALL, 1, 10);
+        assertEquals(ObjectiveSelectionMode.ALL, config.mode());
+        assertEquals(1, config.minCount());
+        assertEquals(10, config.maxCount());
+    }
+
+    @DisplayName("minCount of zero throws IllegalArgumentException")
+    @Test
+    void constructor_minCountZero_throws() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new ObjectiveSelectionConfig(ObjectiveSelectionMode.ALL, 0, 5));
+        assertEquals("minCount must be >= 1, got: 0", exception.getMessage());
+    }
+
+    @DisplayName("Negative minCount throws IllegalArgumentException")
+    @Test
+    void constructor_negativeMinCount_throws() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new ObjectiveSelectionConfig(ObjectiveSelectionMode.WEIGHTED_RANDOM, -3, 5));
+        assertEquals("minCount must be >= 1, got: -3", exception.getMessage());
+    }
+
+    @DisplayName("maxCount less than minCount throws IllegalArgumentException")
+    @Test
+    void constructor_maxCountLessThanMinCount_throws() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new ObjectiveSelectionConfig(ObjectiveSelectionMode.WEIGHTED_RANDOM, 5, 3));
+        assertEquals("maxCount must be >= minCount, got: max=3, min=5", exception.getMessage());
+    }
+
+    @DisplayName("minCount equals maxCount is accepted")
+    @Test
+    void constructor_minEqualsMax_accepted() {
+        var config = new ObjectiveSelectionConfig(ObjectiveSelectionMode.WEIGHTED_RANDOM, 3, 3);
+        assertEquals(3, config.minCount());
+        assertEquals(3, config.maxCount());
+    }
+
+    @DisplayName("Boundary: minCount 1, maxCount 1 is accepted")
+    @Test
+    void constructor_singleObjective_accepted() {
+        var config = new ObjectiveSelectionConfig(ObjectiveSelectionMode.ALL, 1, 1);
+        assertEquals(1, config.minCount());
+        assertEquals(1, config.maxCount());
+    }
+
+    @DisplayName("ObjectiveSelectionMode has exactly two values")
+    @Test
+    void objectiveSelectionMode_hasTwoValues() {
+        assertEquals(2, ObjectiveSelectionMode.values().length);
+        assertEquals(ObjectiveSelectionMode.ALL, ObjectiveSelectionMode.valueOf("ALL"));
+        assertEquals(ObjectiveSelectionMode.WEIGHTED_RANDOM, ObjectiveSelectionMode.valueOf("WEIGHTED_RANDOM"));
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplatePhaseDefinitionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplatePhaseDefinitionTest.java
@@ -1,0 +1,138 @@
+package us.eunoians.mcrpg.quest.board.template;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.board.template.condition.TemplateCondition;
+import us.eunoians.mcrpg.quest.definition.PhaseCompletionMode;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("TemplatePhaseDefinition")
+public class TemplatePhaseDefinitionTest extends McRPGBaseTest {
+
+    @DisplayName("Canonical constructor makes stages list immutable")
+    @Test
+    void constructor_stagesList_isImmutable() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, List.of(createStage()), null);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> phase.stages().add(createStage()));
+    }
+
+    @DisplayName("Mutations to original list do not affect the record")
+    @Test
+    void constructor_defensiveCopy_originalUnaffected() {
+        List<TemplateStageDefinition> mutableList = new ArrayList<>();
+        mutableList.add(createStage());
+
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, mutableList, null);
+        mutableList.add(createStage());
+
+        assertEquals(1, phase.stages().size());
+    }
+
+    @DisplayName("getCondition() returns empty when condition is null")
+    @Test
+    void getCondition_nullCondition_returnsEmpty() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, List.of(createStage()), null);
+        assertTrue(phase.getCondition().isEmpty());
+    }
+
+    @DisplayName("getCondition() returns present Optional when condition is non-null")
+    @Test
+    void getCondition_nonNullCondition_returnsPresent() {
+        TemplateCondition mockCondition = mock(TemplateCondition.class);
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ANY, List.of(createStage()), mockCondition);
+
+        assertTrue(phase.getCondition().isPresent());
+        assertEquals(mockCondition, phase.getCondition().orElseThrow());
+    }
+
+    @DisplayName("Completion mode is stored correctly for ALL")
+    @Test
+    void constructor_allMode_storedCorrectly() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, List.of(createStage()), null);
+        assertEquals(PhaseCompletionMode.ALL, phase.completionMode());
+    }
+
+    @DisplayName("Completion mode is stored correctly for ANY")
+    @Test
+    void constructor_anyMode_storedCorrectly() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ANY, List.of(createStage()), null);
+        assertEquals(PhaseCompletionMode.ANY, phase.completionMode());
+    }
+
+    @DisplayName("withStages returns new instance with updated stages, preserving completionMode and condition")
+    @Test
+    void withStages_preservesOtherFields() {
+        TemplateCondition mockCondition = mock(TemplateCondition.class);
+        TemplateStageDefinition originalStage = createStage();
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ANY, List.of(originalStage), mockCondition);
+
+        TemplateStageDefinition replacementStage = createStage();
+        TemplatePhaseDefinition updated = phase.withStages(List.of(replacementStage));
+
+        assertNotSame(phase, updated);
+        assertEquals(1, updated.stages().size());
+        assertEquals(replacementStage, updated.stages().get(0));
+        assertEquals(PhaseCompletionMode.ANY, updated.completionMode());
+        assertEquals(mockCondition, updated.getCondition().orElseThrow());
+    }
+
+    @DisplayName("withStages on null condition preserves null")
+    @Test
+    void withStages_nullCondition_preservesNull() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, List.of(createStage()));
+        TemplatePhaseDefinition updated = phase.withStages(List.of(createStage()));
+
+        assertTrue(updated.getCondition().isEmpty());
+        assertEquals(PhaseCompletionMode.ALL, updated.completionMode());
+    }
+
+    @DisplayName("Backward-compatible constructor sets null condition")
+    @Test
+    void backwardCompatibleConstructor_setsNullCondition() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, List.of(createStage()));
+
+        assertTrue(phase.getCondition().isEmpty());
+        assertEquals(PhaseCompletionMode.ALL, phase.completionMode());
+        assertEquals(1, phase.stages().size());
+    }
+
+    @DisplayName("Multiple stages are preserved in order")
+    @Test
+    void constructor_multipleStages_preservesOrder() {
+        TemplateStageDefinition stage1 = createStage();
+        TemplateStageDefinition stage2 = createStage();
+        TemplateStageDefinition stage3 = createStage();
+
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL,
+                List.of(stage1, stage2, stage3), null);
+
+        assertEquals(3, phase.stages().size());
+        assertEquals(stage1, phase.stages().get(0));
+        assertEquals(stage2, phase.stages().get(1));
+        assertEquals(stage3, phase.stages().get(2));
+    }
+
+    /**
+     * @return a minimal stage definition for testing
+     */
+    private TemplateStageDefinition createStage() {
+        NamespacedKey key = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "test_obj");
+        TemplateObjectiveDefinition objective =
+                new TemplateObjectiveDefinition("test", key, "10", Map.of(), null, 1);
+        return new TemplateStageDefinition(List.of(objective));
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplatePhaseDefinitionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplatePhaseDefinitionTest.java
@@ -3,7 +3,6 @@ package us.eunoians.mcrpg.quest.board.template;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.board.template.condition.TemplateCondition;
 import us.eunoians.mcrpg.quest.definition.PhaseCompletionMode;
 import us.eunoians.mcrpg.util.McRPGMethods;
@@ -19,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @DisplayName("TemplatePhaseDefinition")
-public class TemplatePhaseDefinitionTest extends McRPGBaseTest {
+public class TemplatePhaseDefinitionTest {
 
     @DisplayName("Canonical constructor makes stages list immutable")
     @Test
@@ -124,6 +123,13 @@ public class TemplatePhaseDefinitionTest extends McRPGBaseTest {
         assertEquals(stage1, phase.stages().get(0));
         assertEquals(stage2, phase.stages().get(1));
         assertEquals(stage3, phase.stages().get(2));
+    }
+
+    @DisplayName("Empty stages list is accepted")
+    @Test
+    void constructor_emptyStagesList_accepted() {
+        var phase = new TemplatePhaseDefinition(PhaseCompletionMode.ALL, List.of(), null);
+        assertTrue(phase.stages().isEmpty());
     }
 
     /**

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateRewardDefinitionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateRewardDefinitionTest.java
@@ -3,7 +3,6 @@ package us.eunoians.mcrpg.quest.board.template;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.util.McRPGMethods;
 
 import java.util.HashMap;
@@ -13,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("TemplateRewardDefinition")
-public class TemplateRewardDefinitionTest extends McRPGBaseTest {
+public class TemplateRewardDefinitionTest {
 
     @DisplayName("Record stores all provided values")
     @Test

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateRewardDefinitionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateRewardDefinitionTest.java
@@ -1,0 +1,61 @@
+package us.eunoians.mcrpg.quest.board.template;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("TemplateRewardDefinition")
+public class TemplateRewardDefinitionTest extends McRPGBaseTest {
+
+    @DisplayName("Record stores all provided values")
+    @Test
+    void constructor_storesAllFields() {
+        NamespacedKey typeKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "experience");
+        var reward = new TemplateRewardDefinition(typeKey, "xp_bonus", Map.of("amount", "100"));
+
+        assertEquals(typeKey, reward.typeKey());
+        assertEquals("xp_bonus", reward.label());
+        assertEquals(Map.of("amount", "100"), reward.config());
+    }
+
+    @DisplayName("Canonical constructor makes config map immutable")
+    @Test
+    void constructor_configMap_isImmutable() {
+        NamespacedKey typeKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "command");
+        var reward = new TemplateRewardDefinition(typeKey, "cmd_reward", Map.of("command", "/give"));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> reward.config().put("extra", "value"));
+    }
+
+    @DisplayName("Mutations to original map do not affect the record")
+    @Test
+    void constructor_defensiveCopy_originalUnaffected() {
+        NamespacedKey typeKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "title");
+        Map<String, Object> mutableMap = new HashMap<>();
+        mutableMap.put("title", "Champion");
+
+        var reward = new TemplateRewardDefinition(typeKey, "champion_title", mutableMap);
+        mutableMap.put("subtitle", "Sneaky");
+
+        assertEquals(1, reward.config().size());
+        assertEquals("Champion", reward.config().get("title"));
+    }
+
+    @DisplayName("Empty config map is accepted")
+    @Test
+    void constructor_emptyConfig_accepted() {
+        NamespacedKey typeKey = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), "sound");
+        var reward = new TemplateRewardDefinition(typeKey, "fanfare", Map.of());
+
+        assertEquals(0, reward.config().size());
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateStageDefinitionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateStageDefinitionTest.java
@@ -1,0 +1,127 @@
+package us.eunoians.mcrpg.quest.board.template;
+
+import org.bukkit.NamespacedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import us.eunoians.mcrpg.McRPGBaseTest;
+import us.eunoians.mcrpg.quest.board.template.ObjectiveSelectionConfig.ObjectiveSelectionMode;
+import us.eunoians.mcrpg.quest.board.template.condition.TemplateCondition;
+import us.eunoians.mcrpg.util.McRPGMethods;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("TemplateStageDefinition")
+public class TemplateStageDefinitionTest extends McRPGBaseTest {
+
+    @DisplayName("Canonical constructor makes objectives list immutable")
+    @Test
+    void constructor_objectivesList_isImmutable() {
+        TemplateObjectiveDefinition objective = createObjective("test_obj");
+        var stage = new TemplateStageDefinition(List.of(objective), null, null);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> stage.objectives().add(createObjective("another")));
+    }
+
+    @DisplayName("Mutations to original list do not affect the record")
+    @Test
+    void constructor_defensiveCopy_originalUnaffected() {
+        TemplateObjectiveDefinition objective = createObjective("test_obj");
+        List<TemplateObjectiveDefinition> mutableList = new ArrayList<>();
+        mutableList.add(objective);
+
+        var stage = new TemplateStageDefinition(mutableList, null, null);
+        mutableList.add(createObjective("sneaky"));
+
+        assertEquals(1, stage.objectives().size());
+    }
+
+    @DisplayName("getCondition() returns empty when condition is null")
+    @Test
+    void getCondition_nullCondition_returnsEmpty() {
+        var stage = new TemplateStageDefinition(List.of(createObjective("obj")), null, null);
+        assertTrue(stage.getCondition().isEmpty());
+    }
+
+    @DisplayName("getCondition() returns present Optional when condition is non-null")
+    @Test
+    void getCondition_nonNullCondition_returnsPresent() {
+        TemplateCondition mockCondition = mock(TemplateCondition.class);
+        var stage = new TemplateStageDefinition(List.of(createObjective("obj")), mockCondition, null);
+
+        assertTrue(stage.getCondition().isPresent());
+        assertEquals(mockCondition, stage.getCondition().orElseThrow());
+    }
+
+    @DisplayName("getObjectiveSelection() returns empty when selection config is null")
+    @Test
+    void getObjectiveSelection_null_returnsEmpty() {
+        var stage = new TemplateStageDefinition(List.of(createObjective("obj")), null, null);
+        assertTrue(stage.getObjectiveSelection().isEmpty());
+    }
+
+    @DisplayName("getObjectiveSelection() returns present Optional when config is non-null")
+    @Test
+    void getObjectiveSelection_nonNull_returnsPresent() {
+        var selection = new ObjectiveSelectionConfig(ObjectiveSelectionMode.WEIGHTED_RANDOM, 1, 3);
+        var stage = new TemplateStageDefinition(List.of(createObjective("obj")), null, selection);
+
+        assertTrue(stage.getObjectiveSelection().isPresent());
+        assertEquals(selection, stage.getObjectiveSelection().orElseThrow());
+    }
+
+    @DisplayName("withObjectives returns new instance with updated objectives, preserving condition")
+    @Test
+    void withObjectives_preservesCondition() {
+        TemplateCondition mockCondition = mock(TemplateCondition.class);
+        var selection = new ObjectiveSelectionConfig(ObjectiveSelectionMode.ALL, 1, 2);
+        TemplateObjectiveDefinition original = createObjective("original");
+        var stage = new TemplateStageDefinition(List.of(original), mockCondition, selection);
+
+        TemplateObjectiveDefinition replacement = createObjective("replacement");
+        TemplateStageDefinition updated = stage.withObjectives(List.of(replacement));
+
+        assertNotSame(stage, updated);
+        assertEquals(1, updated.objectives().size());
+        assertEquals(replacement, updated.objectives().get(0));
+        assertEquals(mockCondition, updated.getCondition().orElseThrow());
+        assertEquals(selection, updated.getObjectiveSelection().orElseThrow());
+    }
+
+    @DisplayName("withObjectives on null condition and selection preserves nulls")
+    @Test
+    void withObjectives_nullFields_preservesNulls() {
+        var stage = new TemplateStageDefinition(List.of(createObjective("a")));
+        TemplateStageDefinition updated = stage.withObjectives(List.of(createObjective("b")));
+
+        assertTrue(updated.getCondition().isEmpty());
+        assertTrue(updated.getObjectiveSelection().isEmpty());
+    }
+
+    @DisplayName("Backward-compatible constructor sets null condition and null objectiveSelection")
+    @Test
+    void backwardCompatibleConstructor_setsNullFields() {
+        var stage = new TemplateStageDefinition(List.of(createObjective("obj")));
+
+        assertTrue(stage.getCondition().isEmpty());
+        assertTrue(stage.getObjectiveSelection().isEmpty());
+        assertEquals(1, stage.objectives().size());
+    }
+
+    /**
+     * @param label the objective label
+     * @return a minimal objective definition for testing
+     */
+    private TemplateObjectiveDefinition createObjective(String label) {
+        NamespacedKey key = new NamespacedKey(McRPGMethods.getMcRPGNamespace(), label);
+        return new TemplateObjectiveDefinition(label, key, "10", Map.of(), null, 1);
+    }
+}

--- a/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateStageDefinitionTest.java
+++ b/src/test/java/us/eunoians/mcrpg/quest/board/template/TemplateStageDefinitionTest.java
@@ -3,7 +3,6 @@ package us.eunoians.mcrpg.quest.board.template;
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import us.eunoians.mcrpg.McRPGBaseTest;
 import us.eunoians.mcrpg.quest.board.template.ObjectiveSelectionConfig.ObjectiveSelectionMode;
 import us.eunoians.mcrpg.quest.board.template.condition.TemplateCondition;
 import us.eunoians.mcrpg.util.McRPGMethods;
@@ -19,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @DisplayName("TemplateStageDefinition")
-public class TemplateStageDefinitionTest extends McRPGBaseTest {
+public class TemplateStageDefinitionTest {
 
     @DisplayName("Canonical constructor makes objectives list immutable")
     @Test
@@ -114,6 +113,13 @@ public class TemplateStageDefinitionTest extends McRPGBaseTest {
         assertTrue(stage.getCondition().isEmpty());
         assertTrue(stage.getObjectiveSelection().isEmpty());
         assertEquals(1, stage.objectives().size());
+    }
+
+    @DisplayName("Empty objectives list is accepted")
+    @Test
+    void constructor_emptyObjectivesList_accepted() {
+        var stage = new TemplateStageDefinition(List.of(), null, null);
+        assertTrue(stage.objectives().isEmpty());
     }
 
     /**

--- a/src/test/java/us/eunoians/mcrpg/setting/impl/DisableTutorialSettingTest.java
+++ b/src/test/java/us/eunoians/mcrpg/setting/impl/DisableTutorialSettingTest.java
@@ -1,0 +1,93 @@
+package us.eunoians.mcrpg.setting.impl;
+
+import com.diamonddagger590.mccore.player.CorePlayer;
+import com.diamonddagger590.mccore.setting.PlayerSetting;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("DisableTutorialSetting")
+public class DisableTutorialSettingTest {
+
+    @DisplayName("DISABLED reports isDisabled() as true")
+    @Test
+    void isDisabled_disabledVariant_returnsTrue() {
+        assertTrue(DisableTutorialSetting.DISABLED.isDisabled());
+    }
+
+    @DisplayName("ENABLED reports isDisabled() as false")
+    @Test
+    void isDisabled_enabledVariant_returnsFalse() {
+        assertFalse(DisableTutorialSetting.ENABLED.isDisabled());
+    }
+
+    @DisplayName("ENABLED cycles to DISABLED")
+    @Test
+    void getNextSetting_enabled_cyclesToDisabled() {
+        DisableTutorialSetting next =
+                (DisableTutorialSetting) DisableTutorialSetting.ENABLED.getNextSetting().getNodeValue();
+        assertEquals(DisableTutorialSetting.DISABLED, next);
+    }
+
+    @DisplayName("DISABLED cycles back to ENABLED")
+    @Test
+    void getNextSetting_disabled_cyclesToEnabled() {
+        DisableTutorialSetting next =
+                (DisableTutorialSetting) DisableTutorialSetting.DISABLED.getNextSetting().getNodeValue();
+        assertEquals(DisableTutorialSetting.ENABLED, next);
+    }
+
+    @DisplayName("getFirstSetting() always returns ENABLED")
+    @Test
+    void getFirstSetting_returnsEnabled() {
+        assertEquals(DisableTutorialSetting.ENABLED,
+                DisableTutorialSetting.ENABLED.getFirstSetting().getNodeValue());
+        assertEquals(DisableTutorialSetting.ENABLED,
+                DisableTutorialSetting.DISABLED.getFirstSetting().getNodeValue());
+    }
+
+    @DisplayName("fromString round-trips for both variants")
+    @Test
+    void fromString_roundTrip_bothVariants() {
+        assertEquals(DisableTutorialSetting.ENABLED,
+                DisableTutorialSetting.ENABLED.fromString("ENABLED").orElseThrow());
+        assertEquals(DisableTutorialSetting.DISABLED,
+                DisableTutorialSetting.DISABLED.fromString("DISABLED").orElseThrow());
+    }
+
+    @DisplayName("fromString is case-insensitive")
+    @Test
+    void fromString_caseInsensitive() {
+        assertEquals(DisableTutorialSetting.ENABLED,
+                DisableTutorialSetting.ENABLED.fromString("enabled").orElseThrow());
+        assertEquals(DisableTutorialSetting.DISABLED,
+                DisableTutorialSetting.DISABLED.fromString("disabled").orElseThrow());
+    }
+
+    @DisplayName("fromString returns empty for unknown value")
+    @Test
+    void fromString_unknownValue_returnsEmpty() {
+        assertTrue(DisableTutorialSetting.ENABLED.fromString("NOT_A_SETTING").isEmpty());
+    }
+
+    @DisplayName("getSettingKey returns the expected namespaced key")
+    @Test
+    void getSettingKey_returnsExpectedKey() {
+        assertEquals("mcrpg:disable-tutorial-setting",
+                DisableTutorialSetting.ENABLED.getSettingKey().toString());
+    }
+
+    @DisplayName("onSettingChange is a no-op and does not throw")
+    @Test
+    void onSettingChange_doesNotThrow() {
+        CorePlayer mockPlayer = mock(CorePlayer.class);
+        DisableTutorialSetting.ENABLED.onSettingChange(mockPlayer, Optional.empty());
+        DisableTutorialSetting.DISABLED.onSettingChange(mockPlayer, Optional.of(mock(PlayerSetting.class)));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `DisableTutorialSettingTest` covering cycling, `fromString` parsing (including case-insensitivity), `isDisabled()`, `getSettingKey()`, and `onSettingChange()` no-op behavior
- Add first test coverage for the `quest.board.template` package:
  - `ObjectiveSelectionConfigTest` — validates constructor input constraints (`minCount >= 1`, `maxCount >= minCount`), boundary cases, and enum completeness
  - `TemplateStageDefinitionTest` — immutable defensive copy of objectives list, `getCondition()`/`getObjectiveSelection()` Optional wrapping, `withObjectives()` copy-method field preservation, backward-compatible constructor, empty list edge case
  - `TemplatePhaseDefinitionTest` — immutable defensive copy of stages list, `getCondition()` Optional wrapping, `withStages()` copy-method field preservation, completion mode storage, backward-compatible constructor, ordering preservation, empty list edge case
  - `TemplateRewardDefinitionTest` — immutable defensive copy of config map, field storage, empty config acceptance

## Test plan

- [x] All 5 new test classes compile and pass
- [x] Full test suite passes (`./gradlew test` — zero failures)
- [x] Testing audit persona reviewed and findings addressed (removed unnecessary `McRPGBaseTest` inheritance, added empty collection edge case tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSTP2JyAj68EvCHh6WzCr3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for quest template configuration, phases, stages, and rewards.
  * Verified validation rules, immutability, defensive copying, optional values, ordering, compatibility, and empty configurations.
  * Added coverage for tutorial setting defaults, value parsing, variant cycling, invalid values, and no-op updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->