### PR TITLE
[Unit Tests] Expand board DAO and ExpiredQuestScanTask test coverage

### DIFF
--- a/src/test/java/us/eunoians/mcrpg/database/table/board/BoardCooldownDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/BoardCooldownDAOTest.java
@@ -76,7 +76,7 @@ public class BoardCooldownDAOTest extends McRPGBaseTest {
 
         @DisplayName("Returns false when no matching rows exist")
         @Test
-        void isOnCooldown_returnsFalseWhenNoResults() throws SQLException {
+        void isOnCooldown_returnsFalse_whenNoResults() throws SQLException {
             Connection mockConnection = mock(Connection.class);
             PreparedStatement mockStatement = mock(PreparedStatement.class);
             ResultSet mockResultSet = mock(ResultSet.class);
@@ -98,7 +98,7 @@ public class BoardCooldownDAOTest extends McRPGBaseTest {
 
         @DisplayName("Returns true when a matching row exists")
         @Test
-        void isOnCooldown_returnsTrueWhenPresent() throws SQLException {
+        void isOnCooldown_returnsTrue_whenPresent() throws SQLException {
             Connection mockConnection = mock(Connection.class);
             PreparedStatement mockStatement = mock(PreparedStatement.class);
             ResultSet mockResultSet = mock(ResultSet.class);

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/BoardCooldownDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/BoardCooldownDAOTest.java
@@ -2,6 +2,7 @@ package us.eunoians.mcrpg.database.table.board;
 
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
@@ -20,104 +21,334 @@ import static org.mockito.Mockito.*;
 
 public class BoardCooldownDAOTest extends McRPGBaseTest {
 
-    @DisplayName("saveCooldown returns prepared statements")
-    @Test
-    void saveCooldown_returnsPreparedStatements() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("saveCooldown")
+    class SaveCooldownTests {
 
-        List<PreparedStatement> statements = BoardCooldownDAO.saveCooldown(
-                mockConnection,
-                "cooldown-1",
-                "rotation",
-                "player",
-                UUID.randomUUID().toString(),
-                new NamespacedKey("mcrpg", "mine_stone"),
-                new NamespacedKey("mcrpg", "daily_personal"),
-                1000000L
-        );
+        @DisplayName("Returns prepared statements with all fields set")
+        @Test
+        void saveCooldown_returnsPreparedStatements() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertNotNull(statements);
-        assertFalse(statements.isEmpty());
+            List<PreparedStatement> statements = BoardCooldownDAO.saveCooldown(
+                    mockConnection,
+                    "cooldown-1",
+                    "rotation",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    new NamespacedKey("mcrpg", "mine_stone"),
+                    new NamespacedKey("mcrpg", "daily_personal"),
+                    1000000L
+            );
+
+            assertNotNull(statements);
+            assertFalse(statements.isEmpty());
+        }
+
+        @DisplayName("Sets null for absent quest definition and category keys")
+        @Test
+        void saveCooldown_handlesNullKeys() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            BoardCooldownDAO.saveCooldown(
+                    mockConnection,
+                    "cooldown-2",
+                    "rotation",
+                    "land",
+                    "land-uuid-123",
+                    null,
+                    null,
+                    2000000L
+            );
+
+            verify(mockStatement).setNull(eq(5), eq(Types.VARCHAR));
+            verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+        }
     }
 
-    @DisplayName("saveCooldown handles null keys")
-    @Test
-    void saveCooldown_handlesNullKeys() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("isOnCooldown")
+    class IsOnCooldownTests {
 
-        BoardCooldownDAO.saveCooldown(
-                mockConnection,
-                "cooldown-2",
-                "rotation",
-                "land",
-                "land-uuid-123",
-                null,
-                null,
-                2000000L
-        );
+        @DisplayName("Returns false when no matching rows exist")
+        @Test
+        void isOnCooldown_returnsFalseWhenNoResults() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        verify(mockStatement).setNull(eq(5), eq(Types.VARCHAR));
-        verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+            boolean result = BoardCooldownDAO.isOnCooldown(
+                    mockConnection,
+                    "rotation",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    null,
+                    null
+            );
+
+            assertFalse(result);
+        }
+
+        @DisplayName("Returns true when a matching row exists")
+        @Test
+        void isOnCooldown_returnsTrueWhenPresent() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true);
+
+            boolean result = BoardCooldownDAO.isOnCooldown(
+                    mockConnection,
+                    "rotation",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    null,
+                    null
+            );
+
+            assertTrue(result);
+        }
+
+        @DisplayName("Binds questDefinitionKey parameter when provided")
+        @Test
+        void isOnCooldown_bindsQuestDefinitionKey() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            NamespacedKey questKey = new NamespacedKey("mcrpg", "mine_stone");
+            BoardCooldownDAO.isOnCooldown(
+                    mockConnection,
+                    "quest_repeat",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    questKey,
+                    null
+            );
+
+            verify(mockStatement).setString(eq(5), eq(questKey.toString()));
+        }
+
+        @DisplayName("Binds categoryKey parameter when provided")
+        @Test
+        void isOnCooldown_bindsCategoryKey() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily_personal");
+            BoardCooldownDAO.isOnCooldown(
+                    mockConnection,
+                    "category_rotation",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    null,
+                    categoryKey
+            );
+
+            verify(mockStatement).setString(eq(5), eq(categoryKey.toString()));
+        }
+
+        @DisplayName("Binds both keys at correct indices when both provided")
+        @Test
+        void isOnCooldown_bindsBothKeys() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
+
+            NamespacedKey questKey = new NamespacedKey("mcrpg", "mine_stone");
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily_personal");
+            BoardCooldownDAO.isOnCooldown(
+                    mockConnection,
+                    "quest_repeat",
+                    "player",
+                    UUID.randomUUID().toString(),
+                    questKey,
+                    categoryKey
+            );
+
+            verify(mockStatement).setString(eq(5), eq(questKey.toString()));
+            verify(mockStatement).setString(eq(6), eq(categoryKey.toString()));
+        }
     }
 
-    @DisplayName("isOnCooldown returns false when no results")
-    @Test
-    void isOnCooldown_returnsFalseWhenNoResults() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+    @Nested
+    @DisplayName("listCooldowns")
+    class ListCooldownsTests {
 
-        boolean result = BoardCooldownDAO.isOnCooldown(
-                mockConnection,
-                "rotation",
-                "player",
-                UUID.randomUUID().toString(),
-                null,
-                null
-        );
+        @DisplayName("Returns empty list when no cooldowns exist")
+        @Test
+        void listCooldowns_returnsEmptyList_whenNoResults() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        assertFalse(result);
+            List<BoardCooldownDAO.CooldownRecord> results = BoardCooldownDAO.listCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString());
+
+            assertNotNull(results);
+            assertTrue(results.isEmpty());
+        }
+
+        @DisplayName("Returns populated records when cooldowns exist")
+        @Test
+        void listCooldowns_returnsRecords_whenResultsExist() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("cooldown_type")).thenReturn("quest_repeat", "category_rotation");
+            when(mockResultSet.getString("quest_definition_key")).thenReturn("mcrpg:mine_stone", (String) null);
+            when(mockResultSet.getString("category_key")).thenReturn(null, "mcrpg:daily_personal");
+            when(mockResultSet.getLong("expires_at")).thenReturn(5000000L, 6000000L);
+
+            List<BoardCooldownDAO.CooldownRecord> results = BoardCooldownDAO.listCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString());
+
+            assertEquals(2, results.size());
+
+            BoardCooldownDAO.CooldownRecord first = results.get(0);
+            assertEquals("quest_repeat", first.cooldownType());
+            assertEquals("mcrpg:mine_stone", first.questDefinitionKey());
+            assertNull(first.categoryKey());
+            assertEquals(5000000L, first.expiresAt());
+
+            BoardCooldownDAO.CooldownRecord second = results.get(1);
+            assertEquals("category_rotation", second.cooldownType());
+            assertNull(second.questDefinitionKey());
+            assertEquals("mcrpg:daily_personal", second.categoryKey());
+            assertEquals(6000000L, second.expiresAt());
+        }
     }
 
-    @DisplayName("isOnCooldown returns true when present")
-    @Test
-    void isOnCooldown_returnsTrueWhenPresent() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
+    @Nested
+    @DisplayName("deleteCooldowns")
+    class DeleteCooldownsTests {
 
-        boolean result = BoardCooldownDAO.isOnCooldown(
-                mockConnection,
-                "rotation",
-                "player",
-                UUID.randomUUID().toString(),
-                null,
-                null
-        );
+        @DisplayName("Deletes all cooldowns for scope when no category key")
+        @Test
+        void deleteCooldowns_deletesAll_whenNoCategoryKey() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(3);
 
-        assertTrue(result);
+            int deleted = BoardCooldownDAO.deleteCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString(), null);
+
+            assertEquals(3, deleted);
+            verify(mockStatement).setString(eq(1), eq("player"));
+            verify(mockStatement, never()).setString(eq(3), anyString());
+        }
+
+        @DisplayName("Filters by category key when provided")
+        @Test
+        void deleteCooldowns_filtersByCategoryKey_whenProvided() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(1);
+
+            NamespacedKey categoryKey = new NamespacedKey("mcrpg", "daily_personal");
+            int deleted = BoardCooldownDAO.deleteCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString(), categoryKey);
+
+            assertEquals(1, deleted);
+            verify(mockStatement).setString(eq(3), eq(categoryKey.toString()));
+        }
+
+        @DisplayName("Returns zero when no rows deleted")
+        @Test
+        void deleteCooldowns_returnsZero_whenNoRowsDeleted() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int deleted = BoardCooldownDAO.deleteCooldowns(
+                    mockConnection, "player", UUID.randomUUID().toString(), null);
+
+            assertEquals(0, deleted);
+        }
     }
 
-    @DisplayName("pruneExpiredCooldowns returns prepared statements")
-    @Test
-    void pruneExpiredCooldowns_returnsPreparedStatements() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("pruneExpiredCooldowns")
+    class PruneExpiredCooldownsTests {
 
-        List<PreparedStatement> statements = BoardCooldownDAO.pruneExpiredCooldowns(mockConnection);
+        @DisplayName("Returns prepared statements")
+        @Test
+        void pruneExpiredCooldowns_returnsPreparedStatements() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        assertNotNull(statements);
-        assertFalse(statements.isEmpty());
+            List<PreparedStatement> statements = BoardCooldownDAO.pruneExpiredCooldowns(mockConnection);
+
+            assertNotNull(statements);
+            assertFalse(statements.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("CooldownRecord")
+    class CooldownRecordTests {
+
+        @DisplayName("Accessors return constructor values")
+        @Test
+        void cooldownRecord_accessorsReturnCorrectValues() {
+            BoardCooldownDAO.CooldownRecord record = new BoardCooldownDAO.CooldownRecord(
+                    "quest_repeat", "mcrpg:mine_stone", "mcrpg:daily_personal", 5000000L);
+
+            assertEquals("quest_repeat", record.cooldownType());
+            assertEquals("mcrpg:mine_stone", record.questDefinitionKey());
+            assertEquals("mcrpg:daily_personal", record.categoryKey());
+            assertEquals(5000000L, record.expiresAt());
+        }
+
+        @DisplayName("Nullable fields accept null")
+        @Test
+        void cooldownRecord_nullableFieldsAcceptNull() {
+            BoardCooldownDAO.CooldownRecord record = new BoardCooldownDAO.CooldownRecord(
+                    "category_rotation", null, null, 1000L);
+
+            assertNull(record.questDefinitionKey());
+            assertNull(record.categoryKey());
+        }
+
+        @DisplayName("Records with same values are equal")
+        @Test
+        void cooldownRecord_equalRecordsAreEqual() {
+            BoardCooldownDAO.CooldownRecord a = new BoardCooldownDAO.CooldownRecord(
+                    "quest_repeat", "mcrpg:mine_stone", null, 5000000L);
+            BoardCooldownDAO.CooldownRecord b = new BoardCooldownDAO.CooldownRecord(
+                    "quest_repeat", "mcrpg:mine_stone", null, 5000000L);
+
+            assertEquals(a, b);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
@@ -2,6 +2,7 @@ package us.eunoians.mcrpg.database.table.board;
 
 import org.bukkit.NamespacedKey;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import us.eunoians.mcrpg.McRPGBaseTest;
 
@@ -20,86 +21,339 @@ import static org.mockito.Mockito.*;
 
 public class PlayerBoardStateDAOTest extends McRPGBaseTest {
 
-    @DisplayName("saveState returns prepared statements")
-    @Test
-    void saveState_returnsPreparedStatements() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("saveState")
+    class SaveStateTests {
 
-        UUID playerUUID = UUID.randomUUID();
-        UUID offeringId = UUID.randomUUID();
-        UUID questInstanceUUID = UUID.randomUUID();
-        NamespacedKey boardKey = new NamespacedKey("mcrpg", "main_board");
-        long acceptedAt = System.currentTimeMillis();
+        @DisplayName("Returns prepared statements with all fields set")
+        @Test
+        void saveState_returnsPreparedStatements() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
 
-        List<PreparedStatement> statements = PlayerBoardStateDAO.saveState(
-                mockConnection,
-                playerUUID,
-                boardKey,
-                offeringId,
-                "ACCEPTED",
-                acceptedAt,
-                questInstanceUUID
-        );
+            UUID playerUUID = UUID.randomUUID();
+            UUID offeringId = UUID.randomUUID();
+            UUID questInstanceUUID = UUID.randomUUID();
+            NamespacedKey boardKey = new NamespacedKey("mcrpg", "main_board");
+            long acceptedAt = System.currentTimeMillis();
 
-        assertNotNull(statements);
-        assertFalse(statements.isEmpty());
+            List<PreparedStatement> statements = PlayerBoardStateDAO.saveState(
+                    mockConnection,
+                    playerUUID,
+                    boardKey,
+                    offeringId,
+                    "ACCEPTED",
+                    acceptedAt,
+                    questInstanceUUID
+            );
+
+            assertNotNull(statements);
+            assertFalse(statements.isEmpty());
+        }
+
+        @DisplayName("Sets null for absent optional fields")
+        @Test
+        void saveState_handlesNullOptionalFields() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+
+            UUID playerUUID = UUID.randomUUID();
+            UUID offeringId = UUID.randomUUID();
+            NamespacedKey boardKey = new NamespacedKey("mcrpg", "main_board");
+
+            PlayerBoardStateDAO.saveState(mockConnection, playerUUID, boardKey, offeringId, "VISIBLE", null, null);
+
+            verify(mockStatement).setNull(eq(5), eq(Types.BIGINT));
+            verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+        }
     }
 
-    @DisplayName("saveState handles null optional fields")
-    @Test
-    void saveState_handlesNullOptionalFields() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    @Nested
+    @DisplayName("countActiveQuestsFromBoard")
+    class CountActiveQuestsTests {
 
-        UUID playerUUID = UUID.randomUUID();
-        UUID offeringId = UUID.randomUUID();
-        NamespacedKey boardKey = new NamespacedKey("mcrpg", "main_board");
+        @DisplayName("Returns zero when ResultSet is empty")
+        @Test
+        void countActiveQuestsFromBoard_returnsZeroWhenNoResults() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        PlayerBoardStateDAO.saveState(mockConnection, playerUUID, boardKey, offeringId, "VISIBLE", null, null);
+            int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(
+                    mockConnection,
+                    UUID.randomUUID(),
+                    new NamespacedKey("mcrpg", "main_board")
+            );
 
-        verify(mockStatement).setNull(eq(5), eq(Types.BIGINT));
-        verify(mockStatement).setNull(eq(6), eq(Types.VARCHAR));
+            assertEquals(0, result);
+        }
+
+        @DisplayName("Returns count from ResultSet when present")
+        @Test
+        void countActiveQuestsFromBoard_returnsCountWhenPresent() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getInt(1)).thenReturn(3);
+
+            int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(
+                    mockConnection,
+                    UUID.randomUUID(),
+                    new NamespacedKey("mcrpg", "main_board")
+            );
+
+            assertEquals(3, result);
+        }
     }
 
-    @DisplayName("countActiveQuestsFromBoard returns zero when no results")
-    @Test
-    void countActiveQuestsFromBoard_returnsZeroWhenNoResults() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(false);
+    @Nested
+    @DisplayName("deleteForPlayer")
+    class DeleteForPlayerTests {
 
-        int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(
-                mockConnection,
-                UUID.randomUUID(),
-                new NamespacedKey("mcrpg", "main_board")
-        );
+        @DisplayName("Returns deleted row count")
+        @Test
+        void deleteForPlayer_returnsDeletedCount() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(5);
 
-        assertEquals(0, result);
+            UUID playerUUID = UUID.randomUUID();
+            int deleted = PlayerBoardStateDAO.deleteForPlayer(mockConnection, playerUUID);
+
+            assertEquals(5, deleted);
+            verify(mockStatement).setString(eq(1), eq(playerUUID.toString()));
+        }
+
+        @DisplayName("Returns zero when no rows exist for player")
+        @Test
+        void deleteForPlayer_returnsZero_whenNoRows() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int deleted = PlayerBoardStateDAO.deleteForPlayer(mockConnection, UUID.randomUUID());
+
+            assertEquals(0, deleted);
+        }
     }
 
-    @DisplayName("countActiveQuestsFromBoard returns count when present")
-    @Test
-    void countActiveQuestsFromBoard_returnsCountWhenPresent() throws SQLException {
-        Connection mockConnection = mock(Connection.class);
-        PreparedStatement mockStatement = mock(PreparedStatement.class);
-        ResultSet mockResultSet = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
-        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true, false);
-        when(mockResultSet.getInt(1)).thenReturn(3);
+    @Nested
+    @DisplayName("loadAcceptedForPlayer")
+    class LoadAcceptedForPlayerTests {
 
-        int result = PlayerBoardStateDAO.countActiveQuestsFromBoard(
-                mockConnection,
-                UUID.randomUUID(),
-                new NamespacedKey("mcrpg", "main_board")
-        );
+        @DisplayName("Returns empty list when no accepted entries")
+        @Test
+        void loadAcceptedForPlayer_returnsEmptyList_whenNoResults() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+            when(mockResultSet.next()).thenReturn(false);
 
-        assertEquals(3, result);
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, UUID.randomUUID());
+
+            assertNotNull(entries);
+            assertTrue(entries.isEmpty());
+        }
+
+        @DisplayName("Returns entries with quest instance UUIDs")
+        @Test
+        void loadAcceptedForPlayer_returnsEntries_withQuestUUID() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+            UUID offeringId = UUID.randomUUID();
+            UUID questUUID = UUID.randomUUID();
+
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getString("offering_id")).thenReturn(offeringId.toString());
+            when(mockResultSet.getString("quest_instance_uuid")).thenReturn(questUUID.toString());
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, UUID.randomUUID());
+
+            assertEquals(1, entries.size());
+            assertEquals(offeringId, entries.get(0).offeringId());
+            assertEquals(questUUID, entries.get(0).questInstanceUUID());
+        }
+
+        @DisplayName("Handles null quest instance UUID in entries")
+        @Test
+        void loadAcceptedForPlayer_handlesNullQuestUUID() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+            UUID offeringId = UUID.randomUUID();
+
+            when(mockResultSet.next()).thenReturn(true, false);
+            when(mockResultSet.getString("offering_id")).thenReturn(offeringId.toString());
+            when(mockResultSet.getString("quest_instance_uuid")).thenReturn(null);
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, UUID.randomUUID());
+
+            assertEquals(1, entries.size());
+            assertEquals(offeringId, entries.get(0).offeringId());
+            assertNull(entries.get(0).questInstanceUUID());
+        }
+
+        @DisplayName("Returns multiple entries across iterations")
+        @Test
+        void loadAcceptedForPlayer_returnsMultipleEntries() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            ResultSet mockResultSet = mock(ResultSet.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+            UUID offering1 = UUID.randomUUID();
+            UUID offering2 = UUID.randomUUID();
+            UUID quest1 = UUID.randomUUID();
+
+            when(mockResultSet.next()).thenReturn(true, true, false);
+            when(mockResultSet.getString("offering_id"))
+                    .thenReturn(offering1.toString(), offering2.toString());
+            when(mockResultSet.getString("quest_instance_uuid"))
+                    .thenReturn(quest1.toString(), (String) null);
+
+            List<PlayerBoardStateDAO.AcceptedBoardEntry> entries =
+                    PlayerBoardStateDAO.loadAcceptedForPlayer(mockConnection, UUID.randomUUID());
+
+            assertEquals(2, entries.size());
+            assertEquals(offering1, entries.get(0).offeringId());
+            assertEquals(quest1, entries.get(0).questInstanceUUID());
+            assertEquals(offering2, entries.get(1).offeringId());
+            assertNull(entries.get(1).questInstanceUUID());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStateByQuestInstanceUUID")
+    class UpdateStateByQuestInstanceUUIDTests {
+
+        @DisplayName("Returns updated row count")
+        @Test
+        void updateStateByQuestInstanceUUID_returnsUpdatedCount() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(1);
+
+            UUID questUUID = UUID.randomUUID();
+            int updated = PlayerBoardStateDAO.updateStateByQuestInstanceUUID(
+                    mockConnection, questUUID, "COMPLETED");
+
+            assertEquals(1, updated);
+            verify(mockStatement).setString(eq(1), eq("COMPLETED"));
+            verify(mockStatement).setString(eq(2), eq(questUUID.toString()));
+        }
+
+        @DisplayName("Returns zero when no matching quest instance")
+        @Test
+        void updateStateByQuestInstanceUUID_returnsZero_whenNoMatch() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int updated = PlayerBoardStateDAO.updateStateByQuestInstanceUUID(
+                    mockConnection, UUID.randomUUID(), "CANCELLED");
+
+            assertEquals(0, updated);
+        }
+    }
+
+    @Nested
+    @DisplayName("bulkCancelExpiredBoardStates")
+    class BulkCancelExpiredBoardStatesTests {
+
+        @DisplayName("Returns count of updated rows")
+        @Test
+        void bulkCancelExpiredBoardStates_returnsUpdatedCount() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(4);
+
+            int updated = PlayerBoardStateDAO.bulkCancelExpiredBoardStates(mockConnection);
+
+            assertEquals(4, updated);
+        }
+
+        @DisplayName("Returns zero when no expired board states")
+        @Test
+        void bulkCancelExpiredBoardStates_returnsZero_whenNoneExpired() throws SQLException {
+            Connection mockConnection = mock(Connection.class);
+            PreparedStatement mockStatement = mock(PreparedStatement.class);
+            when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+            when(mockStatement.executeUpdate()).thenReturn(0);
+
+            int updated = PlayerBoardStateDAO.bulkCancelExpiredBoardStates(mockConnection);
+
+            assertEquals(0, updated);
+        }
+    }
+
+    @Nested
+    @DisplayName("AcceptedBoardEntry")
+    class AcceptedBoardEntryTests {
+
+        @DisplayName("Accessors return constructor values")
+        @Test
+        void acceptedBoardEntry_accessorsReturnCorrectValues() {
+            UUID offeringId = UUID.randomUUID();
+            UUID questUUID = UUID.randomUUID();
+
+            PlayerBoardStateDAO.AcceptedBoardEntry entry =
+                    new PlayerBoardStateDAO.AcceptedBoardEntry(offeringId, questUUID);
+
+            assertEquals(offeringId, entry.offeringId());
+            assertEquals(questUUID, entry.questInstanceUUID());
+        }
+
+        @DisplayName("Nullable questInstanceUUID accepts null")
+        @Test
+        void acceptedBoardEntry_nullableQuestUUID() {
+            UUID offeringId = UUID.randomUUID();
+
+            PlayerBoardStateDAO.AcceptedBoardEntry entry =
+                    new PlayerBoardStateDAO.AcceptedBoardEntry(offeringId, null);
+
+            assertEquals(offeringId, entry.offeringId());
+            assertNull(entry.questInstanceUUID());
+        }
+
+        @DisplayName("Records with same values are equal")
+        @Test
+        void acceptedBoardEntry_equalRecordsAreEqual() {
+            UUID offeringId = UUID.randomUUID();
+            UUID questUUID = UUID.randomUUID();
+
+            PlayerBoardStateDAO.AcceptedBoardEntry a =
+                    new PlayerBoardStateDAO.AcceptedBoardEntry(offeringId, questUUID);
+            PlayerBoardStateDAO.AcceptedBoardEntry b =
+                    new PlayerBoardStateDAO.AcceptedBoardEntry(offeringId, questUUID);
+
+            assertEquals(a, b);
+            assertEquals(a.hashCode(), b.hashCode());
+        }
     }
 }

--- a/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
+++ b/src/test/java/us/eunoians/mcrpg/database/table/board/PlayerBoardStateDAOTest.java
@@ -76,7 +76,7 @@ public class PlayerBoardStateDAOTest extends McRPGBaseTest {
 
         @DisplayName("Returns zero when ResultSet is empty")
         @Test
-        void countActiveQuestsFromBoard_returnsZeroWhenNoResults() throws SQLException {
+        void countActiveQuestsFromBoard_returnsZero_whenNoResults() throws SQLException {
             Connection mockConnection = mock(Connection.class);
             PreparedStatement mockStatement = mock(PreparedStatement.class);
             ResultSet mockResultSet = mock(ResultSet.class);
@@ -95,7 +95,7 @@ public class PlayerBoardStateDAOTest extends McRPGBaseTest {
 
         @DisplayName("Returns count from ResultSet when present")
         @Test
-        void countActiveQuestsFromBoard_returnsCountWhenPresent() throws SQLException {
+        void countActiveQuestsFromBoard_returnsCount_whenPresent() throws SQLException {
             Connection mockConnection = mock(Connection.class);
             PreparedStatement mockStatement = mock(PreparedStatement.class);
             ResultSet mockResultSet = mock(ResultSet.class);

--- a/src/test/java/us/eunoians/mcrpg/task/quest/ExpiredQuestScanTaskTest.java
+++ b/src/test/java/us/eunoians/mcrpg/task/quest/ExpiredQuestScanTaskTest.java
@@ -1,50 +1,73 @@
 package us.eunoians.mcrpg.task.quest;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExpiredQuestScanTaskTest {
 
-    @DisplayName("Zero milliseconds formats as 0h 0m")
-    @Test
-    void formatTimeRemaining_zero_returnsZero() {
-        assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(0));
-    }
+    @Nested
+    @DisplayName("formatTimeRemaining")
+    class FormatTimeRemainingTests {
 
-    @DisplayName("Negative milliseconds clamp to 0h 0m")
-    @Test
-    void formatTimeRemaining_negative_clampedToZero() {
-        assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(-1));
-        assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(-60_000));
-    }
+        @DisplayName("Standard durations format correctly")
+        @ParameterizedTest(name = "{0}ms => \"{1}\"")
+        @CsvSource({
+                "0, 0h 0m",
+                "1, 0h 0m",
+                "59999, 0h 0m",
+                "60000, 0h 1m",
+                "1500000, 0h 25m",
+                "3600000, 1h 0m",
+                "5400000, 1h 30m",
+                "13500000, 3h 45m",
+                "360000000, 100h 0m"
+        })
+        void formatTimeRemaining_standardDurations(long millis, String expected) {
+            assertEquals(expected, ExpiredQuestScanTask.formatTimeRemaining(millis));
+        }
 
-    @DisplayName("Exactly one hour formats as 1h 0m")
-    @Test
-    void formatTimeRemaining_oneHour_returnsOneHourZeroMinutes() {
-        long oneHourMs = 60L * 60_000L;
-        assertEquals("1h 0m", ExpiredQuestScanTask.formatTimeRemaining(oneHourMs));
-    }
+        @DisplayName("Negative values clamp to 0h 0m")
+        @ParameterizedTest(name = "{0}ms => \"0h 0m\"")
+        @CsvSource({
+                "-1",
+                "-60000",
+                "-9223372036854775808"
+        })
+        void formatTimeRemaining_negativeValues_clampToZero(long millis) {
+            assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(millis));
+        }
 
-    @DisplayName("90 minutes formats as 1h 30m")
-    @Test
-    void formatTimeRemaining_ninetyMinutes_returnsOneHourThirtyMinutes() {
-        long ninetyMinutesMs = 90L * 60_000L;
-        assertEquals("1h 30m", ExpiredQuestScanTask.formatTimeRemaining(ninetyMinutesMs));
-    }
+        @DisplayName("Sub-minute values truncate to 0h 0m")
+        @Test
+        void formatTimeRemaining_subMinute_truncatesToZero() {
+            assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(30_000));
+            assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(59_999));
+        }
 
-    @DisplayName("25 minutes formats as 0h 25m")
-    @Test
-    void formatTimeRemaining_twentyFiveMinutes_returnsZeroHoursTwentyFiveMinutes() {
-        long twentyFiveMinutesMs = 25L * 60_000L;
-        assertEquals("0h 25m", ExpiredQuestScanTask.formatTimeRemaining(twentyFiveMinutesMs));
-    }
+        @DisplayName("Boundary between 0m and 1m is exactly 60000ms")
+        @Test
+        void formatTimeRemaining_minuteBoundary() {
+            assertEquals("0h 0m", ExpiredQuestScanTask.formatTimeRemaining(59_999));
+            assertEquals("0h 1m", ExpiredQuestScanTask.formatTimeRemaining(60_000));
+        }
 
-    @DisplayName("Large value (3h 45m) formats correctly")
-    @Test
-    void formatTimeRemaining_largeValue_formatsCorrectly() {
-        long ms = (3L * 60 + 45) * 60_000L;
-        assertEquals("3h 45m", ExpiredQuestScanTask.formatTimeRemaining(ms));
+        @DisplayName("Boundary between 59m and 1h is exactly 3600000ms")
+        @Test
+        void formatTimeRemaining_hourBoundary() {
+            assertEquals("0h 59m", ExpiredQuestScanTask.formatTimeRemaining(3_599_999));
+            assertEquals("1h 0m", ExpiredQuestScanTask.formatTimeRemaining(3_600_000));
+        }
+
+        @DisplayName("24+ hours formats correctly without wrapping")
+        @Test
+        void formatTimeRemaining_moreThan24Hours_doesNotWrap() {
+            long twentyFiveHours = 25L * 60 * 60_000;
+            assertEquals("25h 0m", ExpiredQuestScanTask.formatTimeRemaining(twentyFiveHours));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **BoardCooldownDAOTest**: Added 10 new tests covering `listCooldowns` (empty/populated results), `deleteCooldowns` (with/without category key filter, zero rows), `isOnCooldown` with `questDefinitionKey` filter, `categoryKey` filter, and both filters simultaneously, plus `CooldownRecord` record accessors and equality. Restructured existing tests into `@Nested` groups.
- **PlayerBoardStateDAOTest**: Added 11 new tests covering `deleteForPlayer` (with/without rows), `loadAcceptedForPlayer` (empty, with quest UUID, null quest UUID, multiple entries), `updateStateByQuestInstanceUUID` (match/no match), `bulkCancelExpiredBoardStates` (with/without expired states), plus `AcceptedBoardEntry` record accessors and equality. Restructured existing tests into `@Nested` groups.
- **ExpiredQuestScanTaskTest**: Restructured into `@Nested` grouping, consolidated standard cases into `@ParameterizedTest` with `@CsvSource`, added edge cases for sub-minute truncation, minute/hour boundaries, and 24+ hour non-wrapping behavior.

## Test plan

- [x] All new tests pass (`./gradlew test` — BUILD SUCCESSFUL)
- [x] No compilation warnings
- [x] Full test suite passes with zero failures
- [x] Follows project naming conventions (`action_outcome_whenCondition`, descriptive `@DisplayName`)
- [x] DAO tests use mock JDBC pattern (no real database connections)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFRs1uXn7XmSyHkNk7vAjt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for board cooldown and player board state operations, including empty results, nullable values, deletion behavior, and record comparisons.
  * Improved test organization and naming for clearer, more maintainable validation.
  * Added broader quest expiration time-formatting coverage, including boundary durations, negative values, very large durations, and sub-minute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->